### PR TITLE
fix: use CLAUDE_PLUGIN_ROOT for CLI path in skills

### DIFF
--- a/skills/overlay/SKILL.md
+++ b/skills/overlay/SKILL.md
@@ -7,7 +7,7 @@ description: Manage RHDH plugins in the overlay repository (rhdh-plugin-export-o
 This skill uses the orchestrator CLI. **Set up first:**
 
 ```bash
-RHDH=../rhdh/scripts/rhdh
+RHDH=${CLAUDE_PLUGIN_ROOT}/skills/rhdh/scripts/rhdh
 ```
 
 **Verify environment:**

--- a/skills/rhdh/SKILL.md
+++ b/skills/rhdh/SKILL.md
@@ -7,7 +7,7 @@ description: Orchestrator skill for RHDH plugin development. Provides CLI toolin
 **Set the CLI variable for this session:**
 
 ```bash
-RHDH=scripts/rhdh
+RHDH=${CLAUDE_PLUGIN_ROOT}/skills/rhdh/scripts/rhdh
 ```
 
 **Get oriented (run first):**


### PR DESCRIPTION
## Summary

- Replaces relative CLI paths with absolute paths using `${CLAUDE_PLUGIN_ROOT}` environment variable
- Updates both `skills/rhdh/SKILL.md` and `skills/overlay/SKILL.md`

## Problem

When the plugin is invoked from a different directory than the plugin root, relative paths like `scripts/rhdh` or `../rhdh/scripts/rhdh` fail with errors such as:

```
bash: scripts/rhdh: No such file or directory
```

or

```
bash: ../rhdh/scripts/rhdh: No such file or directory
```

The agent would then need to spend additional turns figuring out the correct path based on `${CLAUDE_PLUGIN_ROOT}`.

## Optimization

While the agent was able to eventually figure out the correct absolute path, this required extra reasoning and tool calls. By using `${CLAUDE_PLUGIN_ROOT}` directly in the skill markdown, the CLI works correctly on the first try, saving agent turns and reducing latency.

## Test plan

- [ ] Invoke the rhdh skill from a project directory outside the plugin
- [ ] Verify `$RHDH` variable resolves correctly
- [ ] Confirm CLI commands execute without path errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)