### PR TITLE
Add skills for creating and deploying RHDH dynamic plugins

### DIFF
--- a/skills/create-backend-plugin/SKILL.md
+++ b/skills/create-backend-plugin/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: RHDH Backend Dynamic Plugin Bootstrap
+description: This skill should be used when the user asks to "create RHDH backend plugin", "bootstrap backend dynamic plugin", "create backstage backend plugin for RHDH", "new backend plugin for Red Hat Developer Hub", "create dynamic backend plugin", "scaffold RHDH backend plugin", "new scaffolder action", "create catalog processor", or mentions creating a new backend plugin, backend module, or server-side functionality for Red Hat Developer Hub or RHDH. This skill is specifically for backend plugins - for frontend plugins, use the separate frontend plugin skill.
+---
+
+## Purpose
+
+Bootstrap a new **backend** dynamic plugin for Red Hat Developer Hub (RHDH). RHDH is the enterprise-ready Backstage applicationthat supports dynamic plugins - plugins that can be installed or uninstalled without rebuilding the application.
+
+> **Note:** This skill covers **backend plugins only**. Frontend dynamic plugins have different requirements (Scalprum configuration, mount points, dynamic routes) and are covered in a separate skill.
+
+## When to Use
+
+Use this skill when creating a new **backend** plugin intended for RHDH dynamic plugin deployment. This includes:
+- New backend API plugins
+- Backend modules for existing plugins (e.g., `catalog-backend-module-*`)
+- Scaffolder actions and templates
+- Catalog processors and providers
+- Authentication modules
+- Any server-side functionality for RHDH
+
+**Do NOT use this skill for:**
+- Frontend plugins (UI components, pages, cards)
+- Frontend plugin wiring (mount points, dynamic routes)
+- Themes or frontend customizations
+
+## Prerequisites
+
+Before starting, ensure the following are available:
+- Node.js 22+ and Yarn
+- Container runtime (`podman` or `docker`)
+- Access to a container registry (e.g., quay.io) for publishing
+
+## Workflow Overview
+
+1. **Determine RHDH Version** - Identify target RHDH version for compatibility
+2. **Create Backstage App** - Scaffold Backstage app with matching version
+3. **Create Backend Plugin** - Generate new backend plugin using Backstage CLI
+4. **Implement Plugin Logic** - Write the plugin code using new backend system
+5. **Export and Package** - Build, export, and package using RHDH CLI (see export-and-package skill)
+6. **Configure for RHDH** - Create dynamic-plugins.yaml configuration
+
+## Step 1: Determine RHDH Version
+Check the target RHDH version and find the compatible Backstage version. Consult  `../rhdh/references/versions.md` file for the version compatibility matrix and available RHDH versions.
+
+Ask the user which RHDH version they are targeting if not specified.
+
+## Step 2: Create Backstage Application
+
+Create a new Backstage application in the current directory using the version-appropriate create-app:
+
+```bash
+# For RHDH 1.8 (adjust version as needed)
+echo "backstage" | npx @backstage/create-app@0.7.3 --path .
+```
+
+After creation, install dependencies:
+
+```bash
+yarn install
+```
+
+ The only purpose this serves is to ensure you can later create the plugin using the correct version of the Backstage CLI. All development and testing will be done in the plugin directory.
+
+
+## Step 3: Create Backend Plugin
+
+Generate a new backend plugin using the Backstage CLI:
+
+```bash
+yarn new
+```
+
+When prompted:
+1. Select **"backend-plugin"** as the plugin type
+2. Enter a plugin ID (e.g., `my-plugin`)
+3. The plugin will be created at `plugins/<plugin-id>-backend/`
+
+The generated plugin structure:
+
+```
+plugins/<plugin-id>-backend/
+├── src/
+│   ├── index.ts           # Main entry point
+│   ├── plugin.ts          # Plugin definition (new backend system)
+│   └── service/
+│       └── router.ts      # Express router
+├── package.json
+└── README.md
+```
+
+## Step 4: Implement Plugin Logic
+
+Backend plugins must use the **new backend system** for dynamic plugin compatibility. The plugin entry point should export a default using `createBackendPlugin()` or `createBackendModule()`.
+
+Example plugin structure (`src/plugin.ts`):
+
+```typescript
+import {
+  coreServices,
+  createBackendPlugin,
+} from '@backstage/backend-plugin-api';
+import { createRouter } from './service/router';
+
+export const myPlugin = createBackendPlugin({
+  pluginId: 'my-plugin',
+  register(env) {
+    env.registerInit({
+      deps: {
+        httpRouter: coreServices.httpRouter,
+        logger: coreServices.logger,
+        config: coreServices.rootConfig,
+      },
+      async init({ httpRouter, logger, config }) {
+        httpRouter.use(
+          await createRouter({
+            logger,
+            config,
+          }),
+        );
+        httpRouter.addAuthPolicy({
+          path: '/health',
+          allow: 'unauthenticated',
+        });
+      },
+    });
+  },
+});
+
+export default myPlugin;
+```
+
+The `src/index.ts` must export the plugin as default:
+
+```typescript
+export { default } from './plugin';
+```
+
+Build and verify the plugin compiles:
+
+```bash
+cd plugins/<plugin-id>-backend
+yarn build
+```
+
+## Step 5: Export and Package
+
+Export the plugin as a dynamic plugin and package it for deployment. For detailed export and packaging options, see the **export-and-package** skill.
+
+### Quick Export
+
+```bash
+cd plugins/<plugin-id>-backend
+npx @red-hat-developer-hub/cli@latest plugin export
+```
+
+This creates `dist-dynamic/` with the dynamic plugin package.
+
+### Quick Package and Push
+
+```bash
+npx @red-hat-developer-hub/cli@latest plugin package \
+  --tag quay.io/<namespace>/<plugin-name>:v0.1.0
+
+podman push quay.io/<namespace>/<plugin-name>:v0.1.0
+```
+
+For advanced options (dependency handling, multi-plugin bundles, tgz/npm packaging), consult the **export-and-package** skill.
+
+## Step 6: Configure for RHDH
+
+Create the dynamic plugin configuration for RHDH. Add to `dynamic-plugins.yaml`:
+
+```yaml
+plugins:
+  - package: oci://quay.io/<namespace>/<plugin-name>:v0.1.0!<plugin-id>-backend-dynamic
+    disabled: false
+    pluginConfig:
+      # Plugin-specific configuration (optional)
+      myPlugin:
+        someOption: value
+```
+
+For local development/testing, copy `dist-dynamic` to RHDH's `dynamic-plugins-root`:
+
+```bash
+cp -r dist-dynamic /path/to/rhdh/dynamic-plugins-root/<plugin-id>-backend-dynamic
+```
+
+See `examples/dynamic-plugins.yaml` for a complete configuration example.
+
+## Common Issues
+
+### Plugin Not Loading
+- Verify plugin uses new backend system (`createBackendPlugin`)
+- Check plugin is exported as default export
+- Ensure version compatibility with target RHDH
+
+### Dependency Conflicts
+- Use `--shared-package` to exclude problematic shared deps
+- Use `--embed-package` to bundle required deps
+
+### Build Failures
+- Run `yarn tsc` to check TypeScript errors before export
+- Ensure all `@backstage/*` versions match target RHDH
+
+## Additional Resources
+
+### Related Skills
+
+- **export-and-package** - Complete export/packaging workflow (OCI, tgz, npm)
+
+### Reference Files
+
+- **`rhdh/references/versions.md`** - Complete version compatibility matrix
+
+### Example Files
+
+- **`examples/dynamic-plugins.yaml`** - Example RHDH plugin configuration
+
+### External Resources
+
+- [RHDH Dynamic Plugins Documentation](https://github.com/redhat-developer/rhdh/tree/main/docs/dynamic-plugins)
+- [Backstage New Backend System](https://backstage.io/docs/backend-system/)

--- a/skills/create-backend-plugin/examples/dynamic-plugins.yaml
+++ b/skills/create-backend-plugin/examples/dynamic-plugins.yaml
@@ -1,0 +1,150 @@
+# Example RHDH Dynamic Plugins Configuration
+# This file shows how to configure dynamic plugins for Red Hat Developer Hub
+#
+# Place this configuration in your RHDH deployment's dynamic-plugins.yaml
+
+# Optional: Include default plugin configurations
+includes:
+  - dynamic-plugins.default.yaml
+
+plugins:
+  # ============================================================
+  # Backend Plugin Examples
+  # ============================================================
+
+  # Basic backend plugin from OCI image
+  - package: oci://quay.io/example/my-backend-plugin:v1.0.0!my-plugin-backend-dynamic
+    disabled: false
+    pluginConfig:
+      # Plugin-specific configuration
+      myPlugin:
+        apiUrl: https://api.example.com
+        timeout: 30000
+
+  # Backend plugin with version inheritance (requires includes)
+  - package: oci://quay.io/example/my-backend-plugin:{{inherit}}!my-plugin-backend-dynamic
+    disabled: false
+    pluginConfig:
+      myPlugin:
+        customSetting: overridden-value
+
+  # Backend plugin using image digest for integrity
+  - package: oci://quay.io/example/my-backend-plugin@sha256:abc123def456...!my-plugin-backend-dynamic
+    disabled: false
+
+  # Backend module (extends another plugin)
+  - package: oci://quay.io/example/catalog-module-custom:v1.0.0!catalog-backend-module-custom-dynamic
+    disabled: false
+    pluginConfig:
+      catalog:
+        providers:
+          custom:
+            schedule:
+              frequency: { minutes: 30 }
+              timeout: { minutes: 3 }
+
+  # ============================================================
+  # Frontend Plugin Examples
+  # ============================================================
+
+  # Frontend plugin with entity page mount point
+  - package: oci://quay.io/example/my-frontend-plugin:v1.0.0!my-plugin
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          example.plugin-my-plugin:
+            mountPoints:
+              - mountPoint: entity.page.overview/cards
+                importName: MyPluginCard
+                config:
+                  layout:
+                    gridColumn: '1 / -1'
+                  if:
+                    allOf:
+                      - isKind: component
+                      - hasAnnotation: example.com/my-annotation
+
+  # Frontend plugin with dynamic route and sidebar menu
+  - package: oci://quay.io/example/my-page-plugin:v1.0.0!my-page-plugin
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          example.plugin-my-page:
+            dynamicRoutes:
+              - path: /my-page
+                importName: MyPageComponent
+                menuItem:
+                  icon: dashboard
+                  text: My Page
+            appIcons:
+              - name: myCustomIcon
+                importName: MyCustomIcon
+
+  # ============================================================
+  # Multi-Plugin Image Example
+  # ============================================================
+
+  # Frontend and backend from same image
+  - package: oci://quay.io/example/my-plugin-bundle:v1.0.0!my-plugin
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          example.plugin-my-plugin:
+            mountPoints:
+              - mountPoint: entity.page.overview/cards
+                importName: MyPluginCard
+
+  - package: oci://quay.io/example/my-plugin-bundle:v1.0.0!my-plugin-backend-dynamic
+    disabled: false
+    pluginConfig:
+      myPlugin:
+        apiUrl: https://api.example.com
+
+  # ============================================================
+  # Local/Development Examples
+  # ============================================================
+
+  # Pre-installed plugin (already in RHDH image)
+  - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-dynamic
+    disabled: false
+
+  # Local development plugin
+  - package: ./dynamic-plugins-root/my-dev-plugin-dynamic
+    disabled: false
+    pluginConfig:
+      myDevPlugin:
+        debug: true
+
+  # ============================================================
+  # tgz Archive Examples
+  # ============================================================
+
+  # Plugin from HTTP server
+  - package: https://plugin-registry.example.com/my-plugin-1.0.0.tgz
+    integrity: sha512-9WlbgEdadJNeQxdn1973r5E4kNFvnT9GjLD627GWgrhCaxjCmxqdNW08cj+Bf47mwAtZMt1Ttyo+ZhDRDj9PoA==
+    disabled: false
+
+  # ============================================================
+  # npm Package Examples
+  # ============================================================
+
+  # Plugin from private npm registry
+  - package: '@my-org/my-plugin-dynamic@1.0.0'
+    integrity: sha512-abc123def456...
+    disabled: false
+
+  # ============================================================
+  # Scaffolder Action Example
+  # ============================================================
+
+  # Custom scaffolder action
+  - package: oci://quay.io/example/scaffolder-actions:v1.0.0!scaffolder-backend-module-custom-actions-dynamic
+    disabled: false
+    pluginConfig:
+      scaffolder:
+        actions:
+          custom:deploy:
+            apiKey: ${DEPLOY_API_KEY}

--- a/skills/create-frontend-plugin/SKILL.md
+++ b/skills/create-frontend-plugin/SKILL.md
@@ -1,0 +1,322 @@
+---
+name: RHDH Frontend Dynamic Plugin Bootstrap
+description: This skill should be used when the user asks to "create RHDH frontend plugin", "bootstrap frontend dynamic plugin", "create UI plugin for RHDH", "new frontend plugin for Red Hat Developer Hub", "add entity card to RHDH", "create dynamic route", "add sidebar menu item", "configure mount points", "create theme plugin", or mentions creating frontend components, UI pages, entity cards, or visual customizations for Red Hat Developer Hub or RHDH. This skill is specifically for frontend plugins - for backend plugins, use the separate backend plugin skill.
+---
+
+## Purpose
+
+Bootstrap a new **frontend** dynamic plugin for Red Hat Developer Hub (RHDH). Frontend dynamic plugins provide UI components, pages, entity cards, themes, and visual customizations that integrate with the RHDH application shell.
+
+> **Note:** This skill covers **frontend plugins only**. Backend dynamic plugins (APIs, scaffolder actions, processors) are covered in a separate skill.
+
+## When to Use
+
+Use this skill when creating a new **frontend** plugin intended for RHDH dynamic plugin deployment. This includes:
+- New pages and routes
+- Entity page cards and tabs
+- Sidebar menu items
+- Custom themes
+- Scaffolder field extensions
+- TechDocs addons
+- Search result types and filters
+- Any UI component for RHDH
+
+**Do NOT use this skill for:**
+- Backend API plugins
+- Scaffolder actions (server-side)
+- Catalog processors or providers
+- Authentication modules
+
+## Prerequisites
+
+Before starting, ensure the following are available:
+- Node.js 22+ and Yarn
+- Container runtime (`podman` or `docker`)
+- Access to a container registry (e.g., quay.io) for publishing
+
+## Workflow Overview
+
+1. **Determine RHDH Version** - Identify target RHDH version for compatibility
+2. **Create Backstage App** - Scaffold Backstage app with matching version
+3. **Create Frontend Plugin** - Generate new frontend plugin using Backstage CLI
+4. **Implement Plugin Components** - Build React components and exports
+5. **Configure Scalprum** - Set up module federation for dynamic loading
+6. **Export and Package** - Build, export, and package using RHDH CLI (see export-and-package skill)
+7. **Configure Plugin Wiring** - Define routes, mount points, and menu items
+
+## Step 1: Determine RHDH Version
+
+Check the target RHDH version and find the compatible Backstage version. Consult  `../rhdh/references/versions.md` file for the version compatibility matrix and available RHDH versions.
+
+Ask the user which RHDH version they are targeting if not specified.
+
+## Step 2: Create Backstage Application
+
+Create a new Backstage application in the current directory using the version-appropriate create-app:
+
+```bash
+# For RHDH 1.8 (adjust version as needed)
+echo "backstage" | npx @backstage/create-app@0.7.3 --path .
+```
+
+After creation, install dependencies:
+
+```bash
+yarn install
+```
+
+
+## Step 3: Decide if you want to use RHDH themes. 
+
+If you want to use RHDH themes, follow the steps below. If you don't want to use RHDH themes, skip to Step 4.
+
+Add RHDH theme to Backstage app dependencies:
+
+```bash
+yarn workspace app add @red-hat-developer-hub/backstage-plugin-theme
+```
+
+Update `packages/app/src/App.tsx` and apply the themes to `createApp`:
+
+```typescript
+import { getThemes } from '@red-hat-developer-hub/backstage-plugin-theme';
+
+// ...
+
+const app = createApp({
+  apis,
+  // ...
+  themes: getThemes(),
+});
+```
+
+## Step 3: Create Frontend Plugin
+
+Generate a new frontend plugin:
+
+```bash
+yarn new --select frontend-plugin --option id=<plugin-id>
+```
+
+The plugin will be created at `plugins/<plugin-id>/`
+
+Generated structure:
+
+```
+plugins/<plugin-id>/
+├── src/
+│   ├── index.ts              # Public exports
+│   ├── plugin.ts             # Plugin definition
+│   ├── routes.ts             # Route references
+│   └── components/
+│       └── ExampleComponent/
+├── package.json
+└── dev/
+    └── index.tsx             # Development harness
+```
+
+
+## Step 4: If you decided to use RHDH themes, add RHDH Theme to Development Harness
+
+By default, `yarn start` uses standard Backstage themes. To preview your plugin with RHDH styling during local development, configure the RHDH theme package.
+
+### Install Theme Package
+
+```bash
+cd plugins/<plugin-id>
+yarn add @red-hat-developer-hub/backstage-plugin-theme
+```
+
+### Configure Development Harness
+
+Update `dev/index.tsx` to use RHDH themes:
+
+```typescript
+import { getAllThemes } from '@red-hat-developer-hub/backstage-plugin-theme';
+import { createDevApp } from '@backstage/dev-utils';
+import { myPlugin, MyPage } from '../src';
+
+createDevApp()
+  .registerPlugin(myPlugin)
+  .addPage({
+    element: <MyPage />,
+    title: 'My Plugin',
+    path: '/my-plugin',
+  })
+  .addThemes(getAllThemes())
+  .render();
+```
+
+### Available Theme APIs
+
+- `getThemes()` / `useThemes()` - Latest RHDH light and dark themes
+- `getAllThemes()` / `useAllThemes()` - All themes including legacy versions
+- `useLoaderTheme()` - Returns Material-UI v5 theme object
+
+> **Note:** When deployed to RHDH, the application shell provides theming automatically. This configuration is only needed for local development.
+
+
+
+## Step 5: Implement Plugin Components
+
+### Page Component
+
+Create a full-page component for dynamic routes:
+
+```typescript
+// src/components/MyPage/MyPage.tsx
+import React from 'react';
+import { Page, Header, Content } from '@backstage/core-components';
+
+export const MyPage = () => (
+  <Page themeId="tool">
+    <Header title="My Plugin" />
+    <Content>
+      <h1>Hello from My Plugin</h1>
+    </Content>
+  </Page>
+);
+```
+
+### Entity Card Component
+
+Create a card for entity pages:
+
+```typescript
+// src/components/MyCard/MyCard.tsx
+import React from 'react';
+import { InfoCard } from '@backstage/core-components';
+import { useEntity } from '@backstage/plugin-catalog-react';
+
+export const MyEntityCard = () => {
+  const { entity } = useEntity();
+  return (
+    <InfoCard title="My Plugin Info">
+      <p>Entity: {entity.metadata.name}</p>
+    </InfoCard>
+  );
+};
+```
+
+### Export Components
+
+Export all components in `src/index.ts`:
+
+```typescript
+// src/index.ts
+export { myPlugin } from './plugin';
+export { MyPage } from './components/MyPage';
+export { MyEntityCard } from './components/MyCard';
+```
+
+Build and verify:
+
+```bash
+cd plugins/<plugin-id>
+yarn build
+```
+
+## Step 6: Export and Package
+
+Export the plugin as a dynamic plugin and package it for deployment. For detailed export and packaging options, see the **export-and-package** skill.
+
+### Quick Export
+
+```bash
+cd plugins/<plugin-id>
+npx @red-hat-developer-hub/cli@latest plugin export
+```
+
+Output shows the generated Scalprum configuration. Creates `dist-dynamic/` with `dist-scalprum/` (webpack federated modules).
+
+### Quick Package and Push
+
+```bash
+npx @red-hat-developer-hub/cli@latest plugin package \
+  --tag quay.io/<namespace>/<plugin-name>:v0.1.0
+
+podman push quay.io/<namespace>/<plugin-name>:v0.1.0
+```
+
+For advanced options (custom Scalprum config, multi-plugin bundles, tgz/npm packaging), consult the **export-and-package** skill.
+
+## Step 7: Configure Plugin Wiring
+
+Frontend plugins require configuration in `dynamic-plugins.yaml` to define how they integrate with RHDH.
+
+### Basic Example
+
+```yaml
+plugins:
+  - package: oci://quay.io/<namespace>/<plugin-name>:v0.1.0!my-plugin
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          my-org.plugin-my-plugin:  # Must match scalprum.name
+            dynamicRoutes:
+              - path: /my-plugin
+                importName: MyPage
+                menuItem:
+                  icon: dashboard
+                  text: My Plugin
+```
+
+### Key Wiring Options
+
+| Option | Purpose |
+|--------|---------|
+| `dynamicRoutes` | Full page routes with optional sidebar menu items |
+| `mountPoints` | Entity page cards, tabs, and other integrations |
+| `menuItems` | Sidebar ordering and nesting |
+| `appIcons` | Custom icons for routes and menus |
+| `entityTabs` | New tabs on entity pages |
+
+For complete wiring configuration (mount points, conditional rendering, custom tabs, themes, scaffolder extensions), use the **generate-frontend-wiring** skill.
+
+## Known Issues
+
+### MUI v5 Styles Missing
+
+If using MUI v5, add class name generator to `src/index.ts`:
+
+```typescript
+import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
+
+ClassNameGenerator.configure(componentName =>
+  componentName.startsWith('v5-') ? componentName : `v5-${componentName}`
+);
+
+export * from './plugin';
+```
+
+### Grid Spacing Missing
+
+Apply spacing manually to MUI v5 Grid:
+
+```tsx
+<Grid container spacing={2}>
+  <Grid item>...</Grid>
+</Grid>
+```
+
+## Additional Resources
+
+### Related Skills
+
+- **export-and-package** - Complete export/packaging workflow
+- **generate-frontend-wiring** - Advanced wiring configuration (mount points, tabs, themes, etc.)
+
+### Reference Files
+
+- **`references/frontend-wiring.md`** - Complete mount points, routes, bindings
+- **`references/entity-page.md`** - Entity page customization
+
+### Example Files
+
+- **`examples/frontend-plugin-config.yaml`** - Complete frontend wiring example
+
+### External Resources
+
+- [RHDH Frontend Plugin Wiring](https://github.com/redhat-developer/rhdh/blob/main/docs/dynamic-plugins/frontend-plugin-wiring.md)
+- [Backstage Plugin Development](https://backstage.io/docs/plugins/)

--- a/skills/create-frontend-plugin/examples/frontend-plugin-config.yaml
+++ b/skills/create-frontend-plugin/examples/frontend-plugin-config.yaml
@@ -1,0 +1,363 @@
+# Example Frontend Dynamic Plugin Configuration for RHDH
+# This file demonstrates various frontend plugin wiring patterns
+
+plugins:
+  # ============================================================
+  # Complete Frontend Plugin Example
+  # Demonstrates all common wiring patterns
+  # ============================================================
+
+  - package: oci://quay.io/example/my-complete-plugin:v1.0.0!my-complete-plugin
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          my-org.plugin-my-complete:
+            # Custom icons (register before using in routes/menus)
+            appIcons:
+              - name: myPluginIcon
+                importName: MyPluginIcon
+
+            # Full page routes with sidebar menu
+            dynamicRoutes:
+              - path: /my-plugin
+                importName: MyPluginPage
+                menuItem:
+                  icon: myPluginIcon
+                  text: My Plugin
+
+              - path: /my-plugin/settings
+                importName: MyPluginSettings
+                # No menuItem = no sidebar entry
+
+            # Entity page cards
+            mountPoints:
+              # Overview card (full width, first row)
+              - mountPoint: entity.page.overview/cards
+                importName: MyOverviewCard
+                config:
+                  layout:
+                    gridColumn: '1 / -1'
+                    gridRowStart: 1
+                  if:
+                    allOf:
+                      - isKind: component
+                      - hasAnnotation: my-plugin/enabled
+
+              # CI tab card
+              - mountPoint: entity.page.ci/cards
+                importName: MyCICard
+                config:
+                  if:
+                    isKind: component
+
+            # Sidebar menu configuration
+            menuItems:
+              my-plugin:
+                priority: 50
+
+  # ============================================================
+  # Entity Card Only Plugin
+  # Adds a card to entity pages without routes
+  # ============================================================
+
+  - package: oci://quay.io/example/my-card-plugin:v1.0.0!my-card-plugin
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          my-org.plugin-my-card:
+            mountPoints:
+              - mountPoint: entity.page.overview/cards
+                importName: MyInfoCard
+                config:
+                  layout:
+                    gridColumn: 'span 2'
+                  if:
+                    anyOf:
+                      - isType: service
+                      - isType: website
+
+  # ============================================================
+  # Custom Tab Plugin
+  # Adds a new tab to entity pages
+  # ============================================================
+
+  - package: oci://quay.io/example/my-tab-plugin:v1.0.0!my-tab-plugin
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          my-org.plugin-my-tab:
+            # Define the new tab
+            entityTabs:
+              - path: /my-custom-tab
+                title: My Custom Tab
+                mountPoint: entity.page.my-custom-tab
+                priority: 50
+
+            # Add content to the tab
+            mountPoints:
+              - mountPoint: entity.page.my-custom-tab/cards
+                importName: MyTabContent
+                config:
+                  layout:
+                    gridColumn: '1 / -1'
+
+  # ============================================================
+  # Search Integration Plugin
+  # Adds custom search types, filters, and results
+  # ============================================================
+
+  - package: oci://quay.io/example/my-search-plugin:v1.0.0!my-search-plugin
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          my-org.plugin-my-search:
+            mountPoints:
+              # Custom search result type
+              - mountPoint: search.page.types
+                importName: MySearchType
+
+              # Custom search filter
+              - mountPoint: search.page.filters
+                importName: MySearchFilter
+
+              # Custom search result renderer
+              - mountPoint: search.page.results
+                importName: MySearchResult
+
+  # ============================================================
+  # Nested Menu Plugin
+  # Demonstrates parent-child menu hierarchy
+  # ============================================================
+
+  - package: oci://quay.io/example/my-tools-plugin:v1.0.0!my-tools-plugin
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          my-org.plugin-my-tools:
+            appIcons:
+              - name: toolsIcon
+                importName: ToolsIcon
+              - name: tool1Icon
+                importName: Tool1Icon
+              - name: tool2Icon
+                importName: Tool2Icon
+
+            dynamicRoutes:
+              - path: /tools/tool1
+                importName: Tool1Page
+                menuItem:
+                  icon: tool1Icon
+                  text: Tool 1
+
+              - path: /tools/tool2
+                importName: Tool2Page
+                menuItem:
+                  icon: tool2Icon
+                  text: Tool 2
+
+            menuItems:
+              # Parent menu item
+              tools:
+                icon: toolsIcon
+                title: Developer Tools
+                priority: 100
+
+              # Child items nested under parent
+              tools.tool1:
+                priority: 20
+                parent: tools
+
+              tools.tool2:
+                priority: 10
+                parent: tools
+
+  # ============================================================
+  # Theme Plugin
+  # Provides custom light and dark themes
+  # ============================================================
+
+  - package: oci://quay.io/example/my-theme-plugin:v1.0.0!my-theme-plugin
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          my-org.plugin-my-theme:
+            themes:
+              # Override default light theme
+              - id: light
+                title: My Light Theme
+                variant: light
+                icon: brightness5
+                importName: myLightThemeProvider
+
+              # Override default dark theme
+              - id: dark
+                title: My Dark Theme
+                variant: dark
+                icon: brightness2
+                importName: myDarkThemeProvider
+
+              # Additional custom theme
+              - id: high-contrast
+                title: High Contrast
+                variant: light
+                icon: contrastIcon
+                importName: highContrastThemeProvider
+
+  # ============================================================
+  # Scaffolder Extension Plugin
+  # Custom form fields for software templates
+  # ============================================================
+
+  - package: oci://quay.io/example/my-scaffolder-plugin:v1.0.0!my-scaffolder-plugin
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          my-org.plugin-my-scaffolder:
+            scaffolderFieldExtensions:
+              - importName: MyCustomPicker
+              - importName: MyValidatedInput
+              - importName: MyRepoSelector
+
+  # ============================================================
+  # TechDocs Addon Plugin
+  # Extends TechDocs functionality
+  # ============================================================
+
+  - package: oci://quay.io/example/my-techdocs-addon:v1.0.0!my-techdocs-addon
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          my-org.plugin-my-techdocs-addon:
+            techdocsAddons:
+              - importName: MyTechDocsAddon
+                config:
+                  props:
+                    position: header
+
+  # ============================================================
+  # Context Menu Plugin
+  # Adds actions to entity context menu
+  # ============================================================
+
+  - package: oci://quay.io/example/my-actions-plugin:v1.0.0!my-actions-plugin
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          my-org.plugin-my-actions:
+            appIcons:
+              - name: refreshIcon
+                importName: RefreshIcon
+              - name: exportIcon
+                importName: ExportIcon
+
+            mountPoints:
+              - mountPoint: entity.context.menu
+                importName: RefreshDialog
+                config:
+                  props:
+                    title: Refresh Data
+                    icon: refreshIcon
+
+              - mountPoint: entity.context.menu
+                importName: ExportDialog
+                config:
+                  props:
+                    title: Export Entity
+                    icon: exportIcon
+
+  # ============================================================
+  # Route Bindings Plugin
+  # Binds external routes between plugins
+  # ============================================================
+
+  - package: oci://quay.io/example/my-integration-plugin:v1.0.0!my-integration-plugin
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          my-org.plugin-my-integration:
+            routeBindings:
+              targets:
+                - importName: myIntegrationPlugin
+
+              bindings:
+                - bindTarget: catalogPlugin.externalRoutes
+                  bindMap:
+                    viewTechDoc: myIntegrationPlugin.routes.docs
+
+  # ============================================================
+  # API Factory Plugin
+  # Provides or overrides Utility APIs
+  # ============================================================
+
+  - package: oci://quay.io/example/my-api-plugin:v1.0.0!my-api-plugin
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          my-org.plugin-my-api:
+            apiFactories:
+              - importName: myCustomApiFactory
+
+  # ============================================================
+  # Custom Sign-In Page Plugin
+  # Provides custom authentication UI
+  # ============================================================
+
+  - package: oci://quay.io/example/my-auth-plugin:v1.0.0!my-auth-plugin
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          my-org.plugin-my-auth:
+            signInPage:
+              importName: MyCustomSignInPage
+
+            providerSettings:
+              - title: My SSO Provider
+                description: Sign in with corporate SSO
+                provider: core.auth.my-sso
+
+  # ============================================================
+  # Application Header Plugin
+  # Adds global header to the application
+  # ============================================================
+
+  - package: oci://quay.io/example/my-header-plugin:v1.0.0!my-header-plugin
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          my-org.plugin-my-header:
+            mountPoints:
+              - mountPoint: application/header
+                importName: GlobalHeader
+                config:
+                  position: above-main-content
+
+  # ============================================================
+  # Application Provider Plugin
+  # Adds context providers to the application
+  # ============================================================
+
+  - package: oci://quay.io/example/my-provider-plugin:v1.0.0!my-provider-plugin
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          my-org.plugin-my-provider:
+            mountPoints:
+              - mountPoint: application/provider
+                importName: MyGlobalProvider
+
+              - mountPoint: application/listener
+                importName: MyEventListener

--- a/skills/export-and-package/SKILL.md
+++ b/skills/export-and-package/SKILL.md
@@ -1,0 +1,334 @@
+---
+name: RHDH Dynamic Plugin Export and Package
+description: This skill should be used when the user asks to "export dynamic plugin", "package plugin as OCI", "create plugin container image", "publish plugin to registry", "build OCI artifact", "package plugin as tgz", "push plugin to quay.io", "create dynamic plugin archive", "bundle multiple plugins", "generate integrity hash", or mentions exporting, packaging, or publishing an existing Backstage plugin for RHDH deployment. This skill handles the export and packaging workflow after a plugin has been implemented.
+---
+
+## Purpose
+
+Export and package Backstage plugins as RHDH dynamic plugins for deployment. This skill covers the build, export, and packaging workflow that transforms a developed plugin into a deployable artifact (OCI image, tgz archive, or npm package).
+
+> **Note:** This skill is for **exporting and packaging** already-implemented plugins. For creating new plugins, use the backend or frontend plugin creation skills first.
+
+## When to Use
+
+Use this skill when you need to:
+- Export a plugin as a dynamic plugin package
+- Package a plugin as an OCI container image
+- Create a tgz archive for HTTP distribution
+- Publish a plugin to a container registry
+- Bundle multiple plugins into a single image
+- Generate integrity hashes for package verification
+- Troubleshoot export or packaging issues
+
+## Prerequisites
+
+Before starting, ensure:
+- Plugin is built and compiles without errors (`yarn build`)
+- Container runtime installed (`podman` or `docker`)
+- Access to a container registry (e.g., quay.io) if publishing OCI images
+- For backend plugins: Uses new backend system with default export
+- For frontend plugins: Has valid Scalprum configuration (auto-generated if not present)
+
+## Workflow Overview
+
+1. **Build Plugin** - Compile TypeScript and verify no errors
+2. **Export as Dynamic Plugin** - Create `dist-dynamic/` with RHDH CLI
+3. **Package as Artifact** - Create OCI image, tgz, or npm package
+4. **Push to Registry** - Publish to container or npm registry
+5. **Verify Locally** - Test before deployment (optional)
+
+## Step 1: Build Plugin
+
+Before exporting, ensure the plugin builds successfully:
+
+```bash
+cd plugins/<plugin-id>  # or plugins/<plugin-id>-backend
+yarn build
+yarn tsc  # Verify no TypeScript errors
+```
+
+## Step 2: Export as Dynamic Plugin
+
+Run the RHDH CLI export command from the plugin directory:
+
+```bash
+npx @red-hat-developer-hub/cli@latest plugin export
+```
+
+This creates a `dist-dynamic/` directory containing:
+- Compiled JavaScript optimized for dynamic loading
+- Modified `package.json` with peer/bundled dependencies
+- Config schema (if defined)
+- For frontend: `dist-scalprum/` with webpack federated modules
+
+### Export Options
+
+#### Control Shared Dependencies
+
+By default, all `@backstage/*` packages are shared (provided by RHDH at runtime). Override this behavior:
+
+```bash
+# Bundle a @backstage package instead of sharing
+npx @red-hat-developer-hub/cli@latest plugin export \
+  --shared-package '!/@backstage/plugin-notifications/'
+
+# Mark a non-backstage package as shared
+npx @red-hat-developer-hub/cli@latest plugin export \
+  --shared-package @my-org/shared-utils
+```
+
+#### Embed Packages
+
+Embed workspace or third-party packages into the plugin:
+
+```bash
+npx @red-hat-developer-hub/cli@latest plugin export \
+  --embed-package @my-org/plugin-common \
+  --embed-package @my-org/utils
+```
+
+#### Combined Example
+
+```bash
+npx @red-hat-developer-hub/cli@latest plugin export \
+  --shared-package '!/@backstage/plugin-notifications/' \
+  --embed-package @internal/common-utils
+```
+
+See `references/export-options.md` for all available options.
+
+## Step 3: Package as Artifact
+
+Choose a packaging format based on your deployment needs.
+
+### OCI Image (Recommended for Production)
+
+Create a container image:
+
+```bash
+npx @red-hat-developer-hub/cli@latest plugin package \
+  --tag quay.io/<namespace>/<plugin-name>:v0.1.0
+```
+
+Specify container tool if needed:
+
+```bash
+npx @red-hat-developer-hub/cli@latest plugin package \
+  --container-tool docker \
+  --tag quay.io/<namespace>/<plugin-name>:v0.1.0
+```
+
+Available tools: `podman` (default), `docker`, `buildah`
+
+### tgz Archive
+
+Create a tar archive for HTTP distribution:
+
+```bash
+cd dist-dynamic
+npm pack
+```
+
+Get the integrity hash:
+
+```bash
+npm pack --json | jq -r '.[0].integrity'
+```
+
+### npm Package
+
+Publish to a private npm registry:
+
+```bash
+cd dist-dynamic
+npm publish --registry https://your-private-registry.com
+```
+
+### Multi-Plugin Image
+
+Bundle frontend and backend plugins in one image:
+
+```bash
+# Export both plugins first
+cd plugins/my-plugin && npx @red-hat-developer-hub/cli@latest plugin export
+cd ../my-plugin-backend && npx @red-hat-developer-hub/cli@latest plugin export
+
+# Package together from monorepo root
+cd ../..
+npx @red-hat-developer-hub/cli@latest plugin package \
+  --tag quay.io/<namespace>/my-plugin-bundle:v0.1.0
+```
+
+See `references/packaging-formats.md` for detailed format comparison.
+
+## Step 4: Push to Registry
+
+### OCI Image
+
+```bash
+# Podman
+podman push quay.io/<namespace>/<plugin-name>:v0.1.0
+
+# Docker
+docker push quay.io/<namespace>/<plugin-name>:v0.1.0
+```
+
+### Private Registry Authentication
+
+Set the auth file environment variable:
+
+```bash
+export REGISTRY_AUTH_FILE=~/.config/containers/auth.json
+# or
+export REGISTRY_AUTH_FILE=~/.docker/config.json
+```
+
+### Image Digest
+
+After pushing, get the digest for reproducible deployments:
+
+```bash
+podman inspect --format='{{.Digest}}' quay.io/<namespace>/<plugin-name>:v0.1.0
+```
+
+Use digest in `dynamic-plugins.yaml`:
+
+```yaml
+plugins:
+  - package: oci://quay.io/<namespace>/<plugin-name>@sha256:abc123...!<plugin-id>-dynamic
+    disabled: false
+```
+
+## Step 5: Verify Locally (Optional)
+
+Test the exported plugin before publishing:
+
+```bash
+# Copy to local RHDH instance
+cp -r dist-dynamic /path/to/rhdh/dynamic-plugins-root/<plugin-id>-dynamic
+
+# Start RHDH and verify plugin loads
+yarn workspace backend start
+```
+
+Check logs for:
+- `loaded dynamic backend plugin` - Success
+- `Skipping disabled dynamic plugin` - Plugin disabled in config
+- Error messages during initialization
+
+## Configuration Examples
+
+### Backend Plugin
+
+```yaml
+plugins:
+  - package: oci://quay.io/<namespace>/<plugin-name>:v0.1.0!<plugin-id>-backend-dynamic
+    disabled: false
+    pluginConfig:
+      myPlugin:
+        apiUrl: https://api.example.com
+```
+
+### Frontend Plugin
+
+```yaml
+plugins:
+  - package: oci://quay.io/<namespace>/<plugin-name>:v0.1.0!<plugin-id>
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          my-org.plugin-my-plugin:
+            dynamicRoutes:
+              - path: /my-plugin
+                importName: MyPage
+```
+
+### Multi-Plugin Bundle
+
+```yaml
+plugins:
+  # Frontend from bundle
+  - package: oci://quay.io/<namespace>/my-bundle:v0.1.0!my-plugin
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          my-org.plugin-my-plugin:
+            mountPoints:
+              - mountPoint: entity.page.overview/cards
+                importName: MyCard
+
+  # Backend from same bundle
+  - package: oci://quay.io/<namespace>/my-bundle:v0.1.0!my-plugin-backend-dynamic
+    disabled: false
+```
+
+See `examples/dynamic-plugins.yaml` for complete examples.
+
+## Troubleshooting
+
+### Export Fails
+
+**Missing dependencies:**
+```bash
+yarn add -D <missing-package>
+npx @red-hat-developer-hub/cli@latest plugin export
+```
+
+**TypeScript errors:**
+```bash
+yarn tsc
+# Fix errors, then retry export
+```
+
+**Clear stale artifacts:**
+```bash
+rm -rf dist dist-dynamic
+yarn build
+npx @red-hat-developer-hub/cli@latest plugin export
+```
+
+### Package Fails
+
+**Container tool not found:**
+```bash
+# Specify available tool
+npx @red-hat-developer-hub/cli@latest plugin package \
+  --container-tool docker \
+  --tag quay.io/<namespace>/<plugin-name>:v0.1.0
+```
+
+**Permission denied:**
+```bash
+# Check registry login
+podman login quay.io
+```
+
+### Plugin Not Loading in RHDH
+
+1. Verify package path matches plugin ID
+2. Check version compatibility with target RHDH
+3. Ensure default export exists (backend plugins)
+4. Verify Scalprum name matches (frontend plugins)
+5. Check RHDH logs for specific errors
+
+### Integrity Hash Mismatch
+
+Regenerate the hash:
+```bash
+cd dist-dynamic
+npm pack --json | jq -r '.[0].integrity'
+```
+
+Update `dynamic-plugins.yaml` with new hash.
+
+## Reference Files
+
+- **`references/export-options.md`** - All export CLI options
+- **`references/packaging-formats.md`** - Format comparison and best practices
+- **`references/integrity-hashes.md`** - Hash generation and verification
+
+## Example Files
+
+- **`examples/dynamic-plugins.yaml`** - Complete configuration examples

--- a/skills/export-and-package/examples/dynamic-plugins.yaml
+++ b/skills/export-and-package/examples/dynamic-plugins.yaml
@@ -1,0 +1,159 @@
+# Example Dynamic Plugin Configurations
+# Demonstrates various packaging formats and configuration patterns
+
+plugins:
+  # ============================================================
+  # OCI Image Examples
+  # ============================================================
+
+  # Backend plugin from OCI image (basic)
+  - package: oci://quay.io/example/my-backend-plugin:v1.0.0!my-plugin-backend-dynamic
+    disabled: false
+    pluginConfig:
+      myPlugin:
+        apiUrl: https://api.example.com
+
+  # Frontend plugin from OCI image
+  - package: oci://quay.io/example/my-frontend-plugin:v1.0.0!my-plugin
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          my-org.plugin-my-plugin:
+            dynamicRoutes:
+              - path: /my-plugin
+                importName: MyPage
+                menuItem:
+                  icon: dashboard
+                  text: My Plugin
+
+  # OCI with digest (recommended for production)
+  - package: oci://quay.io/example/my-plugin@sha256:28036abec4dffc714394e4ee433f16a59493db8017795049c831be41c02eb5dc!my-plugin-backend-dynamic
+    disabled: false
+
+  # OCI with version inheritance (requires includes)
+  # includes:
+  #   - dynamic-plugins.default.yaml
+  - package: oci://quay.io/example/my-plugin:{{inherit}}!my-plugin-backend-dynamic
+    disabled: false
+
+  # ============================================================
+  # Multi-Plugin Bundle Examples
+  # ============================================================
+
+  # Frontend and backend from same OCI image
+  - package: oci://quay.io/example/my-plugin-bundle:v1.0.0!my-plugin
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          my-org.plugin-my-plugin:
+            mountPoints:
+              - mountPoint: entity.page.overview/cards
+                importName: MyPluginCard
+
+  - package: oci://quay.io/example/my-plugin-bundle:v1.0.0!my-plugin-backend-dynamic
+    disabled: false
+    pluginConfig:
+      myPlugin:
+        apiUrl: https://api.example.com
+
+  # ============================================================
+  # tgz Archive Examples
+  # ============================================================
+
+  # Plugin from HTTP server
+  - package: https://plugin-registry.example.com/my-plugin-1.0.0.tgz
+    integrity: sha512-9WlbgEdadJNeQxdn1973r5E4kNFvnT9GjLD627GWgrhCaxjCmxqdNW08cj+Bf47mwAtZMt1Ttyo+ZhDRDj9PoA==
+    disabled: false
+    pluginConfig:
+      myPlugin:
+        enabled: true
+
+  # Plugin from internal httpd service (OpenShift)
+  - package: http://plugin-registry:8080/my-plugin-backend-dynamic-1.0.0.tgz
+    integrity: sha512-abc123def456...
+    disabled: false
+
+  # ============================================================
+  # npm Package Examples
+  # ============================================================
+
+  # Plugin from private npm registry
+  - package: '@my-org/my-plugin-dynamic@1.0.0'
+    integrity: sha512-xyz789...
+    disabled: false
+    pluginConfig:
+      myPlugin:
+        setting: value
+
+  # Scoped package with specific version
+  - package: '@company/backstage-plugin-custom@^2.0.0'
+    integrity: sha512-abc...
+    disabled: false
+
+  # ============================================================
+  # Local Development Examples
+  # ============================================================
+
+  # Pre-installed plugin (already in RHDH image)
+  - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-dynamic
+    disabled: false
+
+  # Local development plugin (copied to dynamic-plugins-root)
+  - package: ./dynamic-plugins-root/my-dev-plugin-dynamic
+    disabled: false
+    pluginConfig:
+      myDevPlugin:
+        debug: true
+
+  # ============================================================
+  # Complete Plugin Configuration Patterns
+  # ============================================================
+
+  # Backend plugin with full config
+  - package: oci://quay.io/example/complete-backend:v1.0.0!complete-backend-dynamic
+    disabled: false
+    pluginConfig:
+      completePlugin:
+        apiUrl: https://api.example.com
+        timeout: 30000
+        auth:
+          type: bearer
+          tokenEnv: PLUGIN_API_TOKEN
+        features:
+          caching: true
+          retries: 3
+
+  # Frontend plugin with full wiring
+  - package: oci://quay.io/example/complete-frontend:v1.0.0!complete-frontend
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          my-org.plugin-complete:
+            appIcons:
+              - name: completeIcon
+                importName: CompleteIcon
+
+            dynamicRoutes:
+              - path: /complete
+                importName: CompletePage
+                menuItem:
+                  icon: completeIcon
+                  text: Complete Plugin
+
+            mountPoints:
+              - mountPoint: entity.page.overview/cards
+                importName: CompleteCard
+                config:
+                  layout:
+                    gridColumn: '1 / -1'
+                  if:
+                    allOf:
+                      - isKind: component
+                      - hasAnnotation: complete-plugin/enabled
+
+            menuItems:
+              complete:
+                priority: 50

--- a/skills/export-and-package/references/export-options.md
+++ b/skills/export-and-package/references/export-options.md
@@ -1,0 +1,269 @@
+# Dynamic Plugin Export Options
+
+Complete reference for `@red-hat-developer-hub/cli plugin export` command options.
+
+## Basic Usage
+
+```bash
+npx @red-hat-developer-hub/cli@latest plugin export
+```
+
+Run from the plugin's root directory (where `package.json` is located). Creates `dist-dynamic/` directory.
+
+## Command Options
+
+### --shared-package
+
+Control which packages are considered shared (provided by RHDH at runtime).
+
+**Default behavior:** All `@backstage/*` scoped packages are shared.
+
+```bash
+# Add a package to shared list
+npx @red-hat-developer-hub/cli@latest plugin export \
+  --shared-package @my-org/shared-utils
+
+# Exclude a @backstage package from shared (bundle it instead)
+npx @red-hat-developer-hub/cli@latest plugin export \
+  --shared-package '!/@backstage/plugin-notifications/'
+
+# Multiple shared package rules
+npx @red-hat-developer-hub/cli@latest plugin export \
+  --shared-package @my-org/shared-utils \
+  --shared-package '!/@backstage/plugin-some-other/'
+```
+
+**Pattern syntax:**
+- Prefix with `!` to negate (exclude from shared)
+- Use regex patterns: `'!/@backstage\/plugin-notifications/'`
+
+### --embed-package
+
+Merge package code directly into the plugin bundle.
+
+**Default behavior:** Packages with `-node` or `-common` suffix are auto-embedded.
+
+```bash
+# Embed a workspace package
+npx @red-hat-developer-hub/cli@latest plugin export \
+  --embed-package @my-org/plugin-common
+
+# Embed multiple packages
+npx @red-hat-developer-hub/cli@latest plugin export \
+  --embed-package @my-org/common \
+  --embed-package @my-org/utils
+```
+
+**Use cases:**
+- Workspace packages that aren't published
+- Third-party packages that need modification
+- Packages with version conflicts
+
+## Dependency Categories
+
+### Shared Dependencies
+
+- Become `peerDependencies` in generated package.json
+- Not bundled in plugin package
+- Provided by RHDH at runtime
+- Must be version-compatible with target RHDH
+
+**Default shared:**
+- All `@backstage/*` packages
+
+### Private Dependencies
+
+- Listed in `bundleDependencies`
+- Included in `node_modules/` within `dist-dynamic/`
+- Isolated from RHDH's dependencies
+
+**Default private:**
+- Non-backstage dependencies
+- Dependencies explicitly excluded from shared
+
+### Embedded Dependencies
+
+- Code merged into plugin bundle
+- No separate entry in node_modules
+- Dependencies hoisted to plugin level
+
+**Default embedded:**
+- Packages with `-node` suffix
+- Packages with `-common` suffix
+
+## Output Structure
+
+After export, `dist-dynamic/` contains:
+
+### Backend Plugins
+
+```
+dist-dynamic/
+├── package.json          # Modified for dynamic loading
+├── dist/
+│   ├── index.js          # Compiled plugin code
+│   └── configSchema.json # Self-contained config schema
+└── node_modules/         # Private dependencies (if any)
+```
+
+### Frontend Plugins
+
+```
+dist-dynamic/
+├── package.json
+├── dist-scalprum/        # Webpack federated modules
+│   ├── plugin-manifest.json
+│   └── static/
+│       ├── main.js
+│       └── main.js.map   # Source maps
+└── node_modules/
+```
+
+## Modified package.json
+
+The generated `package.json` includes:
+
+```json
+{
+  "name": "@my-org/my-plugin-dynamic",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "peerDependencies": {
+    "@backstage/backend-plugin-api": "^1.3.0"
+  },
+  "bundleDependencies": [
+    "some-private-dep"
+  ],
+  "backstage": {
+    "role": "backend-plugin"
+  }
+}
+```
+
+## Scalprum Configuration (Frontend)
+
+Frontend plugins require Scalprum configuration for module federation.
+
+### Auto-generated
+
+If not specified, CLI generates defaults:
+
+```json
+{
+  "scalprum": {
+    "name": "my-org.plugin-my-plugin",
+    "exposedModules": {
+      "PluginRoot": "./src/index.ts"
+    }
+  }
+}
+```
+
+### Custom Configuration
+
+Add to `package.json` before export:
+
+```json
+{
+  "scalprum": {
+    "name": "custom-package-name",
+    "exposedModules": {
+      "FooModule": "./src/foo.ts",
+      "BarModule": "./src/bar.ts"
+    }
+  }
+}
+```
+
+## Troubleshooting
+
+### Build Errors Before Export
+
+```bash
+# Check TypeScript compilation
+yarn tsc
+
+# Ensure dependencies installed
+yarn install
+```
+
+### Missing Dependency Errors
+
+```bash
+# Install missing dev dependency
+yarn add -D <missing-package>
+
+# Re-run export
+npx @red-hat-developer-hub/cli@latest plugin export
+```
+
+### Version Conflicts
+
+Check target RHDH version compatibility:
+1. Identify target RHDH version
+2. Match `@backstage/*` versions to that RHDH
+3. Update package.json dependencies
+4. Re-run `yarn install`
+5. Re-export
+
+### Shared Dependency Not Found
+
+If RHDH doesn't provide an expected shared dependency:
+
+```bash
+# Bundle it instead of sharing
+npx @red-hat-developer-hub/cli@latest plugin export \
+  --shared-package '!/@backstage/problematic-package/'
+```
+
+### Embedded Package Issues
+
+If embedding causes conflicts:
+
+```bash
+# Check if package should be shared instead
+npx @red-hat-developer-hub/cli@latest plugin export \
+  --shared-package @problem/package
+```
+
+## Best Practices
+
+### 1. Lock Backstage Versions
+
+```json
+{
+  "dependencies": {
+    "@backstage/backend-plugin-api": "1.3.1"
+  }
+}
+```
+
+### 2. Minimize Dependencies
+
+Keep dependencies minimal to reduce bundle size and conflicts.
+
+### 3. Test Before Publishing
+
+```bash
+cp -r dist-dynamic /path/to/rhdh/dynamic-plugins-root/my-plugin-dynamic
+yarn workspace backend start
+```
+
+### 4. Include Config Schema
+
+```typescript
+// src/config.ts
+export interface Config {
+  myPlugin?: {
+    /**
+     * Description for users
+     * @visibility backend
+     */
+    apiUrl?: string;
+  };
+}
+```
+
+### 5. Document Required Configuration
+
+Include example configuration with your plugin documentation.

--- a/skills/export-and-package/references/integrity-hashes.md
+++ b/skills/export-and-package/references/integrity-hashes.md
@@ -1,0 +1,240 @@
+# Integrity Hashes for Dynamic Plugins
+
+Reference for generating and using integrity hashes with RHDH dynamic plugins.
+
+## Overview
+
+Integrity hashes ensure downloaded plugin packages haven't been modified. They're cryptographic checksums that verify package authenticity.
+
+## When Required
+
+| Package Format | Integrity Method |
+|---------------|------------------|
+| OCI Image | Use digest (`@sha256:...`) instead of tag |
+| tgz Archive | SHA-512 hash in config |
+| npm Package | SHA-512 hash in config |
+| Local Directory | Not applicable |
+
+## Generating Hashes
+
+### tgz Archive
+
+```bash
+cd dist-dynamic
+npm pack --json | jq -r '.[0].integrity'
+```
+
+Example output:
+```
+sha512-9WlbgEdadJNeQxdn1973r5E4kNFvnT9GjLD627GWgrhCaxjCmxqdNW08cj+Bf47mwAtZMt1Ttyo+ZhDRDj9PoA==
+```
+
+### npm Package
+
+After publishing:
+
+```bash
+npm view @my-org/my-plugin-dynamic@1.0.0 dist.integrity
+```
+
+For private registry:
+
+```bash
+npm view --registry https://your-registry.com \
+  @my-org/my-plugin-dynamic@1.0.0 dist.integrity
+```
+
+### OCI Image Digest
+
+After pushing:
+
+```bash
+# Podman
+podman inspect --format='{{.Digest}}' quay.io/<namespace>/<plugin>:v1.0.0
+
+# Docker
+docker inspect --format='{{index .RepoDigests 0}}' quay.io/<namespace>/<plugin>:v1.0.0
+
+# From registry
+skopeo inspect docker://quay.io/<namespace>/<plugin>:v1.0.0 | jq -r '.Digest'
+```
+
+Example digest:
+```
+sha256:28036abec4dffc714394e4ee433f16a59493db8017795049c831be41c02eb5dc
+```
+
+## Using Hashes in Configuration
+
+### tgz with Integrity
+
+```yaml
+plugins:
+  - package: https://plugins.example.com/my-plugin-1.0.0.tgz
+    integrity: sha512-9WlbgEdadJNeQxdn1973r5E4kNFvnT9GjLD627GWgrhCaxjCmxqdNW08cj+Bf47mwAtZMt1Ttyo+ZhDRDj9PoA==
+    disabled: false
+```
+
+### npm with Integrity
+
+```yaml
+plugins:
+  - package: '@my-org/my-plugin-dynamic@1.0.0'
+    integrity: sha512-abc123def456...
+    disabled: false
+```
+
+### OCI with Digest
+
+```yaml
+plugins:
+  - package: oci://quay.io/<namespace>/<plugin>@sha256:28036abec4dffc714394e4ee433f16a59493db8017795049c831be41c02eb5dc!<plugin-id>-dynamic
+    disabled: false
+```
+
+## Hash Format
+
+### SHA-512 (tgz/npm)
+
+Base64-encoded SHA-512 hash:
+
+```
+sha512-<base64-encoded-hash>
+```
+
+Length: ~88 characters after `sha512-`
+
+### SHA-256 (OCI digest)
+
+Hex-encoded SHA-256 hash:
+
+```
+sha256:<hex-encoded-hash>
+```
+
+Length: 64 hex characters after `sha256:`
+
+## Verification
+
+### Manual Verification (tgz)
+
+```bash
+# Calculate hash of downloaded file
+shasum -a 512 my-plugin-1.0.0.tgz | awk '{print $1}' | xxd -r -p | base64
+
+# Compare with expected hash
+```
+
+### RHDH Verification
+
+RHDH automatically verifies integrity when:
+1. Package is downloaded from URL
+2. Integrity hash is provided in configuration
+3. Calculated hash must match exactly
+
+Mismatch results in plugin load failure with error in logs.
+
+## Common Issues
+
+### Integrity Mismatch
+
+**Symptom:** Plugin fails to load with integrity error
+
+**Causes:**
+1. Package was modified after hash generated
+2. Wrong version specified
+3. Hash from different build
+
+**Solution:**
+```bash
+# Regenerate hash
+cd dist-dynamic
+npm pack --json | jq -r '.[0].integrity'
+
+# Update configuration with new hash
+```
+
+### Missing Integrity
+
+**Symptom:** Warning or error about missing integrity
+
+**Solution:** Always include integrity for tgz/npm packages:
+
+```yaml
+plugins:
+  - package: https://example.com/plugin.tgz
+    integrity: sha512-...  # Required!
+    disabled: false
+```
+
+### Wrong Hash Algorithm
+
+**Symptom:** Hash format not recognized
+
+**Solution:** Use SHA-512 for tgz/npm:
+```
+sha512-<base64>
+```
+
+Not SHA-256 or MD5.
+
+## Best Practices
+
+### 1. Always Use Integrity
+
+For tgz and npm packages, always include integrity hash:
+
+```yaml
+plugins:
+  - package: https://example.com/plugin.tgz
+    integrity: sha512-...
+    disabled: false
+```
+
+### 2. Use Digests for OCI
+
+Prefer digest over tag for production:
+
+```yaml
+# Recommended - immutable
+- package: oci://quay.io/ns/plugin@sha256:abc123...!plugin
+
+# Not recommended - mutable
+- package: oci://quay.io/ns/plugin:v1.0.0!plugin
+```
+
+### 3. Automate Hash Generation
+
+Add to CI/CD pipeline:
+
+```bash
+# Generate and store hash
+INTEGRITY=$(npm pack --json | jq -r '.[0].integrity')
+echo "integrity: $INTEGRITY" >> plugin-metadata.yaml
+```
+
+### 4. Version Control Hashes
+
+Track hashes alongside version:
+
+```yaml
+# plugin-versions.yaml
+my-plugin:
+  v1.0.0:
+    tgz: https://example.com/my-plugin-1.0.0.tgz
+    integrity: sha512-abc123...
+  v1.1.0:
+    tgz: https://example.com/my-plugin-1.1.0.tgz
+    integrity: sha512-def456...
+```
+
+### 5. Document Hash Sources
+
+Include in release notes:
+
+```markdown
+## v1.0.0
+
+Download: https://example.com/my-plugin-1.0.0.tgz
+Integrity: sha512-9WlbgEdadJNeQxdn1973r5E4kNFvnT9GjLD627GWgrhCaxjCmxqdNW08cj+Bf47mwAtZMt1Ttyo+ZhDRDj9PoA==
+```

--- a/skills/export-and-package/references/packaging-formats.md
+++ b/skills/export-and-package/references/packaging-formats.md
@@ -1,0 +1,354 @@
+# Dynamic Plugin Packaging Formats
+
+Complete reference for packaging RHDH dynamic plugins in different formats.
+
+## Format Comparison
+
+| Format | Production Ready | Integrity | Versioning | Use Case |
+|--------|-----------------|-----------|------------|----------|
+| OCI Image | Yes | Digest | Tags | OpenShift/Kubernetes |
+| tgz Archive | Yes | SHA-512 | Filename | HTTP distribution |
+| npm Package | Yes | SHA-512 | Semver | Private npm registry |
+| Local Directory | No | None | None | Development only |
+
+## OCI Image (Recommended)
+
+### Why OCI?
+
+- Standard container format
+- Works with existing container tooling
+- Digest-based integrity verification
+- Easy version management with tags
+- Native to OpenShift/Kubernetes
+
+### Creating the Image
+
+From plugin source directory (not `dist-dynamic/`):
+
+```bash
+npx @red-hat-developer-hub/cli@latest plugin package \
+  --tag quay.io/<namespace>/<plugin-name>:v0.1.0
+```
+
+### Container Tool Selection
+
+```bash
+# Use Docker instead of Podman (default)
+npx @red-hat-developer-hub/cli@latest plugin package \
+  --container-tool docker \
+  --tag quay.io/<namespace>/<plugin-name>:v0.1.0
+
+# Use Buildah
+npx @red-hat-developer-hub/cli@latest plugin package \
+  --container-tool buildah \
+  --tag quay.io/<namespace>/<plugin-name>:v0.1.0
+```
+
+### Pushing to Registry
+
+```bash
+# Podman
+podman push quay.io/<namespace>/<plugin-name>:v0.1.0
+
+# Docker
+docker push quay.io/<namespace>/<plugin-name>:v0.1.0
+```
+
+### Configuration Reference
+
+Using tag:
+
+```yaml
+plugins:
+  - package: oci://quay.io/<namespace>/<plugin-name>:v0.1.0!<plugin-id>-dynamic
+    disabled: false
+```
+
+Using digest (recommended for production):
+
+```yaml
+plugins:
+  - package: oci://quay.io/<namespace>/<plugin-name>@sha256:abc123...!<plugin-id>-dynamic
+    disabled: false
+```
+
+### Version Inheritance
+
+For configurations that include defaults:
+
+```yaml
+includes:
+  - dynamic-plugins.default.yaml
+plugins:
+  - package: oci://quay.io/<namespace>/<plugin-name>:{{inherit}}!<plugin-id>-dynamic
+    disabled: false
+```
+
+### Multi-Plugin Images
+
+Bundle multiple plugins in one image:
+
+```bash
+# Export all plugins first
+cd plugins/frontend && npx @red-hat-developer-hub/cli@latest plugin export
+cd ../backend && npx @red-hat-developer-hub/cli@latest plugin export
+
+# Package from monorepo root
+cd ../..
+npx @red-hat-developer-hub/cli@latest plugin package \
+  --tag quay.io/<namespace>/plugin-bundle:v0.1.0
+```
+
+Reference individual plugins:
+
+```yaml
+plugins:
+  - package: oci://quay.io/<namespace>/plugin-bundle:v0.1.0!frontend-plugin
+    disabled: false
+  - package: oci://quay.io/<namespace>/plugin-bundle:v0.1.0!backend-plugin-dynamic
+    disabled: false
+```
+
+### Private Registries
+
+Set authentication file:
+
+```bash
+export REGISTRY_AUTH_FILE=~/.config/containers/auth.json
+# or
+export REGISTRY_AUTH_FILE=~/.docker/config.json
+```
+
+Login before pushing:
+
+```bash
+podman login quay.io
+# or
+docker login quay.io
+```
+
+## tgz Archive
+
+### Creating the Archive
+
+```bash
+cd dist-dynamic
+npm pack
+```
+
+Output: `<package-name>-<version>.tgz`
+
+### Integrity Hash
+
+```bash
+npm pack --json | jq -r '.[0].integrity'
+# Output: sha512-9WlbgEda...
+```
+
+### Hosting Options
+
+#### HTTP Server
+
+Any web server accessible by RHDH:
+
+```yaml
+plugins:
+  - package: https://plugins.example.com/my-plugin-1.0.0.tgz
+    integrity: sha512-9WlbgEda...
+    disabled: false
+```
+
+#### OpenShift httpd
+
+```bash
+# Pack plugins
+npm pack --pack-destination ~/plugins/
+
+# Create httpd service
+oc project rhdh
+oc new-build httpd --name=plugin-registry --binary
+oc start-build plugin-registry --from-dir=~/plugins/ --wait
+oc new-app --image-stream=plugin-registry
+```
+
+Configure RHDH:
+
+```yaml
+plugins:
+  - package: http://plugin-registry:8080/my-plugin-1.0.0.tgz
+    integrity: sha512-...
+    disabled: false
+```
+
+## npm Package
+
+### Publishing
+
+```bash
+cd dist-dynamic
+npm publish --registry https://your-private-registry.com
+```
+
+Or configure in package.json:
+
+```json
+{
+  "publishConfig": {
+    "registry": "https://your-private-registry.com"
+  }
+}
+```
+
+### Configuration
+
+```yaml
+plugins:
+  - package: '@my-org/my-plugin-dynamic@1.0.0'
+    integrity: sha512-...
+    disabled: false
+```
+
+### Custom Registry in OpenShift
+
+Create `.npmrc` secret:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dynamic-plugins-npmrc
+type: Opaque
+stringData:
+  .npmrc: |
+    registry=https://your-registry.com
+    //your-registry.com:_authToken=<auth-token>
+```
+
+For Helm chart, name it `{{ .Release.Name }}-dynamic-plugins-npmrc`.
+
+### Getting Integrity Hash
+
+```bash
+npm view --registry https://your-registry.com \
+  @my-org/my-plugin-dynamic@1.0.0 dist.integrity
+```
+
+## Local Directory (Development)
+
+### Setup
+
+```bash
+cp -r dist-dynamic /path/to/rhdh/dynamic-plugins-root/my-plugin-dynamic
+```
+
+### Configuration
+
+```yaml
+# app-config.yaml
+dynamicPlugins:
+  rootDirectory: dynamic-plugins-root
+```
+
+```yaml
+# dynamic-plugins.yaml
+plugins:
+  - package: ./dynamic-plugins-root/my-plugin-dynamic
+    disabled: false
+```
+
+### Pre-installed Plugins
+
+RHDH container includes pre-installed plugins:
+
+```yaml
+plugins:
+  - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-dynamic
+    disabled: false
+```
+
+## Integrity Hashes
+
+### Purpose
+
+Verify downloaded package hasn't been tampered with.
+
+### Required For
+
+- tgz archives: Always required
+- npm packages: Always required
+- OCI images: Use digest instead
+
+### Generating Hashes
+
+```bash
+# For tgz
+npm pack --json | jq -r '.[0].integrity'
+
+# For npm package
+npm view @package/name@version dist.integrity
+```
+
+### Format
+
+SHA-512 base64 encoded:
+
+```
+sha512-9WlbgEdadJNeQxdn1973r5E4kNFvnT9GjLD627GWgrhCaxjCmxqdNW08cj+Bf47mwAtZMt1Ttyo+ZhDRDj9PoA==
+```
+
+## Best Practices
+
+### 1. Use OCI for Production
+
+Provides:
+- Standard tooling
+- Digest-based integrity
+- Easy updates
+- OpenShift integration
+
+### 2. Semantic Versioning
+
+```
+quay.io/namespace/plugin:v1.0.0
+quay.io/namespace/plugin:v1.0.1
+quay.io/namespace/plugin:v1.1.0
+```
+
+### 3. Test Before Publishing
+
+```bash
+# Test locally first
+cp -r dist-dynamic /path/to/rhdh/dynamic-plugins-root/my-plugin
+
+# Verify it loads
+yarn workspace backend start
+
+# Then publish
+podman push quay.io/namespace/plugin:v1.0.0
+```
+
+### 4. Document Configuration
+
+Include example configuration:
+
+```yaml
+# Example dynamic-plugins.yaml entry
+plugins:
+  - package: oci://quay.io/namespace/my-plugin:v1.0.0!my-plugin-dynamic
+    disabled: false
+    pluginConfig:
+      myPlugin:
+        apiUrl: https://api.example.com
+```
+
+### 5. Use Digests in Production
+
+Tags can be overwritten; digests are immutable:
+
+```yaml
+# Prefer this for production
+- package: oci://quay.io/ns/plugin@sha256:abc123...!plugin-dynamic
+
+# Not this
+- package: oci://quay.io/ns/plugin:v1.0.0!plugin-dynamic
+```

--- a/skills/generate-frontend-wiring/SKILL.md
+++ b/skills/generate-frontend-wiring/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: Generate Frontend Wiring
+description: This skill should be used when the user asks to "generate frontend wiring", "show frontend wiring", "create RHDH binding", "generate dynamic plugin config", "show plugin wiring for RHDH", "create app-config for frontend plugin", or wants to generate the RHDH dynamic plugin wiring configuration for an existing Backstage frontend plugin. The skill analyzes the plugin's source code and generates the appropriate configuration.
+---
+
+## Purpose
+
+Analyze an existing Backstage frontend plugin and generate the RHDH dynamic plugin wiring configuration. This skill inspects the plugin's source files to determine exports and generates the corresponding `app-config.yaml` configuration.
+
+## When to Use
+
+Use this skill when:
+- User has an existing Backstage frontend plugin
+- User wants to deploy it to RHDH as a dynamic plugin
+- User needs the wiring configuration for `dynamic-plugins.yaml`
+
+## Prerequisites
+
+The plugin directory must contain:
+- `package.json` with plugin metadata
+- `src/plugin.ts` or `src/plugin.tsx` with plugin definition
+- `src/index.ts` exporting plugin components
+
+## Workflow
+
+### Step 1: Locate Plugin Files
+
+Find and read the essential plugin files:
+
+1. **`package.json`** - Get package name
+2. **`src/plugin.ts`** - Find exported extensions (pages, cards)
+3. **`src/index.ts`** - Find public exports (APIs, components)
+4. **`dist-dynamic/dist-scalprum/plugin-manifest.json`** - Get scalprum name if built
+
+### Step 2: Determine Scalprum Name
+
+The scalprum name is used to reference the plugin in RHDH configuration:
+
+1. **If `plugin-manifest.json` exists**: Use the `name` field
+2. **If `scalprum` in `package.json`**: Use `scalprum.name`
+3. **Otherwise derive from package name**:
+   - `@my-org/backstage-plugin-foo` becomes `my-org.backstage-plugin-foo`
+   - `@internal/backstage-plugin-foo` becomes `internal.backstage-plugin-foo`
+
+### Step 3: Identify Exports
+
+Analyze the plugin source to find:
+
+**Routable Extensions** (pages):
+- Look for `createRoutableExtension` in `plugin.ts`
+- These become `dynamicRoutes` entries
+- Extract the export name (e.g., `MyPluginPage`)
+
+**Entity Cards/Content**:
+- Look for `createComponentExtension` in `plugin.ts`
+- These become `mountPoints` entries
+- Identify if they use `useEntity` (entity-scoped)
+
+**API Factories**:
+- Look for `createApiFactory` and `createApiRef` in `plugin.ts` or `api.ts`
+- These become `apiFactories` entries
+- Extract the `apiRef` export name
+
+**Icons**:
+- Look for icon exports (React components returning SVG/Icon)
+- These become `appIcons` entries
+
+### Step 4: Generate Configuration
+
+Output the complete wiring configuration in YAML format:
+
+```yaml
+# RHDH Dynamic Plugin Configuration
+# Add to your dynamic-plugins.yaml or app-config.yaml
+
+dynamicPlugins:
+  frontend:
+    <scalprum-name>:
+      dynamicRoutes:
+        - path: /<plugin-id>
+          importName: <PageComponentName>
+          menuItem:
+            icon: <icon-name>
+            text: <Plugin Display Name>
+
+      mountPoints:
+        - mountPoint: entity.page.overview/cards
+          importName: <CardComponentName>
+          config:
+            if:
+              allOf:
+                - isKind: component
+
+      apiFactories:
+        - importName: <apiRefName>
+
+      appIcons:
+        - name: <iconName>
+          importName: <IconComponentName>
+```
+
+### Step 5: Present to User
+
+Show the generated configuration with:
+1. The YAML configuration block
+2. A table explaining each entry and its source
+3. Notes about any optional configurations
+4. Ask if it should be saved to a file
+
+## Example Output
+
+For a plugin with:
+- Package: `@internal/backstage-plugin-demoplugin`
+- Page: `DemopluginPage`
+- API: `todoApiRef`
+
+Generate:
+
+```yaml
+dynamicPlugins:
+  frontend:
+    internal.backstage-plugin-demoplugin:
+      dynamicRoutes:
+        - path: /demoplugin
+          importName: DemopluginPage
+          menuItem:
+            icon: extension
+            text: Demo Plugin
+      apiFactories:
+        - importName: todoApiRef
+```
+
+## Configuration Options Reference
+
+### Dynamic Routes
+
+```yaml
+dynamicRoutes:
+  - path: /my-plugin           # URL path
+    importName: MyPage         # Exported component name
+    module: PluginRoot         # Optional: scalprum module (default: PluginRoot)
+    menuItem:
+      icon: dashboard          # System icon or custom appIcon
+      text: My Plugin          # Sidebar menu text
+```
+
+### Mount Points
+
+```yaml
+mountPoints:
+  - mountPoint: entity.page.overview/cards
+    importName: MyCard
+    config:
+      layout:
+        gridColumn: '1 / -1'   # Full width
+      if:
+        allOf:
+          - isKind: component
+          - hasAnnotation: my-plugin/enabled
+```
+
+### API Factories
+
+```yaml
+apiFactories:
+  - importName: myApiFactory   # Or myApiRef if plugin exports it
+```
+
+### App Icons
+
+```yaml
+appIcons:
+  - name: myIcon
+    importName: MyIconComponent
+```
+
+## Common Patterns
+
+### Page Plugin
+
+Plugin that adds a standalone page:
+
+```yaml
+dynamicRoutes:
+  - path: /my-plugin
+    importName: MyPluginPage
+    menuItem:
+      icon: extension
+      text: My Plugin
+```
+
+### Entity Card Plugin
+
+Plugin that adds a card to entity pages:
+
+```yaml
+mountPoints:
+  - mountPoint: entity.page.overview/cards
+    importName: MyEntityCard
+    config:
+      if:
+        allOf:
+          - isKind: component
+```
+
+### Page + Card Plugin
+
+Plugin with both page and entity integration:
+
+```yaml
+dynamicRoutes:
+  - path: /my-plugin
+    importName: MyPluginPage
+    menuItem:
+      icon: myIcon
+      text: My Plugin
+
+mountPoints:
+  - mountPoint: entity.page.overview/cards
+    importName: MyEntityCard
+
+appIcons:
+  - name: myIcon
+    importName: MyIcon
+```
+
+## Notes
+
+- The generated configuration is a starting point; adjust as needed
+- Use `references/frontend-wiring.md` for complete configuration options
+- Entity cards may need condition tuning based on target entity kinds
+- Custom icons must be exported from the plugin's index.ts
+
+### Reference Files
+
+- **`references/frontend-wiring.md`** - Complete mount points, routes, bindings
+- **`references/entity-page.md`** - Entity page customization

--- a/skills/generate-frontend-wiring/references/entity-page.md
+++ b/skills/generate-frontend-wiring/references/entity-page.md
@@ -1,0 +1,428 @@
+# Entity Page Customization Reference
+
+Customize the Backstage catalog entity pages with dynamic plugins.
+
+## Entity Page Structure
+
+Entity pages in RHDH consist of:
+- **Tabs**: Major sections (Overview, CI, Docs, etc.)
+- **Cards**: Content within tabs
+- **Context Menu**: Actions in the top-right menu
+- **Context Providers**: React contexts for data sharing
+
+## Default Entity Tabs
+
+| Route | Title | Mount Point | Entity Kind |
+|-------|-------|-------------|-------------|
+| `/` | Overview | `entity.page.overview` | Any |
+| `/topology` | Topology | `entity.page.topology` | Any |
+| `/issues` | Issues | `entity.page.issues` | Any |
+| `/pr` | Pull/Merge Requests | `entity.page.pull-requests` | Any |
+| `/ci` | CI | `entity.page.ci` | Any |
+| `/cd` | CD | `entity.page.cd` | Any |
+| `/kubernetes` | Kubernetes | `entity.page.kubernetes` | Any |
+| `/image-registry` | Image Registry | `entity.page.image-registry` | Any |
+| `/monitoring` | Monitoring | `entity.page.monitoring` | Any |
+| `/lighthouse` | Lighthouse | `entity.page.lighthouse` | Any |
+| `/api` | Api | `entity.page.api` | Service, Component |
+| `/dependencies` | Dependencies | `entity.page.dependencies` | Component |
+| `/docs` | Docs | `entity.page.docs` | TechDocs available |
+| `/definition` | Definition | `entity.page.definition` | API |
+| `/system` | Diagram | `entity.page.diagram` | System |
+
+## Adding Custom Tabs
+
+### New Tab with Mount Point
+
+```yaml
+entityTabs:
+  - path: /my-custom-tab
+    title: My Custom Tab
+    mountPoint: entity.page.my-custom-tab
+
+mountPoints:
+  - mountPoint: entity.page.my-custom-tab/cards
+    importName: MyTabContent
+```
+
+### Tab Visibility
+
+Tabs become visible when:
+1. At least one plugin contributes to their mount point, OR
+2. They have static content (like Overview)
+
+### Tab Priority
+
+Control tab ordering with priority (higher appears first):
+
+```yaml
+entityTabs:
+  - path: /my-tab
+    title: My Tab
+    mountPoint: entity.page.my-tab
+    priority: 100  # Appears before lower priority tabs
+```
+
+### Hide Default Tab
+
+Set negative priority to hide:
+
+```yaml
+entityTabs:
+  - path: /topology
+    title: Topology
+    mountPoint: entity.page.topology
+    priority: -1  # Hidden
+```
+
+### Rename Existing Tab
+
+```yaml
+entityTabs:
+  - path: /
+    title: General  # Renamed from "Overview"
+    mountPoint: entity.page.overview
+```
+
+## Adding Cards to Tabs
+
+### Overview Card
+
+```yaml
+mountPoints:
+  - mountPoint: entity.page.overview/cards
+    importName: MyOverviewCard
+```
+
+### Card with Layout
+
+```yaml
+mountPoints:
+  - mountPoint: entity.page.overview/cards
+    importName: MyCard
+    config:
+      layout:
+        gridColumn: '1 / -1'     # Full width
+        gridRowStart: 1          # First row
+        gridRowEnd: 3            # Span 2 rows
+```
+
+### Grid Layout Properties
+
+Entity pages use CSS Grid. Available properties:
+
+| Property | Description | Example |
+|----------|-------------|---------|
+| `gridColumn` | Column span | `'1 / -1'` (full), `'span 2'` |
+| `gridRow` | Row span | `'1 / 3'` (rows 1-2) |
+| `gridColumnStart` | Start column | `1` |
+| `gridColumnEnd` | End column | `-1` (last) |
+| `gridRowStart` | Start row | `1` |
+| `gridRowEnd` | End row | `3` |
+
+### Conditional Cards
+
+Show cards only for specific entities:
+
+```yaml
+mountPoints:
+  - mountPoint: entity.page.overview/cards
+    importName: MyCard
+    config:
+      if:
+        allOf:
+          - isKind: component
+          - isType: service
+```
+
+## Condition Types
+
+### isKind
+
+Filter by entity kind:
+
+```yaml
+if:
+  isKind: component
+
+# Multiple kinds
+if:
+  anyOf:
+    - isKind: component
+    - isKind: resource
+```
+
+Valid kinds: `component`, `api`, `group`, `user`, `resource`, `system`, `domain`, `location`, `template`
+
+### isType
+
+Filter by entity spec.type:
+
+```yaml
+if:
+  isType: service
+
+# Multiple types
+if:
+  anyOf:
+    - isType: service
+    - isType: website
+```
+
+### hasAnnotation
+
+Filter by annotation presence:
+
+```yaml
+if:
+  hasAnnotation: github.com/project-slug
+
+# Multiple annotations
+if:
+  allOf:
+    - hasAnnotation: backstage.io/techdocs-ref
+    - hasAnnotation: github.com/project-slug
+```
+
+### Custom Conditions
+
+Import condition function from plugin:
+
+```yaml
+mountPoints:
+  - mountPoint: entity.page.overview/cards
+    importName: MyCard
+    config:
+      if:
+        allOf:
+          - isMyPluginEnabled  # Function from plugin
+```
+
+Plugin must export the function:
+
+```typescript
+// src/conditions.ts
+import { Entity } from '@backstage/catalog-model';
+
+export const isMyPluginEnabled = (entity: Entity): boolean => {
+  return entity.metadata.annotations?.['my-plugin/enabled'] === 'true';
+};
+
+// src/index.ts
+export { isMyPluginEnabled } from './conditions';
+```
+
+## Condition Operators
+
+### allOf (AND)
+
+All conditions must be true:
+
+```yaml
+if:
+  allOf:
+    - isKind: component
+    - isType: service
+    - hasAnnotation: my-plugin/enabled
+```
+
+### anyOf (OR)
+
+At least one condition must be true:
+
+```yaml
+if:
+  anyOf:
+    - isKind: component
+    - isKind: api
+```
+
+### oneOf (XOR)
+
+Exactly one condition must be true:
+
+```yaml
+if:
+  oneOf:
+    - isType: service
+    - isType: website
+```
+
+### Nested Conditions
+
+```yaml
+if:
+  allOf:
+    - isKind: component
+    - anyOf:
+        - isType: service
+        - isType: website
+```
+
+## Context Providers
+
+Add React context providers to entity pages:
+
+```yaml
+mountPoints:
+  - mountPoint: entity.page.overview/context
+    importName: MyContextProvider
+```
+
+Context providers wrap the tab content, enabling data sharing.
+
+## Context Menu
+
+Add items to the entity context menu (top-right):
+
+```yaml
+mountPoints:
+  - mountPoint: entity.context.menu
+    importName: MyContextDialog
+    config:
+      props:
+        title: My Action
+        icon: settings
+```
+
+### Dialog Component Requirements
+
+```typescript
+export interface MyDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export const MyContextDialog = ({ open, onClose }: MyDialogProps) => (
+  <Dialog open={open} onClose={onClose}>
+    {/* Dialog content */}
+  </Dialog>
+);
+```
+
+## Card Component Patterns
+
+### Basic Info Card
+
+```typescript
+import { InfoCard } from '@backstage/core-components';
+import { useEntity } from '@backstage/plugin-catalog-react';
+
+export const MyEntityCard = () => {
+  const { entity } = useEntity();
+
+  return (
+    <InfoCard title="My Plugin">
+      <p>Entity: {entity.metadata.name}</p>
+    </InfoCard>
+  );
+};
+```
+
+### Card with Loading State
+
+```typescript
+import { InfoCard, Progress } from '@backstage/core-components';
+import { useAsync } from 'react-use';
+
+export const MyAsyncCard = () => {
+  const { entity } = useEntity();
+  const { loading, error, value } = useAsync(() => fetchData(entity));
+
+  if (loading) return <Progress />;
+  if (error) return <Alert severity="error">{error.message}</Alert>;
+
+  return (
+    <InfoCard title="Data">
+      <pre>{JSON.stringify(value, null, 2)}</pre>
+    </InfoCard>
+  );
+};
+```
+
+### Card with Actions
+
+```typescript
+import { InfoCard } from '@backstage/core-components';
+import { IconButton } from '@material-ui/core';
+import RefreshIcon from '@material-ui/icons/Refresh';
+
+export const MyCardWithActions = () => {
+  const handleRefresh = () => { /* ... */ };
+
+  return (
+    <InfoCard
+      title="My Card"
+      action={
+        <IconButton onClick={handleRefresh}>
+          <RefreshIcon />
+        </IconButton>
+      }
+    >
+      {/* Content */}
+    </InfoCard>
+  );
+};
+```
+
+## Full Tab Content
+
+For custom tabs, create a full-page component:
+
+```typescript
+import { Content, ContentHeader, SupportButton } from '@backstage/core-components';
+import { useEntity } from '@backstage/plugin-catalog-react';
+
+export const MyTabContent = () => {
+  const { entity } = useEntity();
+
+  return (
+    <Content>
+      <ContentHeader title="My Custom Tab">
+        <SupportButton>Help for my plugin</SupportButton>
+      </ContentHeader>
+      {/* Tab content */}
+    </Content>
+  );
+};
+```
+
+## Best Practices
+
+### 1. Use Entity Hooks
+
+```typescript
+import { useEntity } from '@backstage/plugin-catalog-react';
+
+const { entity, loading, error } = useEntity();
+```
+
+### 2. Handle Loading States
+
+Always handle loading and error states in cards.
+
+### 3. Responsive Layout
+
+Use grid properties that work on different screen sizes:
+
+```yaml
+config:
+  layout:
+    gridColumn: '1 / -1'  # Full width on all screens
+```
+
+### 4. Meaningful Conditions
+
+Only show cards when they provide value:
+
+```yaml
+if:
+  hasAnnotation: my-plugin/project-id
+```
+
+### 5. Consistent Styling
+
+Use Backstage core components for consistent look:
+- `InfoCard` for cards
+- `Content` and `ContentHeader` for tabs
+- `Progress` and `Alert` for states

--- a/skills/generate-frontend-wiring/references/frontend-wiring.md
+++ b/skills/generate-frontend-wiring/references/frontend-wiring.md
@@ -1,0 +1,431 @@
+# Frontend Plugin Wiring Reference
+
+Complete reference for wiring frontend dynamic plugins into RHDH.
+
+## Configuration Structure
+
+All frontend plugin configuration lives under `pluginConfig.dynamicPlugins.frontend`:
+
+```yaml
+plugins:
+  - package: oci://quay.io/example/my-plugin:v1.0.0!my-plugin
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          <scalprum-name>:  # Must match package.json scalprum.name
+            dynamicRoutes: []
+            mountPoints: []
+            menuItems: {}
+            appIcons: []
+            routeBindings: {}
+            apiFactories: []
+            entityTabs: []
+            scaffolderFieldExtensions: []
+            techdocsAddons: []
+            themes: []
+            signInPage: {}
+            providerSettings: []
+```
+
+## Dynamic Routes
+
+Add full-page routes to the application.
+
+### Basic Route
+
+```yaml
+dynamicRoutes:
+  - path: /my-plugin
+    importName: MyPage
+```
+
+### Route with Sidebar Menu
+
+```yaml
+dynamicRoutes:
+  - path: /my-plugin
+    importName: MyPage
+    menuItem:
+      icon: dashboard
+      text: My Plugin
+```
+
+### Route with Custom Sidebar Component
+
+```yaml
+dynamicRoutes:
+  - path: /my-plugin
+    importName: MyPage
+    menuItem:
+      importName: MySidebarItem
+      config:
+        props:
+          text: My Plugin
+```
+
+### Route Options
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `path` | string | URL path (unique, can override `/` for home) |
+| `module` | string | Scalprum module name (default: `PluginRoot`) |
+| `importName` | string | Exported component name (default: `default`) |
+| `menuItem.icon` | string | System icon name |
+| `menuItem.text` | string | Menu label |
+| `menuItem.enabled` | boolean | Show/hide menu item |
+| `menuItem.importName` | string | Custom SidebarItem component |
+| `config.props` | object | Props passed to component |
+
+### Override Home Page
+
+```yaml
+dynamicRoutes:
+  - path: /
+    importName: CustomHomePage
+```
+
+## Mount Points
+
+Extend existing pages with additional components.
+
+### Available Mount Points
+
+| Mount Point | Description | Visibility |
+|-------------|-------------|------------|
+| `entity.page.overview` | Entity overview tab | Always |
+| `entity.page.topology` | Topology tab | When plugins enabled |
+| `entity.page.issues` | Issues tab | When plugins enabled |
+| `entity.page.pull-requests` | PR tab | When plugins enabled |
+| `entity.page.ci` | CI tab | When plugins enabled |
+| `entity.page.cd` | CD tab | When plugins enabled |
+| `entity.page.kubernetes` | K8s tab | When plugins enabled |
+| `entity.page.monitoring` | Monitoring tab | When plugins enabled |
+| `entity.page.api` | API tab | Service/Component |
+| `entity.page.dependencies` | Dependencies tab | Component |
+| `entity.page.docs` | Docs tab | TechDocs available |
+| `entity.page.definition` | Definition tab | API kind |
+| `entity.page.diagram` | Diagram tab | System kind |
+| `entity.context.menu` | Context menu | Always |
+| `search.page.types` | Search types | Always |
+| `search.page.filters` | Search filters | Always |
+| `search.page.results` | Search results | Always |
+| `admin.page.plugins` | Admin plugins | When enabled |
+| `admin.page.rbac` | Admin RBAC | When enabled |
+
+### Mount Point Variants
+
+Each `entity.page.*` has two variants:
+- `entity.page.overview/cards` - Regular components
+- `entity.page.overview/context` - React context providers
+
+### Basic Mount Point
+
+```yaml
+mountPoints:
+  - mountPoint: entity.page.overview/cards
+    importName: MyCard
+```
+
+### With Layout
+
+```yaml
+mountPoints:
+  - mountPoint: entity.page.overview/cards
+    importName: MyCard
+    config:
+      layout:
+        gridColumn: '1 / -1'      # Full width
+        gridRowStart: 1           # First row
+```
+
+### With Conditions
+
+```yaml
+mountPoints:
+  - mountPoint: entity.page.overview/cards
+    importName: MyCard
+    config:
+      if:
+        allOf:
+          - isKind: component
+          - isType: service
+          - hasAnnotation: my-plugin/enabled
+```
+
+### Condition Types
+
+| Condition | Description | Example |
+|-----------|-------------|---------|
+| `isKind` | Entity kind | `isKind: component` |
+| `isType` | Entity spec.type | `isType: service` |
+| `hasAnnotation` | Has annotation key | `hasAnnotation: github.com/project` |
+| Custom function | Imported from plugin | `isMyPluginAvailable` |
+
+### Condition Operators
+
+```yaml
+# All conditions must match
+if:
+  allOf:
+    - isKind: component
+    - isType: service
+
+# At least one must match
+if:
+  anyOf:
+    - isKind: component
+    - isKind: resource
+
+# Exactly one must match
+if:
+  oneOf:
+    - isType: service
+    - isType: website
+```
+
+### Context Menu
+
+```yaml
+mountPoints:
+  - mountPoint: entity.context.menu
+    importName: MyContextMenuDialog
+    config:
+      props:
+        title: Open My Dialog
+        icon: myIcon
+```
+
+Component must accept `open` and `onClose` props:
+
+```typescript
+export type MyDialogProps = {
+  open: boolean;
+  onClose: () => void;
+};
+```
+
+## Menu Items
+
+Configure sidebar menu ordering and hierarchy.
+
+### Basic Configuration
+
+```yaml
+menuItems:
+  my-plugin:          # Matches path in dynamicRoutes
+    priority: 10      # Higher = appears first
+```
+
+### Parent-Child Hierarchy
+
+```yaml
+menuItems:
+  my-plugin:
+    priority: 10
+    parent: tools     # Nest under 'tools' parent
+
+  tools:              # Parent menu item
+    icon: build
+    title: Tools
+    priority: 50
+```
+
+### Menu Item Options
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `icon` | string | System icon name |
+| `title` | string | Display text |
+| `priority` | number | Sort order (higher first, default: 0) |
+| `parent` | string | Parent menu item name |
+| `enabled` | boolean | Show/hide (default: true) |
+
+### Path to Name Mapping
+
+| Path | Menu Item Name |
+|------|----------------|
+| `/my-plugin` | `my-plugin` |
+| `/metrics/users/info` | `metrics.users.info` |
+| `/docs` | `docs` |
+
+## App Icons
+
+Register custom icons for use in menus and routes.
+
+```yaml
+appIcons:
+  - name: myCustomIcon
+    importName: MyCustomIcon
+    module: PluginRoot
+```
+
+Then reference in routes:
+
+```yaml
+dynamicRoutes:
+  - path: /my-plugin
+    menuItem:
+      icon: myCustomIcon
+      text: My Plugin
+```
+
+### Built-in Icons
+
+RHDH includes Backstage system icons plus additional icons. See [CommonIcons.tsx](https://github.com/redhat-developer/rhdh/blob/main/packages/app/src/components/DynamicRoot/CommonIcons.tsx).
+
+## Route Bindings
+
+Bind external routes between plugins.
+
+### Define Targets
+
+```yaml
+routeBindings:
+  targets:
+    - name: myPlugin
+      importName: myPlugin
+      module: PluginRoot
+```
+
+### Create Bindings
+
+```yaml
+routeBindings:
+  targets:
+    - importName: myPlugin
+  bindings:
+    - bindTarget: catalogPlugin.externalRoutes
+      bindMap:
+        viewTechDoc: myPlugin.routes.docs
+```
+
+### Available Static Targets
+
+- `catalogPlugin.externalRoutes`
+- `catalogImportPlugin.externalRoutes`
+- `techdocsPlugin.externalRoutes`
+- `scaffolderPlugin.externalRoutes`
+
+## Entity Tabs
+
+Add or customize entity page tabs.
+
+### Add New Tab
+
+```yaml
+entityTabs:
+  - path: /my-tab
+    title: My Tab
+    mountPoint: entity.page.my-tab
+```
+
+### Customize Existing Tab
+
+```yaml
+entityTabs:
+  - path: /
+    title: General           # Rename Overview
+    mountPoint: entity.page.overview
+```
+
+### Tab Priority
+
+```yaml
+entityTabs:
+  - path: /my-tab
+    title: My Tab
+    mountPoint: entity.page.my-tab
+    priority: 100            # Higher = appears first
+```
+
+### Hide Default Tab
+
+```yaml
+entityTabs:
+  - path: /
+    title: Overview
+    mountPoint: entity.page.overview
+    priority: -1             # Negative hides tab
+```
+
+## API Factories
+
+Register Utility APIs.
+
+```yaml
+apiFactories:
+  - importName: myApiFactory
+    module: PluginRoot
+```
+
+If plugin exports its plugin object with API factories, they're registered automatically - no configuration needed.
+
+## Scaffolder Field Extensions
+
+Custom form fields for software templates.
+
+```yaml
+scaffolderFieldExtensions:
+  - importName: MyCustomField
+    module: PluginRoot
+```
+
+## TechDocs Addons
+
+Extend TechDocs functionality.
+
+```yaml
+techdocsAddons:
+  - importName: MyTechDocsAddon
+    config:
+      props:
+        setting: value
+```
+
+## Themes
+
+Provide or override application themes.
+
+```yaml
+themes:
+  - id: light              # 'light' or 'dark' override defaults
+    title: Light Theme
+    variant: light
+    icon: brightness5
+    importName: lightThemeProvider
+  - id: dark
+    title: Dark Theme
+    variant: dark
+    icon: brightness2
+    importName: darkThemeProvider
+```
+
+Theme provider signature:
+
+```typescript
+export const myThemeProvider = ({ children }: { children: ReactNode }) => (
+  <UnifiedThemeProvider theme={myTheme} children={children} />
+);
+```
+
+## Sign-In Page
+
+Custom authentication sign-in page.
+
+```yaml
+signInPage:
+  importName: CustomSignInPage
+  module: PluginRoot
+```
+
+## Provider Settings
+
+Authentication provider settings in user preferences.
+
+```yaml
+providerSettings:
+  - title: My Auth Provider
+    description: Sign in with My Provider
+    provider: core.auth.my-provider
+```

--- a/skills/rhdh/SKILL.md
+++ b/skills/rhdh/SKILL.md
@@ -80,10 +80,19 @@ What would you like to do?
 4. **Triage overlay PRs** — Prioritize open PRs by criticality
 5. **Analyze specific PR** — Check assignment, compatibility, merge readiness
 
+### Plugin Creation Tasks
+
+*For creating new RHDH dynamic plugins from scratch*
+
+6. **Create backend plugin** — Bootstrap a new backend dynamic plugin
+7. **Create frontend plugin** — Bootstrap a new frontend dynamic plugin
+8. **Export and package plugin** — Export plugin and package as OCI/tgz/npm
+9. **Configure frontend wiring** — Set up mount points, routes, entity tabs
+
 ### General Tasks
 
-6. **Check environment** — Run doctor, configure paths
-7. **View/search activity** — Review worklog, todos
+10. **Check environment** — Run doctor, configure paths
+11. **View/search activity** — Review worklog, todos
 
 **Wait for response before proceeding.**
 </intake>
@@ -105,12 +114,23 @@ What would you like to do?
 
 **To route:** Read `../overlay/SKILL.md` and follow its intake process.
 
+### Plugin Creation Routes
+
+| Response | Skill |
+|----------|-------|
+| 6, "backend plugin", "create backend", "new backend plugin" | Route to `@create-backend-plugin` skill |
+| 7, "frontend plugin", "create frontend", "new frontend plugin" | Route to `@create-frontend-plugin` skill |
+| 8, "export", "package", "OCI", "publish plugin" | Route to `@export-and-package` skill |
+| 9, "wiring", "mount points", "routes", "entity tabs" | Route to `@generate-frontend-wiring` skill |
+
+**To route:** Read the corresponding skill file in `../` and follow its workflow.
+
 ### General Routes
 
 | Response | Action |
 |----------|--------|
-| 6, "doctor", "setup", "config" | Use CLI commands below |
-| 7, "log", "todo", "activity" | Use tracking commands below |
+| 10, "doctor", "setup", "config" | Use CLI commands below |
+| 11, "log", "todo", "activity" | Use tracking commands below |
 
 </routing>
 
@@ -225,5 +245,15 @@ $RHDH todo show
 | Skill | Purpose | Path |
 |-------|---------|------|
 | overlay | Manage plugins in rhdh-plugin-export-overlays | `../overlay/SKILL.md` |
+| create-backend-plugin | Bootstrap new RHDH backend dynamic plugins | `../create-backend-plugin/SKILL.md` |
+| create-frontend-plugin | Bootstrap new RHDH frontend dynamic plugins | `../create-frontend-plugin/SKILL.md` |
+| export-and-package | Export and package plugins as OCI/tgz/npm | `../export-and-package/SKILL.md` |
+| generate-frontend-wiring | Configure frontend mount points, routes, tabs | `../generate-frontend-wiring/SKILL.md` |
+
+### Shared References
+
+| Reference | Purpose | Path |
+|-----------|---------|------|
+| versions | RHDH/Backstage version compatibility matrix | `references/versions.md` |
 
 </skills_index>

--- a/skills/rhdh/references/versions.md
+++ b/skills/rhdh/references/versions.md
@@ -1,0 +1,168 @@
+# RHDH Version Compatibility Matrix
+
+This reference provides the complete version compatibility information for RHDH dynamic plugins.
+
+## Version Summary
+
+| RHDH Version | Backstage Version | create-app Version | Status |
+|--------------|-------------------|-------------------|--------|
+| next         | 1.42.5           | 0.7.3             | Pre-release |
+| 1.8          | 1.42.5           | 0.7.3             | Current |
+| 1.7          | 1.39.1           | 0.6.2             | Supported |
+| 1.6          | 1.36.1           | 0.5.25            | Supported |
+| 1.5          | 1.35.1           | 0.5.24            | Legacy |
+
+## RHDH 1.8 / next (Pre-release)
+
+Based on [Backstage 1.42.5](https://backstage.io/docs/releases/v1.42.0)
+
+Bootstrap command:
+```bash
+npx @backstage/create-app@0.7.3
+```
+
+### Frontend Packages
+
+| Package | Version |
+|---------|---------|
+| `@backstage/catalog-model` | `1.7.5` |
+| `@backstage/config` | `1.3.3` |
+| `@backstage/core-app-api` | `1.18.0` |
+| `@backstage/core-components` | `0.17.5` |
+| `@backstage/core-plugin-api` | `1.10.9` |
+| `@backstage/integration-react` | `1.2.9` |
+
+### Backend Packages
+
+| Package | Version |
+|---------|---------|
+| `@backstage/backend-app-api` | `1.2.6` |
+| `@backstage/backend-defaults` | `0.12.0` |
+| `@backstage/backend-dynamic-feature-service` | `0.7.3` |
+| `@backstage/backend-plugin-api` | `1.4.2` |
+| `@backstage/catalog-model` | `1.7.5` |
+| `@backstage/cli-node` | `0.2.14` |
+| `@backstage/config` | `1.3.3` |
+| `@backstage/config-loader` | `1.10.2` |
+
+## RHDH 1.7
+
+Based on [Backstage 1.39.1](https://backstage.io/docs/releases/v1.39.0)
+
+Bootstrap command:
+```bash
+npx @backstage/create-app@0.6.2
+```
+
+### Frontend Packages
+
+| Package | Version |
+|---------|---------|
+| `@backstage/catalog-model` | `1.7.4` |
+| `@backstage/config` | `1.3.2` |
+| `@backstage/core-app-api` | `1.17.0` |
+| `@backstage/core-components` | `0.17.2` |
+| `@backstage/core-plugin-api` | `1.10.7` |
+| `@backstage/integration-react` | `1.2.7` |
+
+### Backend Packages
+
+| Package | Version |
+|---------|---------|
+| `@backstage/backend-app-api` | `1.2.3` |
+| `@backstage/backend-defaults` | `0.10.0` |
+| `@backstage/backend-dynamic-feature-service` | `0.7.0` |
+| `@backstage/backend-plugin-api` | `1.3.1` |
+| `@backstage/catalog-model` | `1.7.4` |
+| `@backstage/cli-node` | `0.2.13` |
+| `@backstage/config` | `1.3.2` |
+| `@backstage/config-loader` | `1.10.1` |
+
+## RHDH 1.6
+
+Based on [Backstage 1.36.1](https://backstage.io/docs/releases/v1.36.0)
+
+Bootstrap command:
+```bash
+npx @backstage/create-app@0.5.25
+```
+
+### Frontend Packages
+
+| Package | Version |
+|---------|---------|
+| `@backstage/catalog-model` | `1.7.3` |
+| `@backstage/config` | `1.3.2` |
+| `@backstage/core-app-api` | `1.15.5` |
+| `@backstage/core-components` | `0.16.4` |
+| `@backstage/core-plugin-api` | `1.10.4` |
+| `@backstage/integration-react` | `1.2.4` |
+
+### Backend Packages
+
+| Package | Version |
+|---------|---------|
+| `@backstage/backend-app-api` | `1.2.0` |
+| `@backstage/backend-defaults` | `0.8.1` |
+| `@backstage/backend-dynamic-feature-service` | `0.6.0` |
+| `@backstage/backend-plugin-api` | `1.2.0` |
+| `@backstage/catalog-model` | `1.7.3` |
+| `@backstage/cli-node` | `0.2.13` |
+| `@backstage/config` | `1.3.2` |
+| `@backstage/config-loader` | `1.9.6` |
+
+## RHDH 1.5
+
+Based on [Backstage 1.35.1](https://backstage.io/docs/releases/v1.35.0)
+
+Bootstrap command:
+```bash
+npx @backstage/create-app@0.5.24
+```
+
+### Frontend Packages
+
+| Package | Version |
+|---------|---------|
+| `@backstage/catalog-model` | `1.7.3` |
+| `@backstage/config` | `1.3.2` |
+| `@backstage/core-app-api` | `1.15.4` |
+| `@backstage/core-components` | `0.16.3` |
+| `@backstage/core-plugin-api` | `1.10.3` |
+| `@backstage/integration-react` | `1.2.3` |
+
+### Backend Packages
+
+| Package | Version |
+|---------|---------|
+| `@backstage/backend-app-api` | `1.1.1` |
+| `@backstage/backend-defaults` | `0.7.0` |
+| `@backstage/backend-dynamic-feature-service` | `0.5.3` |
+| `@backstage/backend-plugin-api` | `1.1.1` |
+| `@backstage/catalog-model` | `1.7.3` |
+| `@backstage/cli-node` | `0.2.12` |
+| `@backstage/config` | `1.3.2` |
+| `@backstage/config-loader` | `1.9.5` |
+
+## Checking Package Versions
+
+To check versions for packages not listed above:
+
+### Frontend packages
+Check the [`package.json`](https://github.com/redhat-developer/rhdh/blob/main/packages/app/package.json) in the `app` package.
+
+### Backend packages
+Check the [`package.json`](https://github.com/redhat-developer/rhdh/blob/main/packages/backend/package.json) in the `backend` package.
+
+For specific RHDH versions, switch to the appropriate branch (e.g., `release-1.7`).
+
+## CLI Version Compatibility
+
+The `@red-hat-developer-hub/cli` version should match the target RHDH version:
+
+```bash
+# Always use the latest compatible version
+npx @red-hat-developer-hub/cli@latest plugin export
+```
+
+Check the [Version Matrix](https://github.com/redhat-developer/rhdh/blob/main/docs/dynamic-plugins/versions.md) for specific CLI versions if needed.


### PR DESCRIPTION
Add skills for creating and deploying RHDH dynamic plugins:

- `create-backend-plugin`: Bootstrap backend plugins with new backend system
- `create-frontend-plugin`: Bootstrap frontend plugins with Scalprum config
- `export-and-package`: Export plugins and package as OCI/tgz/npm artifacts
- `generate-frontend-wiring`: Configure mount points, routes, and entity tabs

Move shared version compatibility matrix to rhdh skill for cross-skill access.