### PR TITLE
feat: add rhdh-repos reference and generalize CLI repo management

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Orchestrator skill for RHDH plugin development - onboard, update, and maintain plugins in the Extensions Catalog",
-    "version": "0.0.1"
+    "version": "0.1.0"
   },
   "plugins": [
     {
       "name": "rhdh",
       "source": "./",
       "description": "Skills and commands for RHDH plugin lifecycle management",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "strict": true
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rhdh",
   "description": "Orchestrator skill for RHDH plugin development - onboard, update, and maintain plugins in the Extensions Catalog",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "author": {
     "name": "RHDH Store Manager"
   },

--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,5 @@ Thumbs.db
 .python-version
 
 # Local config (project-specific settings)
+.rhdh/
 .rhdh-plugin/

--- a/skills/rhdh/SKILL.md
+++ b/skills/rhdh/SKILL.md
@@ -46,7 +46,7 @@ These contain critical gotchas (jq escaping, JQL limitations, assignee format) t
 <principle name="understand_rhdh_repos">
 **Before any RHDH-related work**, consult `references/rhdh-repos.md` for a reference of all RHDH-related repositories, what each one is used for, and how they relate to each other.
 Use this when navigating between projects or understanding the overall RHDH ecosystem.
-use `$RHDH config set`  to set path to the local checkout of the RHDH repositories.
+Use `$RHDH config set` to set the path to the local checkout of the RHDH repositories.
 </principle>
 
 </essential_principles>
@@ -298,6 +298,7 @@ Todos must be **self-contained**—a new session should understand the task with
 
 | Reference | Purpose | Path |
 |-----------|---------|------|
+| rhdh-repos | Repository map, ecosystem relationships, key paths | `references/rhdh-repos.md` |
 | versions | RHDH/Backstage version compatibility matrix | `references/versions.md` |
 | jira-structure | RHDH Jira projects, issue types, filing rules | `references/jira-structure.md` |
 

--- a/skills/rhdh/SKILL.md
+++ b/skills/rhdh/SKILL.md
@@ -175,10 +175,17 @@ $RHDH doctor
 **Configuration:**
 
 ```bash
-$RHDH config init              # Create config with auto-detection
-$RHDH config show              # Show resolved paths
-$RHDH config set overlay /path # Set repo location
-$RHDH config set local /path   # Set rhdh-local location
+$RHDH config init                  # Create config with auto-detection
+$RHDH config show                  # Show resolved paths
+$RHDH config set overlay /path     # Set rhdh-plugin-export-overlays location
+$RHDH config set local /path       # Set rhdh-local location
+$RHDH config set rhdh /path        # Set main rhdh repo location
+$RHDH config set downstream /path  # Set rhdh-downstream location
+$RHDH config set cli /path         # Set rhdh-cli location
+$RHDH config set plugins /path     # Set rhdh-plugins location
+$RHDH config set operator /path    # Set rhdh-operator location
+$RHDH config set chart /path       # Set rhdh-chart location
+$RHDH config set catalog /path     # Set rhdh-plugin-catalog location
 ```
 
 **Workspace operations:**

--- a/skills/rhdh/SKILL.md
+++ b/skills/rhdh/SKILL.md
@@ -43,6 +43,12 @@ See the `<tracking_system>` section for details.
 These contain critical gotchas (jq escaping, JQL limitations, assignee format) that prevent common errors.
 </principle>
 
+<principle name="understand_rhdh_repos">
+**Before any RHDH-related work**, consult `references/rhdh-repos.md` for a reference of all RHDH-related repositories, what each one is used for, and how they relate to each other.
+Use this when navigating between projects or understanding the overall RHDH ecosystem.
+use `$RHDH config set`  to set path to the local checkout of the RHDH repositories.
+</principle>
+
 </essential_principles>
 
 <context_scan>
@@ -263,6 +269,7 @@ Todos must be **self-contained**—a new session should understand the task with
 </tracking_system>
 
 <reference_index>
+**RHDH Repos:** references/rhdh-repos.md — repository map, ecosystem relationships, key paths
 **GitHub CLI (PRs, CI, workflows):** references/github-reference.md
 **JIRA CLI (issues, JQL, comments):** references/jira-reference.md
 **JIRA Structure (projects, issue types, filing rules):** references/jira-structure.md

--- a/skills/rhdh/references/rhdh-repos.md
+++ b/skills/rhdh/references/rhdh-repos.md
@@ -1,0 +1,184 @@
+## Purpose
+
+Reference of all RHDH-related repositories, what each one is used for, and how they relate to each other. Use this when navigating between projects or understanding the overall RHDH ecosystem.
+
+## Repository Map
+
+### rhdh
+
+- **Upstream:** https://github.com/redhat-developer/rhdh
+- **Description:** The main Red Hat Developer Hub application. Enterprise Internal Developer Portal built on Backstage. Formerly `janus-idp/backstage-showcase`.
+- **Tech stack:** Node.js 22, TypeScript, React, Yarn 4, Turbo monorepo
+- **Key concepts:**
+  - **Scalprum dynamic loading:** Frontend plugins are loaded at runtime via [Scalprum](https://github.com/scalprum/scaffolding) (federated module loader), not compiled into the app. `packages/app/` renders `<ScalprumRoot>` which fetches plugin manifests from `/api/scalprum/plugins` served by `@internal/plugin-scalprum-backend`.
+  - **`app-next`:** Parallel frontend using Backstage's standard Module Federation (`@backstage/frontend-dynamic-feature-loader`). Started with `APP_CONFIG_app_packageName=app-next ENABLE_STANDARD_MODULE_FEDERATION=true`.
+  - **Dynamic plugin wrappers:** `dynamic-plugins/wrappers/` contains ~48 thin wrapper packages. Frontend wrappers use `--in-place` (produce `dist-scalprum/`), backend wrappers use `--embed-package` (self-contained `dist-dynamic/`). This is a **separate Yarn workspace** with its own `yarn.lock`.
+  - **Layered config:** `app-config.yaml` (base dev) -> `app-config.dynamic-plugins.yaml` (frontend plugin UI integration: mount points, routes, menu items, icons, route bindings) -> `app-config.production.yaml` (production overlay). `dynamic-plugins.default.yaml` is **generated** (do not edit manually) from `default.packages.yaml`.
+  - **Service override mechanism:** Each default service factory in `packages/backend/src/defaultServiceFactories.ts` can be disabled via `ENABLE_{SERVICE_ID}_OVERRIDE=true` env var to let a dynamic plugin provide its own.
+  - **Branching:** `main` for active development; `release-1.x` for maintained releases; `dependencies/backstage-latest` for tracking upstream.
+- **Key paths:** `packages/app/` (frontend), `packages/backend/` (backend), `plugins/` (internal `@internal/*` plugins), `dynamic-plugins/wrappers/` (wrapper packages), `app-config.dynamic-plugins.yaml` (UI integration config), `default.packages.yaml` (master plugin manifest), `backstage.json` (upstream version tracking)
+
+### rhdh-downstream
+
+- **Upstream:** https://gitlab.cee.redhat.com/rhidp/rhdh
+- **Description:** Downstream (productized) build of RHDH. Internal GitLab repository that produces the official Red Hat-supported container images published to `registry.redhat.io`. Syncs from the upstream `redhat-developer/rhdh` GitHub repo and applies Red Hat-specific patches, branding, and build configuration for Konflux/Brew pipelines.
+- **Note:** Requires Red Hat VPN / internal network access.
+
+### rhdh-cli
+
+- **Upstream:** https://github.com/redhat-developer/rhdh-cli
+- **Description:** CLI tool for developing, packaging, and distributing dynamic plugins for RHDH. Successor to `@janus-idp/cli`. Published as `@red-hat-developer-hub/cli` on npm. Extends/wraps `@backstage/cli`.
+- **Tech stack:** Node.js 22, TypeScript, Webpack, esbuild, Commander.js, Yarn 3
+- **Key concepts:**
+  - **`plugin export`:** Detects plugin role from `package.json`, routes to backend or frontend export. Backend: creates `dist-dynamic/` via `productionPack()`, moves `@backstage/*` to `peerDependencies`, embeds `-common`/`-node` siblings, runs `yarn install --production`, validates entry points (`BackendFeature`/`BackendFeatureFactory` default export). Frontend: generates Scalprum assets in `dist-scalprum/` via `DynamicRemotePlugin` from `@openshift/dynamic-plugin-sdk-webpack`, plus optional Module Federation assets.
+  - **`plugin package`:** Packages exported plugins as OCI container images or directories. Discovers plugins in monorepos, runs export, stages into temp dir, builds `FROM scratch` container with `io.backstage.dynamic-packages` annotation, or copies to `--export-to` directory.
+  - **Embedded packages:** `--embed-package` bundles related packages into `dist-dynamic/embedded/`. Auto-detects `-common` and `-node` siblings. Versions suffixed with `+embedded`.
+  - **Shared packages:** All `@backstage/*` packages are shared by default (moved to `peerDependencies`). Customizable via `--shared-package` with support for `!` exclusion and `/regex/` patterns.
+  - **Versioning:** Major.minor synced with RHDH releases (CLI 1.8.x works with RHDH 1.8.z). Patch incremented independently.
+  - **Branching:** `main` for active development; `release-1.x` for maintenance.
+- **Key paths:** `src/commands/export-dynamic-plugin/` (export logic), `src/commands/package-dynamic-plugins/` (packaging), `src/lib/bundler/scalprumConfig.ts` (webpack config), `src/lib/schema/collect.ts` (config schema), `bin/rhdh-cli` (entry point)
+
+### rhdh-local
+
+- **Upstream:** https://github.com/redhat-developer/rhdh-local
+- **Description:** Docker Compose-based local development and testing environment for RHDH. The fastest way to run RHDH locally without a Kubernetes cluster. Not for production use.
+- **Tech stack:** Docker/Podman Compose, PostgreSQL (optional), Bash scripts
+- **Key concepts:**
+  - **Two-container architecture:** `install-dynamic-plugins` init container installs plugins into a shared `dynamic-plugins-root` volume, then `rhdh` main container starts the Backstage backend. Port `7007` for UI, port `9229` for Node.js debugger.
+  - **Override-based config:** Users never edit defaults; they create git-ignored override files. `default.env` -> `.env`, `app-config.yaml` -> `app-config.local.yaml`, `dynamic-plugins.yaml` -> `dynamic-plugins.override.yaml`, `users.yaml` -> `users.override.yaml`.
+  - **Four plugin sources:** (1) Local directory via `local-plugins/`, (2) OCI image via `oci://`, (3) tarball URL, (4) pre-bundled in RHDH image (`./dynamic-plugins/dist/`).
+  - **Frontend hot-reload:** Use `compose-dynamic-plugins-root.yaml` override to bind-mount `./dynamic-plugins-root` as host directory, then run `npx @red-hat-developer-hub/cli plugin export --dev --dynamic-plugins-root <path>`. Re-export and refresh browser — no container restart needed.
+  - **In-memory SQLite by default.** PostgreSQL can be opted into by uncommenting sections in `compose.yaml`.
+  - **Branching:** `main` for active development; `release-1.x` for maintained releases.
+- **Key paths:** `compose.yaml` (main compose), `configs/app-config/` (app configuration), `configs/dynamic-plugins/` (plugin configuration), `local-plugins/` (local plugin binaries), `docs/` (built-in TechDocs)
+
+### rhdh-operator
+
+- **Upstream:** https://github.com/redhat-developer/rhdh-operator
+- **Description:** Kubernetes Operator for automated installation, configuration, and lifecycle management of RHDH instances on Kubernetes and OpenShift. CRD group is `rhdh.redhat.com`, primary CR kind is `Backstage` (API version `v1alpha5`).
+- **Tech stack:** Go, Kubernetes client libraries, Ginkgo/Gomega testing, OpenShift API integration, kustomize
+- **Key concepts:**
+  - **Backstage CR spec:** `application` (appConfig configMaps, dynamicPluginsConfigMapName, extraFiles, extraEnvs, route), `database` (enableLocalDb, authSecretName), `deployment` (patch via kustomize merge2, kind: Deployment or StatefulSet), `monitoring` (ServiceMonitor toggle).
+  - **Reconciliation flow:** Get CR -> preprocess spec (read ConfigMaps/Secrets, compute SHA-256 hash) -> init object model (Phase 1: load default config, Phase 2: overlay rawRuntimeConfig, Phase 3: apply CR spec) -> apply plugin dependencies -> server-side apply all objects -> clean up disabled features -> update status conditions.
+  - **Auto-refresh:** External ConfigMaps/Secrets are labeled `rhdh.redhat.com/ext-config-sync=true` and watched. Config hash stored as `rhdh.redhat.com/ext-config-hash` pod annotation; hash change triggers rolling restart.
+  - **PostgreSQL provisioning:** When `enableLocalDb: true` (default), creates a Secret (random password), StatefulSet (PostgreSQL 15, 1Gi PVC), and Service. Secret is immutable after creation.
+  - **Platform detection:** Auto-detects OpenShift/EKS/AKS/GKE/vanilla K8s at startup. OpenShift gets Route + ClusterIP; K8s gets NodePort + fsGroup. Platform overrides use `.k8s` file suffix.
+  - **Profiles:** `rhdh` (primary, default), `backstage.io` (community), `external` (no default config). Most `make` commands accept `PROFILE=`.
+  - **Branching:** `main` for active development; `release-1.x` for maintained releases.
+- **Key paths:** `api/v1alpha5/backstage_types.go` (CRD types), `internal/controller/` (reconciler), `pkg/model/` (runtime object model), `config/profile/rhdh/default-config/` (default manifests), `examples/rhdh-cr.yaml` (comprehensive example CR)
+
+### rhdh-chart
+
+- **Upstream:** https://github.com/redhat-developer/rhdh-chart
+- **Description:** Helm chart for deploying RHDH on Kubernetes and OpenShift. Alternative deployment method to the operator. The chart is a **wrapper** around the upstream Backstage Helm chart (pulled as subchart with alias `upstream`).
+- **Tech stack:** Helm 3, Kubernetes/OpenShift YAML manifests, chart-testing, KinD
+- **Key concepts:**
+  - **Subchart architecture:** Upstream Backstage chart aliased as `upstream` in `Chart.yaml`. All upstream values accessible under `upstream:` key. Bitnami `common` chart also included.
+  - **Dynamic plugins via Helm:** `global.dynamic.includes` (default: `dynamic-plugins.default.yaml`) + `global.dynamic.plugins` (user additions). Init container `install-dynamic-plugins` installs into 5Gi ephemeral PVC. Supports OCI plugins, npm tarballs, and pre-bundled plugins.
+  - **Route vs Ingress:** OpenShift Route enabled by default (`route.enabled: true`) with edge TLS. For vanilla K8s, set `route.enabled: false` + `upstream.ingress.enabled: true`.
+  - **Backend auth:** `global.auth.backend.enabled: true` (default) auto-generates a secret for service-to-service auth.
+  - **Branching:** `main` for active development; `release-1.x` for maintained releases; `gh-pages` for published chart index.
+- **Key paths:** `charts/backstage/` (primary chart), `charts/backstage/values.yaml` (main values), `charts/backstage/templates/` (custom templates)
+
+### rhdh-plugin-export-overlays
+
+- **Upstream:** https://github.com/redhat-developer/rhdh-plugin-export-overlays
+- **Description:** Metadata and automation hub for packaging community Backstage plugins as dynamic plugins for RHDH. Contains workspace definitions that point to upstream plugin repos and uses overlays/patches to customize them for dynamic loading. Automated workflows publish OCI container images to `ghcr.io`.
+- **Tech stack:** GitHub Actions, YAML/JSON configuration, OCI container images, Bash scripting
+- **Key concepts:**
+  - **Workspaces:** Each `workspaces/<name>/` directory defines a group of related plugins with `source.json` (upstream repo/commit) and `plugins-list.yaml` (plugins to export)
+  - **Overlays:** Replace/add entire files in plugin source before building (`plugins/<name>/overlay/`)
+  - **Patches:** Apply line-by-line diffs at workspace level (`patches/*.patch`)
+  - **OCI tags:** `bs_<backstage_version>__<plugin_version>` (e.g., `bs_1.45.3__2.4.3`)
+  - **Branching:** `main` for next RHDH release; `release-x.y` branches for specific releases
+- **Companion repo:** Works closely with `rhdh-plugin-export-utils`
+
+### rhdh-plugin-export-utils
+
+- **Upstream:** https://github.com/redhat-developer/rhdh-plugin-export-utils
+- **Description:** Collection of reusable GitHub Actions and callable workflows for exporting, packaging, and validating Backstage plugins as dynamic plugins for RHDH. Primary consumer is `rhdh-plugin-export-overlays`.
+- **Tech stack:** GitHub Actions (composite actions), Bash scripting, TypeScript (validate-metadata)
+- **Key concepts:**
+  - **`override-sources` action:** Applies workspace-level patches then per-plugin source overlays.
+  - **`export-dynamic` action:** Iterates `plugins-list.yaml`, runs CLI export per plugin, optionally packages as OCI image. Supports skip-if-unchanged via `last-publish-commit`.
+  - **`validate-metadata` action:** Validates `metadata/*.yaml` files against `plugins-list.yaml` and `package.json`.
+  - **`update-overlay` action:** Proposes overlay workspace PRs via GitHub API for auto-discovered plugin versions.
+  - **Callable workflows:** `export-dynamic.yaml` (single-workspace pipeline), `export-workspaces-as-dynamic.yaml` (multi-workspace orchestrator), `update-plugins-repo-refs.yaml` (npm discovery), `check-backstage-compatibility.yaml` (compatibility report).
+  - **Branching:** Single `main` branch only. All consumers reference actions at `@main`.
+
+### rhdh-plugin-catalog
+
+- **Upstream:** https://gitlab.cee.redhat.com/rhidp/rhdh-plugin-catalog
+- **Description:** Midstream infrastructure repository that manages building, packaging, and publishing Backstage plugins as OCI artifacts for RHDH. Syncs plugin source from `rhdh-plugin-export-overlays`, builds plugins via Konflux CI/CD, and maintains a catalog index of all available plugins. Publishes to `quay.io/rhdh/` and `registry.redhat.io/rhdh/`.
+- **Tech stack:** Node.js, TypeScript, Yarn 3, Backstage CLI, Python (build scripts), Tekton/Konflux pipelines, Docker/Podman
+- **Key concepts:**
+  - **Workspaces:** 24 plugin workspace directories under `workspaces/`. Each is an independent monorepo with `packages/`, `plugins/`, `package.json`, `yarn.lock`, `manifest.json`, and `backstage.json`.
+  - **Catalog index:** `catalog-index/index.json` is the master catalog of all plugins. Generated by `build/scripts/generateCatalogIndex.py`.
+  - **Konflux pipelines:** 114 Tekton PipelineRun definitions in `.tekton/`. Each plugin has a dedicated pipeline triggered by changes to its workspace directory.
+  - **Upstream sync:** `build/ci/sync-midstream.sh` syncs overlays from `rhdh-plugin-export-overlays` into `overlay-repo/`, updates `plugin_builds/` metadata, and regenerates the catalog index.
+  - **Branching:** `main` for active development; `rhdh-*-rhel-9` for release-specific midstream branches.
+- **Key paths:** `workspaces/` (plugin source), `plugin_builds/` (build metadata), `catalog-index/` (catalog index and default configs), `.tekton/` (Konflux pipelines), `build/scripts/` (build automation scripts)
+
+### rhdh-plugins
+
+- **Upstream:** https://github.com/redhat-developer/rhdh-plugins
+- **Description:** Central repository for Backstage plugins developed by Red Hat for use with RHDH. Multi-workspace monorepo modeled after `backstage/community-plugins`. Each workspace is an independent mini-monorepo with its own `yarn.lock`, release cycle, and changeset history. Publishes to `@red-hat-developer-hub` npm namespace.
+- **Tech stack:** Node.js 22, TypeScript, Yarn 4 (Berry, `node-modules` linker), Backstage plugin SDK, Jest, Playwright
+- **Key concepts:**
+  - **Workspace independence:** Each `workspaces/<name>/` has its own `package.json` (named `@internal/<name>`, `private: true`), `yarn.lock`, `.changeset/`, and `backstage.json`. Run `yarn install` from within the workspace, not the root.
+  - **Workspace structure:** `workspaces/<name>/packages/app/` (dev frontend), `packages/backend/` (dev backend), `plugins/<plugin-name>/` (publishable plugins). Plugin packages follow `-backend`, `-common`, `-node` suffix conventions.
+  - **Changesets:** `yarn changeset` from workspace root. On merge to `main`, automation creates a "Version Packages" PR on `changesets-release/<workspace>/main` branch.
+  - **Notable workspaces:** `bulk-import`, `lightspeed` (AI assistant), `orchestrator` (SonataFlow), `homepage`, `theme`, `extensions`, `global-header`, `adoption-insights`, `scorecard`, `ai-integrations`, `translations`, `konflux`, `mcp-integrations`.
+  - **Creating new workspace:** `yarn create-workspace` from repo root. Creating a plugin within a workspace: `cd workspaces/<name> && yarn new`.
+  - **Branching:** `main` for active development; `1.2` for release maintenance; `changesets-release/<workspace>/main` for automated version PRs.
+- **Key paths:** `workspaces/` (all plugin workspaces), `scripts/ci/` (CI helper scripts), `.github/CODEOWNERS` (per-workspace ownership)
+
+### backstage
+
+- **Upstream:** https://github.com/backstage/backstage
+- **Description:** The upstream Backstage framework — the CNCF open-source foundation that RHDH is built upon. Originally created by Spotify. Provides the core Software Catalog, Software Templates, TechDocs, Search, and the plugin system.
+- **Tech stack:** Node.js, TypeScript, React, Yarn Berry, PostgreSQL
+- **Key concepts:**
+  - **New backend system (current standard):** `createBackendPlugin()`, `createBackendModule()`, `createServiceRef()`, `createExtensionPoint()` from `@backstage/backend-plugin-api`. Services are dependency-injected via `coreServices`.
+  - **Plugin package sets:** A feature like "catalog" spans multiple packages: `-backend` (backend plugin), `-node` (extension points/shared backend types), `-react` (shared React hooks/components), `-common` (isomorphic shared code), `-backend-module-*` (backend modules).
+  - **Software Catalog:** Central entity registry. Entity lifecycle: Ingestion (entity providers) -> Processing (processors validate/enrich/emit relations) -> Stitching (assemble final entity). Entity kinds: Component, API, Resource, System, Domain, User, Group, Location, Template.
+  - **Release cadence:** Monthly minor releases (`v1.X.0`), patch releases as needed. Individual packages have their own semver; `@backstage/release-manifests` maps package versions to Backstage releases.
+  - **Branching:** `master` (not `main`) is the default branch. No long-lived release branches — releases are tags from `master`.
+- **Key paths:** `packages/` (core framework packages), `plugins/` (~155 plugin packages), `docs/` (documentation)
+
+## Ecosystem Relationships
+
+```
+backstage (upstream framework)
+    |
+    v
+rhdh (enterprise distribution, github.com)
+    |
+    +---> rhdh-downstream (productized build, gitlab.cee.redhat.com)
+    |         builds from rhdh, produces registry.redhat.io images
+    |
+    +-- rhdh-cli (plugin development tooling)
+    +-- rhdh-plugins (Red Hat plugin collection)
+    |
+    +-- rhdh-plugin-export-overlays (community plugin packaging & OCI publishing)
+    |       |
+    |       +-- uses rhdh-plugin-export-utils (reusable GitHub Actions)
+    |
+    +-- rhdh-plugin-catalog (midstream plugin builds, OCI artifacts & catalog index)
+    |       syncs from rhdh-plugin-export-overlays
+    |
+    +-- Deployment:
+    |   +-- rhdh-operator (Kubernetes/OpenShift operator)
+    |   +-- rhdh-chart (Helm chart)
+    |
+    +-- rhdh-local (local dev/test environment)
+```
+
+## Common Workflows
+
+- **Plugin development:** Work in `rhdh-plugins`, use `rhdh-cli` to export/package, test with `rhdh-local`
+- **Core RHDH changes:** Work in `rhdh`, reference `backstage` for upstream behavior
+- **Deployment/operator changes:** Work in `rhdh-operator` or `rhdh-chart`
+- **Plugin packaging:** Work in `rhdh-plugin-export-overlays` to add/update plugins as dynamic plugins; uses actions from `rhdh-plugin-export-utils`
+- **Midstream plugin builds:** Work in `rhdh-plugin-catalog` for Konflux pipeline management, catalog index updates, and OCI artifact publishing to Red Hat registries
+- **CI/CD actions for plugins:** Work in `rhdh-plugin-export-utils` to modify the reusable GitHub Actions

--- a/skills/rhdh/references/rhdh-repos.md
+++ b/skills/rhdh/references/rhdh-repos.md
@@ -133,6 +133,16 @@ Reference of all RHDH-related repositories, what each one is used for, and how t
   - **Branching:** `main` for active development; `1.2` for release maintenance; `changesets-release/<workspace>/main` for automated version PRs.
 - **Key paths:** `workspaces/` (all plugin workspaces), `scripts/ci/` (CI helper scripts), `.github/CODEOWNERS` (per-workspace ownership)
 
+### rhdh-dynamic-plugin-factory
+
+- **Upstream:** https://github.com/redhat-developer/rhdh-dynamic-plugin-factory
+- **Description:** Container image and tooling for building dynamic plugins locally. Provides a pre-configured build environment with all necessary dependencies (Node.js, Yarn, Backstage CLI) so plugin authors can export and package plugins without setting up a full development environment. Used via `podman` or `docker`.
+- **Tech stack:** Container (Podman/Docker), Node.js, Yarn, Backstage CLI
+- **Key concepts:**
+  - **Container-based builds:** Run `podman run` or `docker run` with the factory image to build plugins in an isolated environment.
+  - **Used by overlay workflows:** `rhdh-plugin-export-overlays` can use the factory container for local plugin builds.
+- **Key paths:** `Containerfile` (image definition)
+
 ### backstage
 
 - **Upstream:** https://github.com/backstage/backstage
@@ -172,6 +182,7 @@ rhdh (enterprise distribution, github.com)
     |   +-- rhdh-chart (Helm chart)
     |
     +-- rhdh-local (local dev/test environment)
+    +-- rhdh-dynamic-plugin-factory (container for local plugin building)
 ```
 
 ## Common Workflows

--- a/skills/rhdh/rhdh/cli.py
+++ b/skills/rhdh/rhdh/cli.py
@@ -20,7 +20,6 @@ from .config import (
     SUBMODULE_REPOS,
     get_data_dir,
     get_github_username,
-    get_overlay_repo,
     get_repo,
     list_submodule_repos,
     save_github_username,
@@ -97,7 +96,7 @@ def cmd_status(fmt: OutputFormatter, _args: argparse.Namespace) -> int:
     needs_setup = False
 
     # Check all configured repos
-    for repo_name, info in SUBMODULE_REPOS.items():
+    for info in SUBMODULE_REPOS.values():
         config_key = info["config_key"]
         required = info["required"]
         repo_path = get_repo(config_key)
@@ -235,7 +234,7 @@ def cmd_doctor(fmt: OutputFormatter, _args: argparse.Namespace) -> int:
     issues: list[str] = []
 
     # Check all repos
-    for repo_name, info in SUBMODULE_REPOS.items():
+    for info in SUBMODULE_REPOS.values():
         config_key = info["config_key"]
         required = info["required"]
         repo_path = get_repo(config_key)

--- a/skills/rhdh/rhdh/cli.py
+++ b/skills/rhdh/rhdh/cli.py
@@ -19,10 +19,9 @@ from . import __version__
 from .config import (
     SUBMODULE_REPOS,
     get_data_dir,
-    get_factory_repo,
     get_github_username,
-    get_local_repo,
     get_overlay_repo,
+    get_repo,
     list_submodule_repos,
     save_github_username,
     setup_submodule,
@@ -97,89 +96,45 @@ def cmd_status(fmt: OutputFormatter, _args: argparse.Namespace) -> int:
     next_steps: list[str] = []
     needs_setup = False
 
-    # Check overlay repo
-    overlay_repo = get_overlay_repo()
-    if overlay_repo:
-        branch = get_git_branch(overlay_repo)
-        status = "uncommitted" if has_uncommitted_changes(overlay_repo) else "clean"
-        checks.append(
-            {
-                "name": "overlay_repo",
-                "status": "pass",
-                "message": f"{overlay_repo} ({branch}, {status})",
-                "path": str(overlay_repo),
-                "branch": branch,
-                "clean": status == "clean",
-            }
-        )
-        fmt.log_ok(f"overlay repo: {overlay_repo} ({branch}, {status})")
-    else:
-        checks.append(
-            {
-                "name": "overlay_repo",
-                "status": "fail",
-                "message": "not found",
-            }
-        )
-        fmt.log_fail("overlay repo: not found")
-        needs_setup = True
+    # Check all configured repos
+    for repo_name, info in SUBMODULE_REPOS.items():
+        config_key = info["config_key"]
+        required = info["required"]
+        repo_path = get_repo(config_key)
 
-    # Check rhdh-local
-    local_repo = get_local_repo()
-    if local_repo:
-        # Check if running (podman)
-        running = False
-        if check_tool("podman"):
-            rc, stdout, _ = run_command(["podman", "ps", "--format", "{{.Names}}"])
-            running = rc == 0 and "rhdh" in stdout
-
-        status_msg = "running" if running else "not running"
-        check_status = "pass" if running else "warn"
-        checks.append(
-            {
-                "name": "rhdh_local",
-                "status": check_status,
-                "message": f"{local_repo} ({status_msg})",
-                "path": str(local_repo),
-                "running": running,
-            }
-        )
-        if running:
-            fmt.log_ok(f"rhdh-local: {local_repo} (running)")
+        if repo_path:
+            branch = get_git_branch(repo_path)
+            status = "uncommitted" if has_uncommitted_changes(repo_path) else "clean"
+            checks.append(
+                {
+                    "name": config_key,
+                    "status": "pass",
+                    "message": f"{repo_path} ({branch}, {status})",
+                    "path": str(repo_path),
+                    "branch": branch,
+                    "clean": status == "clean",
+                }
+            )
+            fmt.log_ok(f"{config_key}: {repo_path} ({branch}, {status})")
+        elif required:
+            checks.append(
+                {
+                    "name": config_key,
+                    "status": "fail",
+                    "message": "not found",
+                }
+            )
+            fmt.log_fail(f"{config_key}: not found")
+            needs_setup = True
         else:
-            fmt.log_warn(f"rhdh-local: {local_repo} (not running)")
-    else:
-        checks.append(
-            {
-                "name": "rhdh_local",
-                "status": "fail",
-                "message": "not found",
-            }
-        )
-        fmt.log_fail("rhdh-local: not found")
-        needs_setup = True
-
-    # Check factory (optional)
-    factory_repo = get_factory_repo()
-    if factory_repo:
-        checks.append(
-            {
-                "name": "factory",
-                "status": "pass",
-                "message": str(factory_repo),
-                "path": str(factory_repo),
-            }
-        )
-        fmt.log_ok(f"factory: {factory_repo}")
-    else:
-        checks.append(
-            {
-                "name": "factory",
-                "status": "info",
-                "message": "not configured (optional)",
-            }
-        )
-        fmt.log_info("factory: not configured (optional)")
+            checks.append(
+                {
+                    "name": config_key,
+                    "status": "info",
+                    "message": "not configured (optional)",
+                }
+            )
+            fmt.log_info(f"{config_key}: not configured (optional)")
 
     # Check tools
     fmt.header("Tools")
@@ -279,56 +234,38 @@ def cmd_doctor(fmt: OutputFormatter, _args: argparse.Namespace) -> int:
     checks: list[dict[str, Any]] = []
     issues: list[str] = []
 
-    # Check repos
-    overlay_repo = get_overlay_repo()
-    if overlay_repo:
-        checks.append({"name": "overlay_repo", "status": "pass", "message": str(overlay_repo)})
-        fmt.log_ok(f"Overlay repo found: {overlay_repo}")
+    # Check all repos
+    for repo_name, info in SUBMODULE_REPOS.items():
+        config_key = info["config_key"]
+        required = info["required"]
+        repo_path = get_repo(config_key)
 
-        # Check it's a git repo
-        rc, _, _ = run_command(["git", "rev-parse", "--git-dir"], cwd=overlay_repo)
-        if rc == 0:
-            checks.append({"name": "overlay_git", "status": "pass", "message": "valid"})
-            fmt.log_ok("  Git repository valid")
-        else:
-            checks.append({"name": "overlay_git", "status": "fail", "message": "invalid"})
-            fmt.log_fail("  Not a valid git repository")
-            issues.append("Overlay repo is not a git repository")
+        if repo_path:
+            checks.append({"name": config_key, "status": "pass", "message": str(repo_path)})
+            fmt.log_ok(f"{config_key} found: {repo_path}")
 
-        # Check remote
-        rc, stdout, _ = run_command(["git", "remote", "get-url", "origin"], cwd=overlay_repo)
-        if rc == 0:
-            remote = stdout.strip()
-            if "rhdh-plugin-export-overlays" in remote:
-                checks.append({"name": "overlay_remote", "status": "pass", "message": remote})
-                fmt.log_ok(f"  Remote: {remote}")
+            # Check it's a git repo
+            rc, _, _ = run_command(["git", "rev-parse", "--git-dir"], cwd=repo_path)
+            if rc == 0:
+                checks.append(
+                    {"name": f"{config_key}_git", "status": "pass", "message": "valid"}
+                )
+                fmt.log_ok("  Git repository valid")
             else:
-                checks.append({"name": "overlay_remote", "status": "warn", "message": remote})
-                fmt.log_warn(f"  Remote may be incorrect: {remote}")
-    else:
-        checks.append({"name": "overlay_repo", "status": "fail", "message": "not found"})
-        fmt.log_fail("Overlay repo not found")
-        issues.append("Configure overlay repo: rhdh config set overlay /path/to/repo")
-
-    local_repo = get_local_repo()
-    if local_repo:
-        checks.append({"name": "rhdh_local", "status": "pass", "message": str(local_repo)})
-        fmt.log_ok(f"rhdh-local found: {local_repo}")
-
-        # Check compose file exists
-        has_compose = (local_repo / "compose.yaml").exists() or (
-            local_repo / "docker-compose.yaml"
-        ).exists()
-        if has_compose:
-            checks.append({"name": "compose_file", "status": "pass", "message": "found"})
-            fmt.log_ok("  Compose file found")
+                checks.append(
+                    {"name": f"{config_key}_git", "status": "fail", "message": "invalid"}
+                )
+                fmt.log_fail("  Not a valid git repository")
+                issues.append(f"{config_key} is not a git repository")
+        elif required:
+            checks.append({"name": config_key, "status": "fail", "message": "not found"})
+            fmt.log_fail(f"{config_key} not found")
+            issues.append(f"Configure {config_key}: rhdh config set {config_key} /path/to/repo")
         else:
-            checks.append({"name": "compose_file", "status": "warn", "message": "not found"})
-            fmt.log_warn("  No compose file found")
-    else:
-        checks.append({"name": "rhdh_local", "status": "fail", "message": "not found"})
-        fmt.log_fail("rhdh-local not found")
-        issues.append("Configure rhdh-local: rhdh config set local /path/to/repo")
+            checks.append(
+                {"name": config_key, "status": "info", "message": "not configured (optional)"}
+            )
+            fmt.log_info(f"{config_key}: not configured (optional)")
 
     fmt.header("GitHub CLI")
 
@@ -479,14 +416,14 @@ def cmd_config_init(fmt: OutputFormatter, args: argparse.Namespace) -> int:
         fmt.log_ok(f"Created: {data.get('created', '')}")
         config = data.get("config", {})
         repos = config.get("repos", {})
-        if repos.get("overlay"):
-            fmt.log_ok(f"Auto-detected overlay: {repos['overlay']}")
-        else:
-            fmt.log_info("overlay: not found (configure with: rhdh config set repos.overlay /path)")
-        if repos.get("local"):
-            fmt.log_ok(f"Auto-detected local: {repos['local']}")
-        else:
-            fmt.log_info("local: not found (configure with: rhdh config set repos.local /path)")
+        for info in SUBMODULE_REPOS.values():
+            key = info["config_key"]
+            if repos.get(key):
+                fmt.log_ok(f"Auto-detected {key}: {repos[key]}")
+            elif info["required"]:
+                fmt.log_info(
+                    f"{key}: not found (configure with: rhdh config set {key} /path)"
+                )
         fmt.success(data, next_steps=next_steps)
         return 0
     else:
@@ -511,18 +448,14 @@ def cmd_config_show(fmt: OutputFormatter, args: argparse.Namespace) -> int:
 
         fmt.header("Resolved Paths")
         resolved = data.get("resolved", {})
-        if resolved.get("overlay"):
-            fmt.log_ok(f"overlay: {resolved['overlay']}")
-        else:
-            fmt.log_fail("overlay: not found")
-        if resolved.get("local"):
-            fmt.log_ok(f"local: {resolved['local']}")
-        else:
-            fmt.log_fail("local: not found")
-        if resolved.get("factory"):
-            fmt.log_ok(f"factory: {resolved['factory']}")
-        else:
-            fmt.log_info("factory: not configured")
+        for info in SUBMODULE_REPOS.values():
+            key = info["config_key"]
+            if resolved.get(key):
+                fmt.log_ok(f"{key}: {resolved[key]}")
+            elif info["required"]:
+                fmt.log_fail(f"{key}: not found")
+            else:
+                fmt.log_info(f"{key}: not configured")
 
         fmt.success(data, next_steps=next_steps)
         return 0

--- a/skills/rhdh/rhdh/config.py
+++ b/skills/rhdh/rhdh/config.py
@@ -32,23 +32,74 @@ DATA_DIR_ENV_VAR = "RHDH_SKILL_DATA_DIR"
 # Repos with has_fork=True use user's fork as origin, redhat-developer as upstream
 # Repos with has_fork=False use redhat-developer as origin (no upstream)
 SUBMODULE_REPOS: dict[str, dict] = {
+    "rhdh": {
+        "has_fork": False,
+        "required": False,
+        "config_key": "rhdh",
+        "description": "Main RHDH application (enterprise Backstage distribution)",
+    },
+    "rhdh-downstream": {
+        "has_fork": False,
+        "required": False,
+        "config_key": "downstream",
+        "description": "Downstream productized RHDH build (internal GitLab)",
+        "upstream_host": "gitlab.cee.redhat.com",
+        "upstream_path": "rhidp/rhdh",
+    },
+    "rhdh-cli": {
+        "has_fork": False,
+        "required": False,
+        "config_key": "cli",
+        "description": "CLI for developing/packaging dynamic plugins",
+    },
+    "rhdh-plugins": {
+        "has_fork": False,
+        "required": False,
+        "config_key": "plugins",
+        "description": "Red Hat Backstage plugins (multi-workspace monorepo)",
+    },
     "rhdh-plugin-export-overlays": {
         "has_fork": True,  # Users fork this repo to contribute
-        "required": True,
+        "required": False,
         "config_key": "overlay",
-        "description": "Plugin overlay repository (required for all operations)",
+        "description": "Plugin overlay repository (community plugin packaging)",
+    },
+    "rhdh-plugin-export-utils": {
+        "has_fork": False,
+        "required": False,
+        "config_key": "export-utils",
+        "description": "Reusable GitHub Actions for plugin packaging",
+    },
+    "rhdh-plugin-catalog": {
+        "has_fork": False,
+        "required": False,
+        "config_key": "catalog",
+        "description": "Midstream plugin builds, OCI artifacts & catalog index",
+    },
+    "rhdh-operator": {
+        "has_fork": False,
+        "required": False,
+        "config_key": "operator",
+        "description": "Kubernetes/OpenShift operator for RHDH",
+    },
+    "rhdh-chart": {
+        "has_fork": False,
+        "required": False,
+        "config_key": "chart",
+        "description": "Helm chart for RHDH deployment",
     },
     "rhdh-local": {
         "has_fork": False,  # No fork needed, clone directly
-        "required": True,
-        "config_key": "local",
-        "description": "Local RHDH testing environment",
-    },
-    "rhdh-dynamic-plugin-factory": {
-        "has_fork": False,  # No fork needed
         "required": False,
-        "config_key": "factory",
-        "description": "Dynamic plugin factory (optional)",
+        "config_key": "local",
+        "description": "Local RHDH testing environment (Docker Compose)",
+    },
+    "backstage": {
+        "has_fork": False,
+        "required": False,
+        "config_key": "backstage",
+        "description": "Upstream Backstage framework",
+        "upstream_org": "backstage",
     },
 }
 
@@ -308,6 +359,19 @@ def save_config(config: dict, global_: bool = False) -> bool:
 # =============================================================================
 
 
+def _repo_name_to_config_key(repo_name: str) -> str:
+    """Map a repo directory name to its config key."""
+    repo_info = SUBMODULE_REPOS.get(repo_name)
+    if repo_info:
+        return repo_info["config_key"]
+    return repo_name
+
+
+def _config_key_to_env_var(config_key: str) -> str:
+    """Map a config key to its environment variable name."""
+    return f"RHDH_{config_key.upper().replace('-', '_')}_REPO"
+
+
 def find_repo(repo_name: str, env_var: str) -> Optional[Path]:
     """Find a repository in well-known locations.
 
@@ -333,12 +397,8 @@ def find_repo(repo_name: str, env_var: str) -> Optional[Path]:
 
     # 2. Merged config (project overrides user)
     config = load_merged_config()
-    key_map = {
-        "rhdh-plugin-export-overlays": "overlay",
-        "rhdh-local": "local",
-        "rhdh-dynamic-plugin-factory": "factory",
-    }
-    config_key = key_map.get(repo_name, repo_name)
+    # Map repo directory names to config keys
+    config_key = _repo_name_to_config_key(repo_name)
     config_path = config.get("repos", {}).get(config_key)
     if config_path:
         path = Path(config_path)
@@ -359,19 +419,36 @@ def find_repo(repo_name: str, env_var: str) -> Optional[Path]:
     return None
 
 
+def get_repo(config_key: str) -> Optional[Path]:
+    """Get path to a repo by its config key.
+
+    Args:
+        config_key: The config key (e.g., "overlay", "local", "rhdh", "cli")
+
+    Returns:
+        Path to the repository, or None if not found.
+    """
+    # Find the repo name from the config key
+    for repo_name, info in SUBMODULE_REPOS.items():
+        if info["config_key"] == config_key:
+            env_var = _config_key_to_env_var(config_key)
+            return find_repo(repo_name, env_var)
+    return None
+
+
 def get_overlay_repo() -> Optional[Path]:
     """Get path to rhdh-plugin-export-overlays repo."""
-    return find_repo("rhdh-plugin-export-overlays", "RHDH_OVERLAY_REPO")
+    return get_repo("overlay")
 
 
 def get_local_repo() -> Optional[Path]:
     """Get path to rhdh-local repo."""
-    return find_repo("rhdh-local", "RHDH_LOCAL_REPO")
+    return get_repo("local")
 
 
 def get_factory_repo() -> Optional[Path]:
     """Get path to rhdh-dynamic-plugin-factory repo."""
-    return find_repo("rhdh-dynamic-plugin-factory", "RHDH_FACTORY_REPO")
+    return get_repo("factory")
 
 
 # =============================================================================
@@ -381,13 +458,8 @@ def get_factory_repo() -> Optional[Path]:
 
 def get_default_config() -> dict:
     """Get default configuration values."""
-    return {
-        "repos": {
-            "overlay": "",
-            "local": "",
-            "factory": "",
-        }
-    }
+    repos = {info["config_key"]: "" for info in SUBMODULE_REPOS.values()}
+    return {"repos": repos}
 
 
 def run_config(
@@ -446,17 +518,10 @@ def _config_init(force: bool, global_: bool) -> tuple[bool, dict | str, list[str
 
     if not global_:
         skill_root = get_skill_root()
-        overlay_path = skill_root.parent / "repo" / "rhdh-plugin-export-overlays"
-        if overlay_path.is_dir():
-            config["repos"]["overlay"] = str(overlay_path.resolve())
-
-        local_path = skill_root.parent / "repo" / "rhdh-local"
-        if local_path.is_dir():
-            config["repos"]["local"] = str(local_path.resolve())
-
-        factory_path = skill_root.parent / "repo" / "rhdh-dynamic-plugin-factory"
-        if factory_path.is_dir():
-            config["repos"]["factory"] = str(factory_path.resolve())
+        for repo_name, info in SUBMODULE_REPOS.items():
+            repo_path = skill_root.parent / "repo" / repo_name
+            if repo_path.is_dir():
+                config["repos"][info["config_key"]] = str(repo_path.resolve())
 
     try:
         config_dir.mkdir(parents=True, exist_ok=True)
@@ -474,6 +539,16 @@ def _config_init(force: bool, global_: bool) -> tuple[bool, dict | str, list[str
     return True, data, next_steps
 
 
+def _resolve_all_repos() -> dict[str, str | None]:
+    """Resolve paths for all configured repos."""
+    resolved = {}
+    for info in SUBMODULE_REPOS.values():
+        key = info["config_key"]
+        path = get_repo(key)
+        resolved[key] = str(path) if path else None
+    return resolved
+
+
 def _config_show(global_: bool) -> tuple[bool, dict, list[str]]:
     """Display config."""
     user_config = load_user_config()
@@ -486,11 +561,7 @@ def _config_show(global_: bool) -> tuple[bool, dict, list[str]]:
         "user_config": user_config if user_config else None,
         "project_config": project_config if project_config else None,
         "merged_config": merged_config if merged_config else None,
-        "resolved": {
-            "overlay": str(get_overlay_repo()) if get_overlay_repo() else None,
-            "local": str(get_local_repo()) if get_local_repo() else None,
-            "factory": str(get_factory_repo()) if get_factory_repo() else None,
-        },
+        "resolved": _resolve_all_repos(),
     }
 
     next_steps = ["rhdh config set <key> <value>", "rhdh config keys"]
@@ -552,8 +623,9 @@ def _config_set(
         return False, "Value is required for 'config set'", []
 
     # Map shorthand keys to full dot-notation paths
-    key_map = {"overlay": "repos.overlay", "local": "repos.local", "factory": "repos.factory"}
-    key = key_map.get(key, key)
+    all_config_keys = {info["config_key"] for info in SUBMODULE_REPOS.values()}
+    if key in all_config_keys:
+        key = f"repos.{key}"
 
     # Load appropriate config
     if global_:
@@ -652,8 +724,13 @@ def get_repo_urls(repo_name: str, github_username: str | None = None) -> tuple[s
     repo_info = SUBMODULE_REPOS[repo_name]
     has_fork = repo_info.get("has_fork", False)
 
+    # Determine upstream org/host
+    upstream_org = repo_info.get("upstream_org", GITHUB_ORG)
+    upstream_host = repo_info.get("upstream_host")
+    upstream_path = repo_info.get("upstream_path")
+
     if has_fork:
-        # User's fork as origin, redhat-developer as upstream
+        # User's fork as origin, upstream org as upstream
         if github_username is None:
             github_username = get_github_username()
         if not github_username:
@@ -662,10 +739,15 @@ def get_repo_urls(repo_name: str, github_username: str | None = None) -> tuple[s
                 "Run 'gh auth login' or set github.username in config."
             )
         origin_url = f"git@github.com:{github_username}/{repo_name}.git"
-        upstream_url = f"git@github.com:{GITHUB_ORG}/{repo_name}.git"
+        upstream_url = f"git@github.com:{upstream_org}/{repo_name}.git"
+    elif upstream_host:
+        # Non-GitHub repo (e.g., GitLab)
+        path = upstream_path or repo_name
+        origin_url = f"git@{upstream_host}:{path}.git"
+        upstream_url = None
     else:
-        # Direct clone from redhat-developer
-        origin_url = f"git@github.com:{GITHUB_ORG}/{repo_name}.git"
+        # Direct clone from GitHub org
+        origin_url = f"git@github.com:{upstream_org}/{repo_name}.git"
         upstream_url = None
 
     return origin_url, upstream_url
@@ -880,16 +962,10 @@ def list_submodule_repos() -> list[dict]:
 
         # Also check if configured via other means
         config_key = info["config_key"]
-        key_map = {
-            "overlay": get_overlay_repo,
-            "local": get_local_repo,
-            "factory": get_factory_repo,
-        }
-        if config_key in key_map:
-            discovered = key_map[config_key]()
-            if discovered:
-                status = "configured" if status == "not_configured" else status
-                path = str(discovered) if not path else path
+        discovered = get_repo(config_key)
+        if discovered:
+            status = "configured" if status == "not_configured" else status
+            path = str(discovered) if not path else path
 
         # Get URLs if possible
         has_fork = info.get("has_fork", False)
@@ -956,18 +1032,14 @@ def config_init() -> tuple[bool, list[str]]:
             messages.append(f"Created: {data.get('created', '')}")
             config = data.get("config", {})
             repos = config.get("repos", {})
-            if repos.get("overlay"):
-                messages.append(f"Auto-detected overlay repo: {repos['overlay']}")
-            else:
-                messages.append(
-                    "overlay repo: not found (configure with: rhdh config set repos.overlay /path)"
-                )
-            if repos.get("local"):
-                messages.append(f"Auto-detected rhdh-local: {repos['local']}")
-            else:
-                messages.append(
-                    "rhdh-local: not found (configure with: rhdh config set repos.local /path)"
-                )
+            for info in SUBMODULE_REPOS.values():
+                key = info["config_key"]
+                if repos.get(key):
+                    messages.append(f"Auto-detected {key}: {repos[key]}")
+                elif info["required"]:
+                    messages.append(
+                        f"{key}: not found (configure with: rhdh config set {key} /path)"
+                    )
     else:
         messages.append(str(data))
 
@@ -1005,9 +1077,5 @@ def get_config_info() -> dict:
         "skill_root": str(get_skill_root()),
         "user_config": load_user_config(),
         "project_config": load_project_config(),
-        "resolved": {
-            "overlay": get_overlay_repo(),
-            "local": get_local_repo(),
-            "factory": get_factory_repo(),
-        },
+        "resolved": _resolve_all_repos(),
     }

--- a/skills/rhdh/rhdh/config.py
+++ b/skills/rhdh/rhdh/config.py
@@ -94,6 +94,12 @@ SUBMODULE_REPOS: dict[str, dict] = {
         "config_key": "local",
         "description": "Local RHDH testing environment (Docker Compose)",
     },
+    "rhdh-dynamic-plugin-factory": {
+        "has_fork": False,
+        "required": False,
+        "config_key": "factory",
+        "description": "Container for local dynamic plugin building",
+    },
     "backstage": {
         "has_fork": False,
         "required": False,

--- a/skills/rhdh/rhdh/config.py
+++ b/skills/rhdh/rhdh/config.py
@@ -75,6 +75,8 @@ SUBMODULE_REPOS: dict[str, dict] = {
         "required": False,
         "config_key": "catalog",
         "description": "Midstream plugin builds, OCI artifacts & catalog index",
+        "upstream_host": "gitlab.cee.redhat.com",
+        "upstream_path": "rhidp/rhdh-plugin-catalog",
     },
     "rhdh-operator": {
         "has_fork": False,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -224,12 +224,12 @@ def unconfigured_cli(isolated_env, monkeypatch):
     """Fixture providing CLI with no repos configured.
 
     Use this to test the "needs setup" state without manual monkeypatching.
-    Mocks get_overlay_repo and get_local_repo to return None.
+    Mocks get_repo to return None for all repos.
     """
     from rhdh import cli as cli_module
 
     monkeypatch.setattr(cli_module, "get_overlay_repo", lambda: None)
-    monkeypatch.setattr(cli_module, "get_local_repo", lambda: None)
+    monkeypatch.setattr(cli_module, "get_repo", lambda key: None)
 
     def _run_cli(*args, env=None):
         full_env = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -224,11 +224,10 @@ def unconfigured_cli(isolated_env, monkeypatch):
     """Fixture providing CLI with no repos configured.
 
     Use this to test the "needs setup" state without manual monkeypatching.
-    Mocks get_overlay_repo and get_repo to return None for all repos.
+    Mocks get_repo to return None for all repos.
     """
     from rhdh import cli as cli_module
 
-    monkeypatch.setattr(cli_module, "get_overlay_repo", lambda: None)
     monkeypatch.setattr(cli_module, "get_repo", lambda key: None)
 
     def _run_cli(*args, env=None):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -224,7 +224,7 @@ def unconfigured_cli(isolated_env, monkeypatch):
     """Fixture providing CLI with no repos configured.
 
     Use this to test the "needs setup" state without manual monkeypatching.
-    Mocks get_repo to return None for all repos.
+    Mocks get_overlay_repo and get_repo to return None for all repos.
     """
     from rhdh import cli as cli_module
 

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -56,21 +56,15 @@ class TestCliStatus:
         assert response is not None
         assert "next_steps" in response
 
-    def test_status_needs_setup_points_to_doctor(self, unconfigured_cli):
-        """When needs_setup is true, status should point to doctor command.
-
-        Doctor command has all the setup guidance - status just redirects there.
-        """
+    def test_status_unconfigured_is_valid(self, unconfigured_cli):
+        """When no repos are configured, needs_setup should be false (all repos are optional)."""
         result = unconfigured_cli()
 
         response = parse_response(result)
         assert response is not None
-        assert response["data"]["needs_setup"] is True
+        assert response["data"]["needs_setup"] is False
 
-        # next_steps should include doctor command
-        assert "rhdh doctor" in response["next_steps"]
-
-        # Should NOT include setup_options or doctor_workflow (that's doctor's job)
+        # Should NOT include setup_options or doctor_workflow
         assert "setup_options" not in response["data"]
         assert "doctor_workflow" not in response["data"]
 
@@ -106,26 +100,31 @@ class TestCliDoctor:
         assert response is not None
         assert "all_passed" in response["data"]
 
-    def test_doctor_points_to_workflow_when_issues_found(self, unconfigured_cli):
-        """When doctor finds issues, it should point to the workflow file.
+    def test_doctor_checks_all_repos(self, unconfigured_cli):
+        """Doctor should include a check for every configured repository."""
+        from rhdh.config import SUBMODULE_REPOS
 
-        This enables agents to read the workflow for remediation steps.
-        """
+        result = unconfigured_cli("doctor")
+        response = parse_response(result)
+        assert response is not None
+
+        check_names = [c["name"] for c in response["data"]["checks"]]
+        for info in SUBMODULE_REPOS.values():
+            config_key = info["config_key"]
+            assert config_key in check_names, (
+                f"Doctor missing check for repo '{config_key}'"
+            )
+
+    def test_doctor_unconfigured_repos_no_issues(self, unconfigured_cli):
+        """When no repos are configured, doctor should not report repo issues (all optional)."""
         result = unconfigured_cli("doctor")
 
         response = parse_response(result)
         assert response is not None
-        assert response["data"]["all_passed"] is False
 
-        # Should include workflow path for agentic discovery
-        assert "workflow" in response["data"]
-        assert response["data"]["workflow"] == "workflows/doctor.md"
-
-        # Should include instruction for agent
-        assert "agent_instruction" in response["data"]
-
-        # next_steps should point to reading the workflow
-        assert any("workflow" in step.lower() for step in response["next_steps"])
+        # No repo-related issues should appear (all repos are optional)
+        repo_issues = [i for i in response["data"]["issues"] if "config set" in i]
+        assert repo_issues == [], f"Unexpected repo issues: {repo_issues}"
 
 
 class TestCliConfig:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -57,8 +57,11 @@ class TestFindRepo:
         config.USER_CONFIG_DIR = tmp_path / ".config" / "rhdh"
         config.USER_CONFIG_FILE = config.USER_CONFIG_DIR / "config.json"
 
-        result = config.find_repo("rhdh-plugin-export-overlays", "RHDH_OVERLAY_REPO")
-        assert result is None
+        # Mock find_git_root to tmp_path to prevent picking up real .rhdh/config.json
+        # (find_git_root=None falls back to cwd which may have real project config)
+        with patch.object(config, "find_git_root", return_value=tmp_path):
+            result = config.find_repo("rhdh-plugin-export-overlays", "RHDH_OVERLAY_REPO")
+            assert result is None
 
     def test_user_config_lookup(self, tmp_path, monkeypatch):
         """Should find repo from user config file."""
@@ -83,8 +86,8 @@ class TestFindRepo:
         config.USER_CONFIG_DIR = config_dir
         config.USER_CONFIG_FILE = config_file
 
-        # Mock find_git_root to return None (no project config)
-        with patch.object(config, "find_git_root", return_value=None):
+        # Mock find_git_root to tmp_path (prevents picking up real .rhdh/config.json via cwd fallback)
+        with patch.object(config, "find_git_root", return_value=tmp_path):
             result = config.find_repo("rhdh-plugin-export-overlays", "RHDH_OVERLAY_REPO")
             assert result == repo_dir.resolve()
 
@@ -99,9 +102,29 @@ class TestFindRepo:
         config.USER_CONFIG_DIR = tmp_path / ".config" / "rhdh"
         config.USER_CONFIG_FILE = config.USER_CONFIG_DIR / "config.json"
 
-        with patch.object(config, "find_git_root", return_value=None):
+        # Mock find_git_root to prevent picking up real .rhdh/config.json
+        with patch.object(config, "find_git_root", return_value=tmp_path):
             result = config.find_repo("rhdh-plugin-export-overlays", "RHDH_OVERLAY_REPO")
             assert result is None
+
+    def test_get_repo_by_config_key(self, tmp_path, monkeypatch):
+        """get_repo() should find repos by their config key."""
+        from rhdh import config
+
+        repo_dir = tmp_path / "rhdh-cli"
+        repo_dir.mkdir()
+
+        monkeypatch.setenv("RHDH_CLI_REPO", str(repo_dir))
+
+        result = config.get_repo("cli")
+        assert result == repo_dir.resolve()
+
+    def test_get_repo_returns_none_for_unknown_key(self):
+        """get_repo() should return None for unknown config keys."""
+        from rhdh import config
+
+        result = config.get_repo("nonexistent_key")
+        assert result is None
 
 
 class TestConfigInit:
@@ -166,6 +189,16 @@ class TestConfigSet:
             saved_config = json.loads(project_config.read_text())
             assert saved_config["repos"]["overlay"] == str(repo_dir)
 
+    def test_sets_new_repo_shorthand_keys(self, tmp_path):
+        """Should map all new repo shorthand keys."""
+        from rhdh import config
+
+        with patch.object(config, "find_git_root", return_value=tmp_path):
+            for key in ["rhdh", "downstream", "cli", "plugins", "operator", "chart", "catalog"]:
+                success, message = config.config_set(key, f"/path/to/{key}")
+                assert success is True
+                assert f"repos.{key}" in message
+
     def test_sets_value_with_dotnotation_key(self, tmp_path):
         """Should accept full dot-notation keys."""
         from rhdh import config
@@ -188,6 +221,28 @@ class TestConfigSet:
             project_config = tmp_path / ".rhdh" / "config.json"
             saved_config = json.loads(project_config.read_text())
             assert saved_config["custom"]["deeply"]["nested"]["key"] == "value"
+
+
+class TestDefaultConfig:
+    """Test default configuration generation."""
+
+    def test_default_config_has_all_repo_keys(self):
+        """Default config should have keys for all defined repos."""
+        from rhdh.config import SUBMODULE_REPOS, get_default_config
+
+        default = get_default_config()
+        repos = default["repos"]
+        for info in SUBMODULE_REPOS.values():
+            assert info["config_key"] in repos, f"Missing key: {info['config_key']}"
+
+    def test_default_config_has_core_repos(self):
+        """Default config should include all core RHDH repos."""
+        from rhdh.config import get_default_config
+
+        default = get_default_config()
+        repos = default["repos"]
+        for key in ["rhdh", "downstream", "cli", "plugins", "overlay", "operator", "chart", "local"]:
+            assert key in repos, f"Missing core repo key: {key}"
 
 
 class TestLoadSaveConfig:

--- a/tests/unit/test_skill_structure.py
+++ b/tests/unit/test_skill_structure.py
@@ -202,6 +202,43 @@ class TestWorkflowStructure:
             )
 
 
+class TestRhdhReposReference:
+    """Test that rhdh-repos.md reference file exists and has required content."""
+
+    @pytest.fixture
+    def rhdh_repos(self, skills_dir):
+        """Load rhdh-repos.md content."""
+        path = skills_dir / "references" / "rhdh-repos.md"
+        assert path.exists(), "rhdh-repos.md must exist in skills/rhdh/references/"
+        return path.read_text()
+
+    def test_rhdh_repos_exists(self, skills_dir):
+        """rhdh-repos.md must exist."""
+        assert (skills_dir / "references" / "rhdh-repos.md").exists()
+
+    def test_has_key_repos(self, rhdh_repos):
+        """Must document the core RHDH repositories."""
+        for repo in ["rhdh", "rhdh-cli", "rhdh-operator", "rhdh-plugins"]:
+            assert repo in rhdh_repos, f"Missing repo: {repo}"
+
+    def test_has_ecosystem_relationships(self, rhdh_repos):
+        """Must contain ecosystem relationships section."""
+        assert "Ecosystem Relationships" in rhdh_repos
+
+    def test_no_hardcoded_user_paths(self, rhdh_repos):
+        """Must not contain hardcoded user-specific paths."""
+        assert "/Users/" not in rhdh_repos
+        assert "/home/" not in rhdh_repos
+
+    def test_no_yaml_frontmatter(self, rhdh_repos):
+        """Reference file should not have YAML frontmatter."""
+        assert not rhdh_repos.startswith("---")
+
+    def test_has_upstream_urls(self, rhdh_repos):
+        """Must include upstream GitHub URLs."""
+        assert "github.com/redhat-developer/" in rhdh_repos
+
+
 class TestReferenceStructure:
     """Test that reference files have required structure."""
 
@@ -220,7 +257,13 @@ class TestReferenceStructure:
     def test_reference_has_xml_sections(self, reference_files):
         """Reference files should use XML tags for structure (optional for cheatsheets)."""
         # Some reference files are practical cheatsheets without XML structure
-        xml_optional = {"jira-reference.md", "jira-structure.md", "github-tips.md"}
+        xml_optional = {
+            "jira-reference.md",
+            "jira-structure.md",
+            "github-tips.md",
+            "rhdh-repos.md",
+            "versions.md",
+        }
 
         for ref in reference_files:
             if ref.name in xml_optional:

--- a/tests/unit/test_workspace.py
+++ b/tests/unit/test_workspace.py
@@ -95,6 +95,8 @@ class TestListWorkspaces:
 
     def test_returns_none_when_no_overlay(self, tmp_path, monkeypatch):
         """Should return (None, []) when overlay repo not found."""
+        from unittest.mock import patch
+
         from rhdh import config
         from rhdh.workspace import list_workspaces
 
@@ -106,10 +108,12 @@ class TestListWorkspaces:
         config.USER_CONFIG_DIR = tmp_path / ".config"
         config.USER_CONFIG_FILE = config.USER_CONFIG_DIR / "config.json"
 
-        overlay_path, workspaces = list_workspaces()
+        # Mock find_git_root to prevent picking up real .rhdh/config.json
+        with patch.object(config, "find_git_root", return_value=tmp_path):
+            overlay_path, workspaces = list_workspaces()
 
-        assert overlay_path is None
-        assert workspaces == []
+            assert overlay_path is None
+            assert workspaces == []
 
     def test_returns_empty_list_when_no_workspaces_dir(self, tmp_path, monkeypatch):
         """Should return empty list when workspaces dir doesn't exist."""
@@ -185,6 +189,8 @@ class TestGetWorkspace:
 
     def test_returns_error_when_no_overlay(self, tmp_path, monkeypatch):
         """Should return error when overlay repo not configured."""
+        from unittest.mock import patch
+
         from rhdh import config
         from rhdh.workspace import get_workspace
 
@@ -193,8 +199,10 @@ class TestGetWorkspace:
         config.USER_CONFIG_DIR = tmp_path / ".config"
         config.USER_CONFIG_FILE = config.USER_CONFIG_DIR / "config.json"
 
-        found, workspace, error = get_workspace("any")
+        # Mock find_git_root to prevent picking up real .rhdh/config.json
+        with patch.object(config, "find_git_root", return_value=tmp_path):
+            found, workspace, error = get_workspace("any")
 
-        assert found is False
-        assert workspace is None
-        assert "overlay" in error.lower()
+            assert found is False
+            assert workspace is None
+            assert "overlay" in error.lower()


### PR DESCRIPTION
## Summary

- Add `rhdh-repos.md` reference documenting all 11 RHDH ecosystem repositories, their relationships, tech stacks, and key paths
- Expand `SUBMODULE_REPOS` in config from 3 to 11 repos (rhdh, rhdh-downstream, rhdh-cli, rhdh-plugins, rhdh-operator, rhdh-chart, rhdh-plugin-catalog, rhdh-plugin-export-utils, backstage) — all optional
- Generalize CLI status/doctor/config commands to dynamically iterate over all repos instead of hardcoding overlay/local/factory checks
- Add `get_repo()` helper for config-key-based repo lookup

## Test plan

- [x] All 154 tests pass (`uv run pytest`)
- [ ] Verify `rhdh config init` auto-detects repos in expected locations
- [ ] Verify `rhdh config set <key> /path` works for new repo keys (rhdh, cli, plugins, etc.)
- [ ] Verify `rhdh status` and `rhdh doctor` show all configured repos