### PR TITLE
docs: update version matrix for RHDH 1.9 release

### DIFF
--- a/skills/rhdh/references/versions.md
+++ b/skills/rhdh/references/versions.md
@@ -6,13 +6,79 @@ This reference provides the complete version compatibility information for RHDH 
 
 | RHDH Version | Backstage Version | create-app Version | Status |
 |--------------|-------------------|-------------------|--------|
-| next         | 1.42.5           | 0.7.3             | Pre-release |
-| 1.8          | 1.42.5           | 0.7.3             | Current |
+| next         | 1.45.3           | 0.7.6             | Pre-release |
+| 1.9          | 1.45.3           | 0.7.6             | Current |
+| 1.8          | 1.42.5           | 0.7.3             | Supported |
 | 1.7          | 1.39.1           | 0.6.2             | Supported |
-| 1.6          | 1.36.1           | 0.5.25            | Supported |
-| 1.5          | 1.35.1           | 0.5.24            | Legacy |
+| 1.6          | 1.36.1           | 0.5.25            | Legacy |
 
-## RHDH 1.8 / next (Pre-release)
+## RHDH next (Pre-release)
+
+Based on [Backstage 1.45.3](https://backstage.io/docs/releases/v1.45.0)
+
+Bootstrap command:
+```bash
+npx @backstage/create-app@0.7.6
+```
+
+### Frontend Packages
+
+| Package | Version |
+|---------|---------|
+| `@backstage/catalog-model` | `1.7.6` |
+| `@backstage/config` | `1.3.6` |
+| `@backstage/core-app-api` | `1.19.2` |
+| `@backstage/core-components` | `0.18.3` |
+| `@backstage/core-plugin-api` | `1.12.0` |
+| `@backstage/integration-react` | `1.2.12` |
+
+### Backend Packages
+
+| Package | Version |
+|---------|---------|
+| `@backstage/backend-app-api` | `1.3.0` |
+| `@backstage/backend-defaults` | `0.13.1` |
+| `@backstage/backend-dynamic-feature-service` | `0.7.6` |
+| `@backstage/backend-plugin-api` | `1.5.0` |
+| `@backstage/catalog-model` | `1.7.6` |
+| `@backstage/cli-node` | `0.2.15` |
+| `@backstage/config` | `1.3.6` |
+| `@backstage/config-loader` | `1.10.6` |
+
+## RHDH 1.9
+
+Based on [Backstage 1.45.3](https://backstage.io/docs/releases/v1.45.0)
+
+Bootstrap command:
+```bash
+npx @backstage/create-app@0.7.6
+```
+
+### Frontend Packages
+
+| Package | Version |
+|---------|---------|
+| `@backstage/catalog-model` | `1.7.6` |
+| `@backstage/config` | `1.3.6` |
+| `@backstage/core-app-api` | `1.19.2` |
+| `@backstage/core-components` | `0.18.3` |
+| `@backstage/core-plugin-api` | `1.12.0` |
+| `@backstage/integration-react` | `1.2.12` |
+
+### Backend Packages
+
+| Package | Version |
+|---------|---------|
+| `@backstage/backend-app-api` | `1.3.0` |
+| `@backstage/backend-defaults` | `0.13.1` |
+| `@backstage/backend-dynamic-feature-service` | `0.7.6` |
+| `@backstage/backend-plugin-api` | `1.5.0` |
+| `@backstage/catalog-model` | `1.7.6` |
+| `@backstage/cli-node` | `0.2.15` |
+| `@backstage/config` | `1.3.6` |
+| `@backstage/config-loader` | `1.10.6` |
+
+## RHDH 1.8
 
 Based on [Backstage 1.42.5](https://backstage.io/docs/releases/v1.42.0)
 
@@ -111,39 +177,6 @@ npx @backstage/create-app@0.5.25
 | `@backstage/config` | `1.3.2` |
 | `@backstage/config-loader` | `1.9.6` |
 
-## RHDH 1.5
-
-Based on [Backstage 1.35.1](https://backstage.io/docs/releases/v1.35.0)
-
-Bootstrap command:
-```bash
-npx @backstage/create-app@0.5.24
-```
-
-### Frontend Packages
-
-| Package | Version |
-|---------|---------|
-| `@backstage/catalog-model` | `1.7.3` |
-| `@backstage/config` | `1.3.2` |
-| `@backstage/core-app-api` | `1.15.4` |
-| `@backstage/core-components` | `0.16.3` |
-| `@backstage/core-plugin-api` | `1.10.3` |
-| `@backstage/integration-react` | `1.2.3` |
-
-### Backend Packages
-
-| Package | Version |
-|---------|---------|
-| `@backstage/backend-app-api` | `1.1.1` |
-| `@backstage/backend-defaults` | `0.7.0` |
-| `@backstage/backend-dynamic-feature-service` | `0.5.3` |
-| `@backstage/backend-plugin-api` | `1.1.1` |
-| `@backstage/catalog-model` | `1.7.3` |
-| `@backstage/cli-node` | `0.2.12` |
-| `@backstage/config` | `1.3.2` |
-| `@backstage/config-loader` | `1.9.5` |
-
 ## Checking Package Versions
 
 To check versions for packages not listed above:
@@ -154,7 +187,7 @@ Check the [`package.json`](https://github.com/redhat-developer/rhdh/blob/main/pa
 ### Backend packages
 Check the [`package.json`](https://github.com/redhat-developer/rhdh/blob/main/packages/backend/package.json) in the `backend` package.
 
-For specific RHDH versions, switch to the appropriate branch (e.g., `release-1.7`).
+For specific RHDH versions, switch to the appropriate branch (e.g., `release-1.9`).
 
 ## CLI Version Compatibility
 


### PR DESCRIPTION
Add RHDH 1.9 (Backstage 1.45.3) with all package versions, update next to match, and drop unsupported 1.5 per upstream.