### PR TITLE
fix: improve skill descriptions for better triggering and clarity

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rhdh",
-  "description": "Orchestrator skill for RHDH plugin development - onboard, update, and maintain plugins in the Extensions Catalog",
+  "description": "All-in-one toolkit for Red Hat Developer Hub (RHDH). Covers plugin development, overlay management, environment setup, version compatibility, CI/CD, and RHDH ecosystem navigation.",
   "version": "0.1.0",
   "author": {
     "name": "RHDH Store Manager"

--- a/skills/overlay/SKILL.md
+++ b/skills/overlay/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: overlay
-description: Manage RHDH plugins in the overlay repository (rhdh-plugin-export-overlays). Onboard, update, maintain, and triage plugins in the Extensions Catalog.
+description: Use when working with the rhdh-plugin-export-overlays repository — onboarding plugins to the Extensions Catalog, updating plugin versions, fixing overlay build failures, triaging and analyzing PRs, triggering publishes, or managing plugin workspaces.
 ---
 
 <cli_setup>

--- a/skills/rhdh/SKILL.md
+++ b/skills/rhdh/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rhdh
-description: Orchestrator skill for RHDH plugin development. Provides CLI tooling, activity tracking, and routes to specialized skills (overlay, etc.).
+description: Use for ANY work related to "RHDH", "Red Hat Developer Hub", or "Developer Hub". This is the primary entry point for all RHDH tasks — plugin development, overlay management, environment setup, repo navigation, version compatibility, CI/CD, configuration, debugging, and general RHDH ecosystem knowledge. Routes to specialized sub-skills as needed.
 ---
 
 <cli_setup>


### PR DESCRIPTION
## Summary
- Broaden rhdh skill description to cover all RHDH work, not just plugin development
- Make overlay skill description action-oriented with specific trigger contexts
- Update plugin.json to reflect the broader "all-in-one toolkit" scope

## Test plan
- [ ] Verify skill triggers correctly for general RHDH queries (not just plugin dev)
- [ ] Verify overlay skill triggers for overlay-specific tasks