### PR TITLE
Fix skill spec compliance and add automation scripts

### DIFF
--- a/skills/create-backend-plugin/SKILL.md
+++ b/skills/create-backend-plugin/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: RHDH Backend Dynamic Plugin Bootstrap
-description: This skill should be used when the user asks to "create RHDH backend plugin", "bootstrap backend dynamic plugin", "create backstage backend plugin for RHDH", "new backend plugin for Red Hat Developer Hub", "create dynamic backend plugin", "scaffold RHDH backend plugin", "new scaffolder action", "create catalog processor", or mentions creating a new backend plugin, backend module, or server-side functionality for Red Hat Developer Hub or RHDH. This skill is specifically for backend plugins - for frontend plugins, use the separate frontend plugin skill.
+name: create-backend-plugin
+description: Bootstraps a new backend dynamic plugin for Red Hat Developer Hub (RHDH). Use when the user asks to "create RHDH backend plugin", "bootstrap backend dynamic plugin", "create backstage backend plugin for RHDH", "new backend plugin for Red Hat Developer Hub", "create dynamic backend plugin", "scaffold RHDH backend plugin", "new scaffolder action", "create catalog processor", or mentions creating a new backend plugin, backend module, or server-side functionality for Red Hat Developer Hub or RHDH. This skill is specifically for backend plugins - for frontend plugins, use the separate frontend plugin skill.
 ---
 
 ## Purpose
 
-Bootstrap a new **backend** dynamic plugin for Red Hat Developer Hub (RHDH). RHDH is the enterprise-ready Backstage applicationthat supports dynamic plugins - plugins that can be installed or uninstalled without rebuilding the application.
+Bootstrap a new **backend** dynamic plugin for Red Hat Developer Hub (RHDH). RHDH is the enterprise-ready Backstage application that supports dynamic plugins - plugins that can be installed or uninstalled without rebuilding the application.
 
 > **Note:** This skill covers **backend plugins only**. Frontend dynamic plugins have different requirements (Scalprum configuration, mount points, dynamic routes) and are covered in a separate skill.
 
@@ -49,36 +49,40 @@ Check the target RHDH version and find the compatible Backstage version. Consult
 
 Ask the user which RHDH version they are targeting if not specified.
 
-## Step 2: Create Backstage Application
+## Steps 2-3: Create Backstage Application & Backend Plugin
 
-Create a new Backstage application in the current directory using the version-appropriate create-app:
+Use the scaffold script to automate app creation, dependency installation, and plugin generation in one command:
 
 ```bash
-# For RHDH 1.8 (adjust version as needed)
+python skills/create-backend-plugin/scripts/scaffold.py \
+  --rhdh-version 1.9 \
+  --plugin-id my-plugin \
+  --path ./my-app
+```
+
+The script:
+- Looks up the correct `@backstage/create-app` version for the target RHDH release
+- Creates the Backstage app (idempotent — skips if `package.json` already exists)
+- Runs `yarn install`
+- Generates the backend plugin via `yarn new --select backend-plugin --option id=<plugin-id>`
+
+Use `--json` for structured output, or `--create-app-version` to override the auto-detected version. Run with `--help` for all options.
+
+### Manual alternative
+
+If you prefer to run the commands manually:
+
+```bash
+# Step 2: Create Backstage app
+# Consult ../rhdh/references/versions.md for the correct create-app version
 echo "backstage" | npx @backstage/create-app@0.7.3 --path .
-```
-
-After creation, install dependencies:
-
-```bash
 yarn install
+
+# Step 3: Create backend plugin
+yarn new --select backend-plugin --option id=my-plugin
 ```
 
- The only purpose this serves is to ensure you can later create the plugin using the correct version of the Backstage CLI. All development and testing will be done in the plugin directory.
-
-## Step 3: Create Backend Plugin
-
-Generate a new backend plugin using the Backstage CLI:
-
-```bash
-yarn new
-```
-
-When prompted:
-
-1. Select **"backend-plugin"** as the plugin type
-2. Enter a plugin ID (e.g., `my-plugin`)
-3. The plugin will be created at `plugins/<plugin-id>-backend/`
+The only purpose of the Backstage app is to ensure you can create the plugin using the correct version of the Backstage CLI. All development and testing will be done in the plugin directory.
 
 The generated plugin structure:
 
@@ -190,6 +194,8 @@ For local development/testing, copy `dist-dynamic` to RHDH's `dynamic-plugins-ro
 ```bash
 cp -r dist-dynamic /path/to/rhdh/dynamic-plugins-root/<plugin-id>-backend-dynamic
 ```
+
+> **Windows note:** Use `xcopy /E /I dist-dynamic \path\to\rhdh\dynamic-plugins-root\<plugin-id>-backend-dynamic` or `robocopy dist-dynamic \path\to\rhdh\dynamic-plugins-root\<plugin-id>-backend-dynamic /E` instead of `cp -r`.
 
 See `examples/dynamic-plugins.yaml` for a complete configuration example.
 

--- a/skills/create-backend-plugin/SKILL.md
+++ b/skills/create-backend-plugin/SKILL.md
@@ -50,38 +50,17 @@ Ask the user which RHDH version they are targeting if not specified.
 
 ## Step 2: Scaffold App and Plugin
 
-Use the scaffold script to automate app creation, dependency installation, and plugin generation in one command:
+Run the scaffold script from the directory where the app should be created:
 
 ```bash
-python skills/create-backend-plugin/scripts/scaffold.py \
+python scripts/scaffold.py \
   --rhdh-version 1.9 \
-  --plugin-id my-plugin \
-  --path ./my-app
+  --plugin-id my-plugin
 ```
 
-The script:
-- Looks up the correct `@backstage/create-app` version for the target RHDH release
-- Creates the Backstage app (idempotent — skips if `package.json` already exists)
-- Runs `yarn install`
-- Generates the backend plugin via `yarn new --select backend-plugin --option id=<plugin-id>`
+Run `python scripts/scaffold.py --help` for all options (e.g., `--path`, `--create-app-version`, `--json`).
 
-Use `--json` for structured output, or `--create-app-version` to override the auto-detected version. Run with `--help` for all options.
-
-### Manual alternative
-
-If you prefer to run the commands manually:
-
-```bash
-# Step 2: Create Backstage app
-# Consult ../rhdh/references/versions.md for the correct create-app version
-echo "backstage" | npx @backstage/create-app@0.7.3 --path .
-yarn install
-
-# Step 3: Create backend plugin
-yarn new --select backend-plugin --option id=my-plugin
-```
-
-The only purpose of the Backstage app is to ensure you can create the plugin using the correct version of the Backstage CLI. All development and testing will be done in the plugin directory.
+The Backstage app exists only to provide the correct CLI version for plugin generation. All development and testing happens in the plugin directory.
 
 The generated plugin structure:
 

--- a/skills/create-backend-plugin/SKILL.md
+++ b/skills/create-backend-plugin/SKILL.md
@@ -37,11 +37,10 @@ Before starting, ensure the following are available:
 ## Workflow Overview
 
 1. **Determine RHDH Version** - Identify target RHDH version for compatibility
-2. **Create Backstage App** - Scaffold Backstage app with matching version
-3. **Create Backend Plugin** - Generate new backend plugin using Backstage CLI
-4. **Implement Plugin Logic** - Write the plugin code using new backend system
-5. **Export and Package** - Build, export, and package using RHDH CLI (see export-and-package skill)
-6. **Configure for RHDH** - Create dynamic-plugins.yaml configuration
+2. **Scaffold App and Plugin** - Create Backstage app and generate backend plugin
+3. **Implement Plugin Logic** - Write the plugin code using new backend system
+4. **Export and Package** - Build, export, and package using RHDH CLI (see export-and-package skill)
+5. **Configure for RHDH** - Create dynamic-plugins.yaml configuration
 
 ## Step 1: Determine RHDH Version
 
@@ -49,7 +48,7 @@ Check the target RHDH version and find the compatible Backstage version. Consult
 
 Ask the user which RHDH version they are targeting if not specified.
 
-## Steps 2-3: Create Backstage Application & Backend Plugin
+## Step 2: Scaffold App and Plugin
 
 Use the scaffold script to automate app creation, dependency installation, and plugin generation in one command:
 
@@ -97,7 +96,7 @@ plugins/<plugin-id>-backend/
 └── README.md
 ```
 
-## Step 4: Implement Plugin Logic
+## Step 3: Implement Plugin Logic
 
 Backend plugins must use the **new backend system** for dynamic plugin compatibility. The plugin entry point should export a default using `createBackendPlugin()` or `createBackendModule()`.
 
@@ -151,7 +150,7 @@ cd plugins/<plugin-id>-backend
 yarn build
 ```
 
-## Step 5: Export and Package
+## Step 4: Export and Package
 
 Export the plugin as a dynamic plugin and package it for deployment. For detailed export and packaging options, see the **export-and-package** skill.
 
@@ -175,7 +174,7 @@ podman push quay.io/<namespace>/<plugin-name>:v0.1.0
 
 For advanced options (dependency handling, multi-plugin bundles, tgz/npm packaging), consult the **export-and-package** skill.
 
-## Step 6: Configure for RHDH
+## Step 5: Configure for RHDH
 
 Create the dynamic plugin configuration for RHDH. Add to `dynamic-plugins.yaml`:
 

--- a/skills/create-backend-plugin/scripts/scaffold.py
+++ b/skills/create-backend-plugin/scripts/scaffold.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+"""Scaffold a Backstage app and backend plugin for RHDH.
+
+Automates Steps 2-3 of the create-backend-plugin workflow:
+  1. Creates a Backstage app using the correct create-app version for the
+     target RHDH release.
+  2. Runs yarn install.
+  3. Generates a backend plugin via `yarn new`.
+
+Uses only Python stdlib (no external dependencies).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+# ─── RHDH → create-app version mapping (from versions.md) ───────────────────
+
+RHDH_VERSION_MAP: dict[str, str] = {
+    "next": "0.7.6",
+    "1.9": "0.7.6",
+    "1.8": "0.7.3",
+    "1.7": "0.6.2",
+    "1.6": "0.5.25",
+}
+
+SUPPORTED_VERSIONS = sorted(
+    (v for v in RHDH_VERSION_MAP if v != "next"),
+    key=lambda v: list(map(int, v.split("."))),
+    reverse=True,
+)
+
+# ─── ANSI helpers ────────────────────────────────────────────────────────────
+
+RED = "\033[0;31m"
+GREEN = "\033[0;32m"
+YELLOW = "\033[1;33m"
+BLUE = "\033[0;34m"
+BOLD = "\033[1m"
+NC = "\033[0m"
+
+
+def _color(code: str, text: str) -> str:
+    if sys.stdout.isatty():
+        return f"{code}{text}{NC}"
+    return text
+
+
+# ─── Validation ──────────────────────────────────────────────────────────────
+
+PLUGIN_ID_RE = re.compile(r"^[a-z][a-z0-9]*(-[a-z0-9]+)*$")
+
+
+def validate_plugin_id(value: str) -> str:
+    """Validate plugin ID is a lowercase kebab-case identifier."""
+    if not PLUGIN_ID_RE.match(value):
+        raise argparse.ArgumentTypeError(
+            f"Invalid plugin ID '{value}'. "
+            "Must be lowercase kebab-case (e.g., 'my-plugin')."
+        )
+    return value
+
+
+def validate_rhdh_version(value: str) -> str:
+    """Validate RHDH version is in the known map."""
+    if value not in RHDH_VERSION_MAP:
+        supported = ", ".join(["next", *SUPPORTED_VERSIONS])
+        raise argparse.ArgumentTypeError(
+            f"Unknown RHDH version '{value}'. Supported: {supported}"
+        )
+    return value
+
+
+# ─── Tool checks ─────────────────────────────────────────────────────────────
+
+
+def check_tool(name: str) -> str | None:
+    """Return path to tool or None if missing."""
+    return shutil.which(name)
+
+
+def check_prerequisites() -> list[str]:
+    """Return list of missing prerequisite tools."""
+    missing = []
+    for tool in ("npx", "yarn", "node"):
+        if not check_tool(tool):
+            missing.append(tool)
+    return missing
+
+
+# ─── Subprocess helpers ──────────────────────────────────────────────────────
+
+
+def run_cmd(
+    args: list[str],
+    *,
+    cwd: Path | None = None,
+    stdin_text: str | None = None,
+    description: str = "",
+    use_json: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    """Run a command, stream output in human mode, capture in JSON mode."""
+    if not use_json:
+        print(f"  {_color(BLUE, '→')} {description or ' '.join(args)}")
+
+    try:
+        result = subprocess.run(
+            args,
+            cwd=cwd,
+            input=stdin_text,
+            capture_output=use_json,
+            text=True,
+            # On Windows, shell=True is needed for npx/yarn .cmd scripts
+            shell=(os.name == "nt"),
+        )
+    except FileNotFoundError as exc:
+        msg = f"Command not found: {args[0]}"
+        if use_json:
+            _json_error("COMMAND_NOT_FOUND", msg)
+        else:
+            print(f"  {_color(RED, '✗')} {msg}: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if result.returncode != 0:
+        msg = f"Command failed (exit {result.returncode}): {' '.join(args)}"
+        if use_json:
+            stderr_text = getattr(result, "stderr", "") or ""
+            _json_error("COMMAND_FAILED", msg, detail=stderr_text.strip())
+        else:
+            print(f"  {_color(RED, '✗')} {msg}", file=sys.stderr)
+        sys.exit(1)
+
+    return result
+
+
+# ─── Output helpers ──────────────────────────────────────────────────────────
+
+
+def _json_error(
+    code: str, message: str, *, detail: str = "", exit_code: int = 1
+) -> None:
+    """Print a JSON error and exit."""
+    resp: dict = {"success": False, "error": {"code": code, "message": message}}
+    if detail:
+        resp["error"]["detail"] = detail
+    print(json.dumps(resp, indent=2))
+    sys.exit(exit_code)
+
+
+def _json_success(data: dict) -> None:
+    """Print a JSON success payload."""
+    print(json.dumps({"success": True, **data}, indent=2))
+
+
+# ─── Core workflow ───────────────────────────────────────────────────────────
+
+
+def scaffold(
+    *,
+    rhdh_version: str,
+    plugin_id: str,
+    app_path: Path,
+    create_app_version: str,
+    use_json: bool,
+) -> None:
+    """Run the full scaffold workflow (Steps 2-3)."""
+
+    plugin_dir_name = f"{plugin_id}-backend"
+    plugin_path = app_path / "plugins" / plugin_dir_name
+
+    # ── Idempotency: check if plugin already exists ──────────────────────
+    if plugin_path.exists():
+        msg = f"Plugin directory already exists: {plugin_path}"
+        if use_json:
+            _json_error("ALREADY_EXISTS", msg)
+        else:
+            print(f"  {_color(YELLOW, '⚠')} {msg}")
+            print("  Remove it first if you want to re-scaffold.")
+        sys.exit(1)
+
+    # ── Step 2a: Create Backstage app ────────────────────────────────────
+    app_pkg_json = app_path / "package.json"
+    if app_pkg_json.exists():
+        if not use_json:
+            print(
+                f"  {_color(GREEN, '✓')} Backstage app already exists at "
+                f"{app_path} — skipping create-app"
+            )
+    else:
+        if not use_json:
+            print(
+                f"\n{_color(BOLD, 'Step 2: Create Backstage app')}"
+                f" (create-app@{create_app_version})"
+            )
+
+        # Ensure parent directory exists
+        app_path.mkdir(parents=True, exist_ok=True)
+
+        run_cmd(
+            [
+                "npx",
+                f"@backstage/create-app@{create_app_version}",
+                "--path",
+                str(app_path),
+            ],
+            stdin_text="backstage\n",
+            description=(
+                f"npx @backstage/create-app@{create_app_version} "
+                f"--path {app_path}"
+            ),
+            use_json=use_json,
+        )
+
+    # ── Step 2b: yarn install ────────────────────────────────────────────
+    if not use_json:
+        print(f"\n  {_color(BLUE, '→')} Running yarn install …")
+
+    run_cmd(
+        ["yarn", "install"],
+        cwd=app_path,
+        description="yarn install",
+        use_json=use_json,
+    )
+
+    # ── Step 3: Create backend plugin ────────────────────────────────────
+    if not use_json:
+        print(
+            f"\n{_color(BOLD, 'Step 3: Create backend plugin')} "
+            f"(id={plugin_id})"
+        )
+
+    run_cmd(
+        [
+            "yarn",
+            "new",
+            "--select",
+            "backend-plugin",
+            "--option",
+            f"id={plugin_id}",
+        ],
+        cwd=app_path,
+        description=f"yarn new --select backend-plugin --option id={plugin_id}",
+        use_json=use_json,
+    )
+
+    # ── Summary ──────────────────────────────────────────────────────────
+    if not plugin_path.exists():
+        msg = (
+            f"Expected plugin directory not found at {plugin_path}. "
+            "The scaffold command may have used a different naming convention."
+        )
+        if use_json:
+            _json_error("PLUGIN_DIR_MISSING", msg)
+        else:
+            print(f"  {_color(YELLOW, '⚠')} {msg}")
+        sys.exit(1)
+
+    if use_json:
+        _json_success(
+            {
+                "rhdh_version": rhdh_version,
+                "create_app_version": create_app_version,
+                "plugin_id": plugin_id,
+                "app_path": str(app_path.resolve()),
+                "plugin_path": str(plugin_path.resolve()),
+            }
+        )
+    else:
+        print(f"\n{_color(GREEN, '✓')} Scaffold complete!")
+        print(f"  RHDH version:      {rhdh_version}")
+        print(f"  create-app:        @backstage/create-app@{create_app_version}")
+        print(f"  Plugin ID:         {plugin_id}")
+        print(f"  App path:          {app_path.resolve()}")
+        print(f"  Plugin path:       {plugin_path.resolve()}")
+        print(f"\n{_color(BOLD, 'Next steps:')}")
+        print(f"  cd {plugin_path}")
+        print("  # Implement plugin logic in src/plugin.ts")
+        print("  yarn build")
+
+
+# ─── CLI ─────────────────────────────────────────────────────────────────────
+
+
+def build_parser() -> argparse.ArgumentParser:
+    supported = ", ".join(["next", *SUPPORTED_VERSIONS])
+    parser = argparse.ArgumentParser(
+        description=(
+            "Scaffold a Backstage app and backend plugin for Red Hat Developer Hub. "
+            "Automates Steps 2-3 of the create-backend-plugin workflow: creates the "
+            "Backstage app with the correct create-app version, installs dependencies, "
+            "and generates the backend plugin."
+        ),
+        epilog=f"Supported RHDH versions: {supported}",
+    )
+    parser.add_argument(
+        "--rhdh-version",
+        required=True,
+        type=validate_rhdh_version,
+        metavar="VERSION",
+        help=f"Target RHDH version ({supported})",
+    )
+    parser.add_argument(
+        "--plugin-id",
+        required=True,
+        type=validate_plugin_id,
+        metavar="ID",
+        help="Plugin identifier in kebab-case (e.g., 'my-plugin')",
+    )
+    parser.add_argument(
+        "--path",
+        default=".",
+        metavar="DIR",
+        help="Directory in which to create the Backstage app (default: current dir)",
+    )
+    parser.add_argument(
+        "--create-app-version",
+        default=None,
+        metavar="VERSION",
+        help="Override the auto-detected @backstage/create-app version",
+    )
+    parser.add_argument(
+        "--json",
+        dest="use_json",
+        action="store_true",
+        default=False,
+        help="Output structured JSON instead of human-readable text",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    use_json: bool = args.use_json
+
+    # ── Resolve create-app version ───────────────────────────────────────
+    create_app_version = args.create_app_version or RHDH_VERSION_MAP[args.rhdh_version]
+
+    # ── Check prerequisites ──────────────────────────────────────────────
+    missing = check_prerequisites()
+    if missing:
+        msg = f"Missing required tools: {', '.join(missing)}"
+        next_steps = [f"Install {tool} and ensure it is on PATH" for tool in missing]
+        if use_json:
+            _json_error(
+                "MISSING_TOOLS",
+                msg,
+                detail="; ".join(next_steps),
+            )
+        else:
+            print(f"  {_color(RED, '✗')} {msg}", file=sys.stderr)
+            for step in next_steps:
+                print(f"    - {step}", file=sys.stderr)
+        return 1
+
+    # ── Resolve path ─────────────────────────────────────────────────────
+    app_path = Path(args.path).resolve()
+
+    if not use_json:
+        print(
+            f"{_color(BOLD, 'Scaffolding backend plugin for RHDH')} "
+            f"{args.rhdh_version}"
+        )
+
+    scaffold(
+        rhdh_version=args.rhdh_version,
+        plugin_id=args.plugin_id,
+        app_path=app_path,
+        create_app_version=create_app_version,
+        use_json=use_json,
+    )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/create-backend-plugin/scripts/scaffold.py
+++ b/skills/create-backend-plugin/scripts/scaffold.py
@@ -356,13 +356,23 @@ def main(argv: list[str] | None = None) -> int:
     if not use_json:
         print(f"{_color(BOLD, 'Scaffolding backend plugin for RHDH')} {args.rhdh_version}")
 
-    scaffold(
-        rhdh_version=args.rhdh_version,
-        plugin_id=args.plugin_id,
-        app_path=app_path,
-        create_app_version=create_app_version,
-        use_json=use_json,
-    )
+    try:
+        scaffold(
+            rhdh_version=args.rhdh_version,
+            plugin_id=args.plugin_id,
+            app_path=app_path,
+            create_app_version=create_app_version,
+            use_json=use_json,
+        )
+    except (OSError, PermissionError) as exc:
+        if use_json:
+            _json_error("PATH_ERROR", str(exc))
+        else:
+            print(f"  {_color(RED, '✗')} {exc}", file=sys.stderr)
+        return 1
+    except KeyboardInterrupt:
+        print("\nInterrupted.", file=sys.stderr)
+        return 130
 
     return 0
 

--- a/skills/create-backend-plugin/scripts/scaffold.py
+++ b/skills/create-backend-plugin/scripts/scaffold.py
@@ -62,8 +62,7 @@ def validate_plugin_id(value: str) -> str:
     """Validate plugin ID is a lowercase kebab-case identifier."""
     if not PLUGIN_ID_RE.match(value):
         raise argparse.ArgumentTypeError(
-            f"Invalid plugin ID '{value}'. "
-            "Must be lowercase kebab-case (e.g., 'my-plugin')."
+            f"Invalid plugin ID '{value}'. Must be lowercase kebab-case (e.g., 'my-plugin')."
         )
     return value
 
@@ -72,9 +71,7 @@ def validate_rhdh_version(value: str) -> str:
     """Validate RHDH version is in the known map."""
     if value not in RHDH_VERSION_MAP:
         supported = ", ".join(["next", *SUPPORTED_VERSIONS])
-        raise argparse.ArgumentTypeError(
-            f"Unknown RHDH version '{value}'. Supported: {supported}"
-        )
+        raise argparse.ArgumentTypeError(f"Unknown RHDH version '{value}'. Supported: {supported}")
     return value
 
 
@@ -143,9 +140,7 @@ def run_cmd(
 # ─── Output helpers ──────────────────────────────────────────────────────────
 
 
-def _json_error(
-    code: str, message: str, *, detail: str = "", exit_code: int = 1
-) -> None:
+def _json_error(code: str, message: str, *, detail: str = "", exit_code: int = 1) -> None:
     """Print a JSON error and exit."""
     resp: dict = {"success": False, "error": {"code": code, "message": message}}
     if detail:
@@ -211,10 +206,7 @@ def scaffold(
                 str(app_path),
             ],
             stdin_text="backstage\n",
-            description=(
-                f"npx @backstage/create-app@{create_app_version} "
-                f"--path {app_path}"
-            ),
+            description=(f"npx @backstage/create-app@{create_app_version} --path {app_path}"),
             use_json=use_json,
         )
 
@@ -231,10 +223,7 @@ def scaffold(
 
     # ── Step 3: Create backend plugin ────────────────────────────────────
     if not use_json:
-        print(
-            f"\n{_color(BOLD, 'Step 3: Create backend plugin')} "
-            f"(id={plugin_id})"
-        )
+        print(f"\n{_color(BOLD, 'Step 3: Create backend plugin')} (id={plugin_id})")
 
     run_cmd(
         [
@@ -365,10 +354,7 @@ def main(argv: list[str] | None = None) -> int:
     app_path = Path(args.path).resolve()
 
     if not use_json:
-        print(
-            f"{_color(BOLD, 'Scaffolding backend plugin for RHDH')} "
-            f"{args.rhdh_version}"
-        )
+        print(f"{_color(BOLD, 'Scaffolding backend plugin for RHDH')} {args.rhdh_version}")
 
     scaffold(
         rhdh_version=args.rhdh_version,

--- a/skills/create-frontend-plugin/SKILL.md
+++ b/skills/create-frontend-plugin/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: RHDH Frontend Dynamic Plugin Bootstrap
+name: create-frontend-plugin
 description: This skill should be used when the user asks to "create RHDH frontend plugin", "bootstrap frontend dynamic plugin", "create UI plugin for RHDH", "new frontend plugin for Red Hat Developer Hub", "add entity card to RHDH", "create dynamic route", "add sidebar menu item", "configure mount points", "create theme plugin", or mentions creating frontend components, UI pages, entity cards, or visual customizations for Red Hat Developer Hub or RHDH. This skill is specifically for frontend plugins - for backend plugins, use the separate backend plugin skill.
 ---
 
@@ -41,11 +41,12 @@ Before starting, ensure the following are available:
 
 1. **Determine RHDH Version** - Identify target RHDH version for compatibility
 2. **Create Backstage App** - Scaffold Backstage app with matching version
-3. **Create Frontend Plugin** - Generate new frontend plugin using Backstage CLI
-4. **Implement Plugin Components** - Build React components and exports
-5. **Configure Scalprum** - Set up module federation for dynamic loading
-6. **Export and Package** - Build, export, and package using RHDH CLI (see export-and-package skill)
-7. **Configure Plugin Wiring** - Define routes, mount points, and menu items
+3. **Configure RHDH Themes (Optional)** - Add RHDH theme to Backstage app
+4. **Create Frontend Dynamic Plugin** - Generate new frontend plugin using Backstage CLI
+5. **Apply RHDH Theme Configuration** - Configure RHDH theme in development harness
+6. **Implement Plugin Components** - Build React components and exports
+7. **Export and Package** - Build, export, and package using RHDH CLI (see export-and-package skill)
+8. **Configure Plugin Wiring** - Define routes, mount points, and menu items
 
 ## Step 1: Determine RHDH Version
 
@@ -54,6 +55,21 @@ Check the target RHDH version and find the compatible Backstage version. Consult
 Ask the user which RHDH version they are targeting if not specified.
 
 ## Step 2: Create Backstage Application
+
+> **Automated:** Steps 2 + 4 (and optionally 3) are automated by the scaffold script.
+> Run it from the directory where the app should be created:
+>
+> ```bash
+> python scripts/scaffold.py --rhdh-version 1.9 --plugin-id my-plugin
+> # With RHDH theme:
+> python scripts/scaffold.py --rhdh-version 1.9 --plugin-id my-plugin --with-theme
+> # JSON output:
+> python scripts/scaffold.py --rhdh-version 1.9 --plugin-id my-plugin --json
+> ```
+>
+> See `python scripts/scaffold.py --help` for all options.
+
+### Manual method
 
 Create a new Backstage application in the current directory using the version-appropriate create-app:
 
@@ -68,7 +84,7 @@ After creation, install dependencies:
 yarn install
 ```
 
-## Step 3: Decide if you want to use RHDH themes
+## Step 3: Configure RHDH Themes (Optional)
 
 If you want to use RHDH themes, follow the steps below. If you don't want to use RHDH themes, skip to Step 4.
 
@@ -92,7 +108,11 @@ const app = createApp({
 });
 ```
 
-## Step 3: Create Frontend Plugin
+## Step 4: Create Frontend Dynamic Plugin
+
+> **Automated:** If you used `scripts/scaffold.py` in Step 2, this step was already completed. Skip to Step 5.
+
+### Manual method
 
 Generate a new frontend plugin:
 
@@ -117,7 +137,7 @@ plugins/<plugin-id>/
     └── index.tsx             # Development harness
 ```
 
-## Step 4: If you decided to use RHDH themes, add RHDH Theme to Development Harness
+## Step 5: Apply RHDH Theme Configuration
 
 By default, `yarn start` uses standard Backstage themes. To preview your plugin with RHDH styling during local development, configure the RHDH theme package.
 
@@ -156,7 +176,7 @@ createDevApp()
 
 > **Note:** When deployed to RHDH, the application shell provides theming automatically. This configuration is only needed for local development.
 
-## Step 5: Implement Plugin Components
+## Step 6: Implement Plugin Components
 
 ### Page Component
 
@@ -215,7 +235,7 @@ cd plugins/<plugin-id>
 yarn build
 ```
 
-## Step 6: Export and Package
+## Step 7: Export and Package
 
 Export the plugin as a dynamic plugin and package it for deployment. For detailed export and packaging options, see the **export-and-package** skill.
 
@@ -239,7 +259,7 @@ podman push quay.io/<namespace>/<plugin-name>:v0.1.0
 
 For advanced options (custom Scalprum config, multi-plugin bundles, tgz/npm packaging), consult the **export-and-package** skill.
 
-## Step 7: Configure Plugin Wiring
+## Step 8: Configure Plugin Wiring
 
 Frontend plugins require configuration in `dynamic-plugins.yaml` to define how they integrate with RHDH.
 
@@ -299,6 +319,10 @@ Apply spacing manually to MUI v5 Grid:
 </Grid>
 ```
 
+### Scalprum Name Mismatch
+
+The `scalprum.name` in `package.json` (auto-generated during export) must match the key under `dynamicPlugins.frontend.<key>` in `dynamic-plugins.yaml`. If you customize `scalprum.name`, update the wiring config to match. Default derivation: `@my-org/backstage-plugin-foo` → `my-org.backstage-plugin-foo`.
+
 ## Additional Resources
 
 ### Related Skills
@@ -308,8 +332,8 @@ Apply spacing manually to MUI v5 Grid:
 
 ### Reference Files
 
-- **`references/frontend-wiring.md`** - Complete mount points, routes, bindings
-- **`references/entity-page.md`** - Entity page customization
+- **`../generate-frontend-wiring/references/frontend-wiring.md`** - Complete mount points, routes, bindings
+- **`../generate-frontend-wiring/references/entity-page.md`** - Entity page customization
 
 ### Example Files
 

--- a/skills/create-frontend-plugin/SKILL.md
+++ b/skills/create-frontend-plugin/SKILL.md
@@ -56,33 +56,13 @@ Ask the user which RHDH version they are targeting if not specified.
 
 ## Step 2: Create Backstage Application
 
-> **Automated:** This step plus Step 4 (and optionally Step 3) are automated by the scaffold script.
-> Run it from the directory where the app should be created:
->
-> ```bash
-> python scripts/scaffold.py --rhdh-version 1.9 --plugin-id my-plugin
-> # With RHDH theme:
-> python scripts/scaffold.py --rhdh-version 1.9 --plugin-id my-plugin --with-theme
-> # JSON output:
-> python scripts/scaffold.py --rhdh-version 1.9 --plugin-id my-plugin --json
-> ```
->
-> See `python scripts/scaffold.py --help` for all options.
-
-### Manual method
-
-Create a new Backstage application in the current directory using the version-appropriate create-app:
+Run the scaffold script from the directory where the app should be created. This handles app creation, dependency installation, and plugin generation (Step 4) in one command:
 
 ```bash
-# For RHDH 1.8 (adjust version as needed)
-echo "backstage" | npx @backstage/create-app@0.7.3 --path .
+python scripts/scaffold.py --rhdh-version 1.9 --plugin-id my-plugin
 ```
 
-After creation, install dependencies:
-
-```bash
-yarn install
-```
+Add `--with-theme` to also install the RHDH theme package (Step 3). Run `python scripts/scaffold.py --help` for all options.
 
 ## Step 3: Configure RHDH Themes (Optional)
 
@@ -110,17 +90,13 @@ const app = createApp({
 
 ## Step 4: Create Frontend Dynamic Plugin
 
-> **Automated:** If you used the scaffold script in Step 2, this step was already completed. Skip to Step 5.
+If you used the scaffold script in Step 2, this step was already completed — skip to Step 5.
 
-### Manual method
-
-Generate a new frontend plugin:
+Otherwise, generate the plugin manually:
 
 ```bash
 yarn new --select frontend-plugin --option id=<plugin-id>
 ```
-
-The plugin will be created at `plugins/<plugin-id>/`
 
 Generated structure:
 

--- a/skills/create-frontend-plugin/SKILL.md
+++ b/skills/create-frontend-plugin/SKILL.md
@@ -56,7 +56,7 @@ Ask the user which RHDH version they are targeting if not specified.
 
 ## Step 2: Create Backstage Application
 
-> **Automated:** Steps 2 + 4 (and optionally 3) are automated by the scaffold script.
+> **Automated:** This step plus Step 4 (and optionally Step 3) are automated by the scaffold script.
 > Run it from the directory where the app should be created:
 >
 > ```bash
@@ -110,7 +110,7 @@ const app = createApp({
 
 ## Step 4: Create Frontend Dynamic Plugin
 
-> **Automated:** If you used `scripts/scaffold.py` in Step 2, this step was already completed. Skip to Step 5.
+> **Automated:** If you used the scaffold script in Step 2, this step was already completed. Skip to Step 5.
 
 ### Manual method
 

--- a/skills/create-frontend-plugin/scripts/scaffold.py
+++ b/skills/create-frontend-plugin/scripts/scaffold.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+"""Scaffold a Backstage app and frontend dynamic plugin for RHDH.
+
+Automates Steps 2 + 4 of the create-frontend-plugin workflow:
+  Step 2: Create Backstage app with version-matched create-app
+  Step 4: Generate frontend plugin via `yarn new`
+
+Optionally installs RHDH theme package (Step 3).
+
+Uses only Python stdlib per project ADR-0002.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# RHDH version → @backstage/create-app version mapping
+# Source: skills/rhdh/references/versions.md
+# ---------------------------------------------------------------------------
+VERSION_MAP: dict[str, str] = {
+    "next": "0.7.6",
+    "1.9": "0.7.6",
+    "1.8": "0.7.3",
+    "1.7": "0.6.2",
+    "1.6": "0.5.25",
+}
+
+RHDH_THEME_PACKAGE = "@red-hat-developer-hub/backstage-plugin-theme"
+
+# Exit codes
+EXIT_SUCCESS = 0
+EXIT_FAILURE = 1
+EXIT_USAGE = 2
+
+# ANSI colors (disabled when not a TTY or --json)
+_is_tty = sys.stdout.isatty()
+
+
+def _c(code: str, text: str) -> str:
+    if _is_tty:
+        return f"{code}{text}\033[0m"
+    return text
+
+
+def green(t: str) -> str:
+    return _c("\033[0;32m", t)
+
+
+def red(t: str) -> str:
+    return _c("\033[0;31m", t)
+
+
+def yellow(t: str) -> str:
+    return _c("\033[1;33m", t)
+
+
+def blue(t: str) -> str:
+    return _c("\033[0;34m", t)
+
+
+def bold(t: str) -> str:
+    return _c("\033[1m", t)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def log(msg: str) -> None:
+    """Print to stderr so it doesn't interfere with --json on stdout."""
+    print(msg, file=sys.stderr)
+
+
+def log_step(msg: str) -> None:
+    log(f"  {blue('→')} {msg}")
+
+
+def log_ok(msg: str) -> None:
+    log(f"  {green('✓')} {msg}")
+
+
+def log_fail(msg: str) -> None:
+    log(f"  {red('✗')} {msg}")
+
+
+def run(
+    cmd: list[str],
+    *,
+    cwd: Path | None = None,
+    stdin_text: str | None = None,
+    use_json: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    """Run a subprocess, logging the command. Raises on failure."""
+    display = " ".join(cmd)
+    if stdin_text:
+        display = f"echo {stdin_text!r} | {display}"
+    log_step(f"Running: {display}")
+
+    # On Windows, shell=True is needed for npx/yarn from PATH
+    use_shell = sys.platform == "win32"
+
+    result = subprocess.run(
+        cmd,
+        cwd=cwd,
+        input=stdin_text,
+        capture_output=False,
+        text=True,
+        shell=use_shell,
+    )
+    if result.returncode != 0:
+        log_fail(f"Command failed (exit {result.returncode}): {display}")
+        if not use_json:
+            sys.exit(EXIT_FAILURE)
+        else:
+            # Let caller handle structured error
+            raise subprocess.CalledProcessError(result.returncode, cmd)
+    log_ok(f"Done: {cmd[0]}")
+    return result
+
+
+def resolve_create_app_version(rhdh_version: str) -> str | None:
+    """Look up the create-app version for an RHDH version."""
+    return VERSION_MAP.get(rhdh_version)
+
+
+def check_plugin_exists(app_path: Path, plugin_id: str) -> bool:
+    """Check if plugin directory already exists (idempotency)."""
+    return (app_path / "plugins" / plugin_id).is_dir()
+
+
+def check_app_exists(app_path: Path) -> bool:
+    """Check if a Backstage app already exists at path."""
+    return (app_path / "package.json").is_file() and (
+        app_path / "packages" / "app"
+    ).is_dir()
+
+
+# ---------------------------------------------------------------------------
+# Main workflow
+# ---------------------------------------------------------------------------
+
+
+def scaffold(args: argparse.Namespace) -> dict:
+    """Run the scaffold workflow. Returns a result dict."""
+    rhdh_version: str = args.rhdh_version
+    plugin_id: str = args.plugin_id
+    app_path = Path(args.path).resolve()
+    with_theme: bool = args.with_theme
+    use_json: bool = args.json
+
+    # Resolve create-app version
+    if args.create_app_version:
+        create_app_version = args.create_app_version
+    else:
+        create_app_version = resolve_create_app_version(rhdh_version)
+        if create_app_version is None:
+            known = ", ".join(sorted(VERSION_MAP.keys()))
+            msg = (
+                f"Unknown RHDH version '{rhdh_version}'. "
+                f"Known versions: {known}. "
+                f"Use --create-app-version to override."
+            )
+            if use_json:
+                return {
+                    "success": False,
+                    "error": {"code": "UNKNOWN_RHDH_VERSION", "message": msg},
+                }
+            log_fail(msg)
+            sys.exit(EXIT_USAGE)
+
+    result: dict = {
+        "success": True,
+        "rhdh_version": rhdh_version,
+        "create_app_version": create_app_version,
+        "plugin_id": plugin_id,
+        "app_path": str(app_path),
+        "with_theme": with_theme,
+        "steps_completed": [],
+    }
+
+    log(bold(f"\nScaffolding frontend plugin '{plugin_id}' for RHDH {rhdh_version}"))
+    log(f"  App path:          {app_path}")
+    log(f"  create-app version: {create_app_version}")
+    log(f"  Theme:             {'yes' if with_theme else 'no'}\n")
+
+    # ------------------------------------------------------------------
+    # Step 2: Create Backstage app (idempotent)
+    # ------------------------------------------------------------------
+    if check_app_exists(app_path):
+        log_ok("Backstage app already exists — skipping create-app")
+        result["steps_completed"].append("create-app (skipped, already exists)")
+    else:
+        log(bold("Step 2: Creating Backstage application"))
+        app_path.mkdir(parents=True, exist_ok=True)
+        try:
+            run(
+                [
+                    "npx",
+                    f"@backstage/create-app@{create_app_version}",
+                    "--path",
+                    str(app_path),
+                ],
+                stdin_text="backstage\n",
+                use_json=use_json,
+            )
+        except subprocess.CalledProcessError:
+            result["success"] = False
+            result["error"] = {
+                "code": "CREATE_APP_FAILED",
+                "message": "npx @backstage/create-app failed",
+            }
+            return result
+        result["steps_completed"].append("create-app")
+
+    # yarn install
+    if not (app_path / "node_modules").is_dir():
+        log(bold("Installing dependencies"))
+        try:
+            run(["yarn", "install"], cwd=app_path, use_json=use_json)
+        except subprocess.CalledProcessError:
+            result["success"] = False
+            result["error"] = {
+                "code": "YARN_INSTALL_FAILED",
+                "message": "yarn install failed",
+            }
+            return result
+        result["steps_completed"].append("yarn install")
+    else:
+        log_ok("node_modules exists — skipping yarn install")
+        result["steps_completed"].append("yarn install (skipped, already exists)")
+
+    # ------------------------------------------------------------------
+    # Step 3 (optional): Install RHDH theme
+    # ------------------------------------------------------------------
+    if with_theme:
+        log(bold("Step 3: Installing RHDH theme package"))
+        try:
+            run(
+                ["yarn", "workspace", "app", "add", RHDH_THEME_PACKAGE],
+                cwd=app_path,
+                use_json=use_json,
+            )
+        except subprocess.CalledProcessError:
+            result["success"] = False
+            result["error"] = {
+                "code": "THEME_INSTALL_FAILED",
+                "message": f"Failed to install {RHDH_THEME_PACKAGE}",
+            }
+            return result
+        result["steps_completed"].append("install-theme")
+
+    # ------------------------------------------------------------------
+    # Step 4: Create frontend plugin (idempotent)
+    # ------------------------------------------------------------------
+    if check_plugin_exists(app_path, plugin_id):
+        log_ok(f"Plugin '{plugin_id}' already exists — skipping yarn new")
+        result["steps_completed"].append("yarn new (skipped, already exists)")
+    else:
+        log(bold("Step 4: Creating frontend plugin"))
+        try:
+            run(
+                [
+                    "yarn",
+                    "new",
+                    "--select",
+                    "frontend-plugin",
+                    "--option",
+                    f"id={plugin_id}",
+                ],
+                cwd=app_path,
+                use_json=use_json,
+            )
+        except subprocess.CalledProcessError:
+            result["success"] = False
+            result["error"] = {
+                "code": "YARN_NEW_FAILED",
+                "message": "yarn new --select frontend-plugin failed",
+            }
+            return result
+        result["steps_completed"].append("yarn new")
+
+    # ------------------------------------------------------------------
+    # Summary
+    # ------------------------------------------------------------------
+    plugin_path = app_path / "plugins" / plugin_id
+    result["plugin_path"] = str(plugin_path)
+
+    if not use_json:
+        log(bold("\n✅ Scaffold complete!\n"))
+        log(f"  Plugin location: {plugin_path}")
+        log(f"  RHDH version:    {rhdh_version}")
+        log(f"  Steps completed: {', '.join(result['steps_completed'])}")
+        log(bold("\nNext steps:"))
+        log(f"  1. cd {app_path}")
+        log(f"  2. Implement components in plugins/{plugin_id}/src/")
+        if with_theme:
+            log(
+                f"  3. Configure theme in plugins/{plugin_id}/dev/index.tsx "
+                "(see SKILL.md Step 5)"
+            )
+        log(f"  {'4' if with_theme else '3'}. yarn build")
+        log(
+            f"  {'5' if with_theme else '4'}. "
+            "npx @red-hat-developer-hub/cli@latest plugin export"
+        )
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="scaffold",
+        description=(
+            "Scaffold a Backstage app and frontend dynamic plugin for RHDH.\n\n"
+            "Automates Steps 2+4 of the create-frontend-plugin skill:\n"
+            "  Step 2: Create Backstage app with the correct create-app version\n"
+            "  Step 4: Generate a new frontend plugin via yarn new\n\n"
+            "Optionally installs the RHDH theme package (Step 3)."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "examples:\n"
+            "  %(prog)s --rhdh-version 1.9 --plugin-id my-plugin\n"
+            "  %(prog)s --rhdh-version 1.8 --plugin-id my-card --with-theme\n"
+            "  %(prog)s --rhdh-version 1.7 --plugin-id foo --path ./my-app --json\n"
+            "  %(prog)s --rhdh-version next --plugin-id bar "
+            "--create-app-version 0.7.6\n"
+        ),
+    )
+
+    parser.add_argument(
+        "--rhdh-version",
+        required=True,
+        metavar="VERSION",
+        help=(
+            f"Target RHDH version. "
+            f"Known: {', '.join(sorted(VERSION_MAP.keys()))}."
+        ),
+    )
+    parser.add_argument(
+        "--plugin-id",
+        required=True,
+        metavar="ID",
+        help="Plugin identifier (e.g. 'my-plugin'). Creates plugins/<ID>/.",
+    )
+    parser.add_argument(
+        "--path",
+        default=".",
+        metavar="DIR",
+        help="Directory in which to create the Backstage app (default: '.').",
+    )
+    parser.add_argument(
+        "--create-app-version",
+        default=None,
+        metavar="VER",
+        help="Override the auto-detected @backstage/create-app version.",
+    )
+    parser.add_argument(
+        "--with-theme",
+        action="store_true",
+        help="Also install the RHDH theme package in the app workspace.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output structured JSON result to stdout.",
+    )
+
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    try:
+        result = scaffold(args)
+    except KeyboardInterrupt:
+        log("\nInterrupted.")
+        sys.exit(130)
+    except Exception as exc:
+        if args.json:
+            print(
+                json.dumps(
+                    {
+                        "success": False,
+                        "error": {
+                            "code": "UNEXPECTED_ERROR",
+                            "message": str(exc),
+                        },
+                    },
+                    indent=2,
+                )
+            )
+            sys.exit(EXIT_FAILURE)
+        raise
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+
+    sys.exit(EXIT_SUCCESS if result.get("success") else EXIT_FAILURE)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/create-frontend-plugin/scripts/scaffold.py
+++ b/skills/create-frontend-plugin/scripts/scaffold.py
@@ -136,9 +136,7 @@ def check_plugin_exists(app_path: Path, plugin_id: str) -> bool:
 
 def check_app_exists(app_path: Path) -> bool:
     """Check if a Backstage app already exists at path."""
-    return (app_path / "package.json").is_file() and (
-        app_path / "packages" / "app"
-    ).is_dir()
+    return (app_path / "package.json").is_file() and (app_path / "packages" / "app").is_dir()
 
 
 # ---------------------------------------------------------------------------
@@ -300,15 +298,9 @@ def scaffold(args: argparse.Namespace) -> dict:
         log(f"  1. cd {app_path}")
         log(f"  2. Implement components in plugins/{plugin_id}/src/")
         if with_theme:
-            log(
-                f"  3. Configure theme in plugins/{plugin_id}/dev/index.tsx "
-                "(see SKILL.md Step 5)"
-            )
+            log(f"  3. Configure theme in plugins/{plugin_id}/dev/index.tsx (see SKILL.md Step 5)")
         log(f"  {'4' if with_theme else '3'}. yarn build")
-        log(
-            f"  {'5' if with_theme else '4'}. "
-            "npx @red-hat-developer-hub/cli@latest plugin export"
-        )
+        log(f"  {'5' if with_theme else '4'}. npx @red-hat-developer-hub/cli@latest plugin export")
 
     return result
 
@@ -343,10 +335,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--rhdh-version",
         required=True,
         metavar="VERSION",
-        help=(
-            f"Target RHDH version. "
-            f"Known: {', '.join(sorted(VERSION_MAP.keys()))}."
-        ),
+        help=(f"Target RHDH version. Known: {', '.join(sorted(VERSION_MAP.keys()))}."),
     )
     parser.add_argument(
         "--plugin-id",

--- a/skills/create-frontend-plugin/scripts/scaffold.py
+++ b/skills/create-frontend-plugin/scripts/scaffold.py
@@ -378,22 +378,23 @@ def main() -> None:
     except KeyboardInterrupt:
         log("\nInterrupted.")
         sys.exit(130)
-    except Exception as exc:
+    except (OSError, PermissionError) as exc:
         if args.json:
             print(
                 json.dumps(
                     {
                         "success": False,
                         "error": {
-                            "code": "UNEXPECTED_ERROR",
+                            "code": "PATH_ERROR",
                             "message": str(exc),
                         },
                     },
                     indent=2,
                 )
             )
-            sys.exit(EXIT_FAILURE)
-        raise
+        else:
+            log(f"Error: {exc}")
+        sys.exit(EXIT_FAILURE)
 
     if args.json:
         print(json.dumps(result, indent=2))

--- a/skills/create-frontend-plugin/scripts/scaffold.py
+++ b/skills/create-frontend-plugin/scripts/scaffold.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import subprocess
 import sys
 from pathlib import Path

--- a/skills/export-and-package/SKILL.md
+++ b/skills/export-and-package/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: RHDH Dynamic Plugin Export and Package
+name: export-and-package
 description: This skill should be used when the user asks to "export dynamic plugin", "package plugin as OCI", "create plugin container image", "publish plugin to registry", "build OCI artifact", "package plugin as tgz", "push plugin to quay.io", "create dynamic plugin archive", "bundle multiple plugins", "generate integrity hash", or mentions exporting, packaging, or publishing an existing Backstage plugin for RHDH deployment. This skill handles the export and packaging workflow after a plugin has been implemented.
 ---
 
@@ -32,6 +32,22 @@ Before starting, ensure:
 - For frontend plugins: Has valid Scalprum configuration (auto-generated if not present)
 
 ## Workflow Overview
+
+> **Automation script:** `scripts/export-plugin.py` automates Steps 1-4 below in
+> a single command. Run `python scripts/export-plugin.py --help` for usage, or
+> see examples:
+>
+> ```bash
+> # OCI (default) — build, export, package, push
+> python scripts/export-plugin.py --plugin-dir plugins/my-plugin \
+>   --tag quay.io/ns/my-plugin:v0.1.0 --push --clean
+>
+> # tgz archive with integrity hash
+> python scripts/export-plugin.py --format tgz --clean
+>
+> # JSON output for CI pipelines
+> python scripts/export-plugin.py --tag quay.io/ns/my-plugin:v0.1.0 --json
+> ```
 
 1. **Build Plugin** - Compile TypeScript and verify no errors
 2. **Export as Dynamic Plugin** - Create `dist-dynamic/` with RHDH CLI

--- a/skills/export-and-package/SKILL.md
+++ b/skills/export-and-package/SKILL.md
@@ -33,21 +33,16 @@ Before starting, ensure:
 
 ## Workflow Overview
 
-> **Automation script:** `scripts/export-plugin.py` automates Steps 1-4 below in
-> a single command. Run `python scripts/export-plugin.py --help` for usage, or
-> see examples:
->
-> ```bash
-> # OCI (default) — build, export, package, push
-> python scripts/export-plugin.py --plugin-dir plugins/my-plugin \
->   --tag quay.io/ns/my-plugin:v0.1.0 --push --clean
->
-> # tgz archive with integrity hash
-> python scripts/export-plugin.py --format tgz --clean
->
-> # JSON output for CI pipelines
-> python scripts/export-plugin.py --tag quay.io/ns/my-plugin:v0.1.0 --json
-> ```
+For the common case, use the automation script:
+
+```bash
+python scripts/export-plugin.py --plugin-dir plugins/my-plugin \
+  --tag quay.io/ns/my-plugin:v0.1.0 --push --clean
+```
+
+Run `python scripts/export-plugin.py --help` for all options (`--format tgz`, `--shared-package`, `--embed-package`, `--json`).
+
+The steps below explain each phase for advanced use cases (custom shared deps, multi-plugin bundles, npm publishing).
 
 1. **Build Plugin** - Compile TypeScript and verify no errors
 2. **Export as Dynamic Plugin** - Create `dist-dynamic/` with RHDH CLI

--- a/skills/export-and-package/scripts/export-plugin.py
+++ b/skills/export-and-package/scripts/export-plugin.py
@@ -279,10 +279,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--tag",
-        help=(
-            "OCI image tag, e.g. 'quay.io/namespace/plugin:v0.1.0'. "
-            "Required when --format=oci."
-        ),
+        help=("OCI image tag, e.g. 'quay.io/namespace/plugin:v0.1.0'. Required when --format=oci."),
     )
     parser.add_argument(
         "--format",
@@ -423,7 +420,9 @@ def main(argv: list[str] | None = None) -> int:
         if fmt == "oci":
             assert container_tool is not None
             pkg_result = step_package_oci(
-                plugin_dir, tag=tag, container_tool=container_tool  # type: ignore[arg-type]
+                plugin_dir,
+                tag=tag,
+                container_tool=container_tool,  # type: ignore[arg-type]
             )
         elif fmt == "tgz":
             pkg_result = step_package_tgz(plugin_dir)

--- a/skills/export-and-package/scripts/export-plugin.py
+++ b/skills/export-and-package/scripts/export-plugin.py
@@ -1,0 +1,497 @@
+#!/usr/bin/env python3
+"""Export, package, and push a Backstage plugin as an RHDH dynamic plugin.
+
+Automates the full export+package+push pipeline described in the
+export-and-package skill (SKILL.md Steps 1-4):
+
+  1. Validate plugin directory and package.json
+  2. Build (yarn build + yarn tsc)
+  3. Export via @red-hat-developer-hub/cli
+  4. Package as OCI image, tgz archive, or npm package
+  5. Optionally push OCI image to registry
+
+Uses only Python stdlib — no external dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+# ---------------------------------------------------------------------------
+# ANSI helpers
+# ---------------------------------------------------------------------------
+
+_NO_COLOR = os.environ.get("NO_COLOR") is not None or not sys.stdout.isatty()
+
+RED = "" if _NO_COLOR else "\033[0;31m"
+GREEN = "" if _NO_COLOR else "\033[0;32m"
+YELLOW = "" if _NO_COLOR else "\033[1;33m"
+BLUE = "" if _NO_COLOR else "\033[0;34m"
+BOLD = "" if _NO_COLOR else "\033[1m"
+NC = "" if _NO_COLOR else "\033[0m"
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+
+def _log_ok(msg: str) -> None:
+    print(f"  {GREEN}✓{NC} {msg}")
+
+
+def _log_fail(msg: str) -> None:
+    print(f"  {RED}✗{NC} {msg}", file=sys.stderr)
+
+
+def _log_info(msg: str) -> None:
+    print(f"  {BLUE}→{NC} {msg}")
+
+
+def _log_step(msg: str) -> None:
+    print(f"\n{BOLD}{msg}{NC}")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _detect_container_tool() -> Optional[str]:
+    """Return the first available container tool, or None."""
+    for tool in ("podman", "docker", "buildah"):
+        if shutil.which(tool):
+            return tool
+    return None
+
+
+def _run(
+    cmd: list[str],
+    *,
+    cwd: Optional[Path] = None,
+    capture: bool = False,
+) -> subprocess.CompletedProcess:
+    """Run a subprocess, raising on failure."""
+    return subprocess.run(
+        cmd,
+        cwd=cwd,
+        check=True,
+        capture_output=capture,
+        text=True,
+    )
+
+
+def _read_package_json(plugin_dir: Path) -> dict:
+    pkg = plugin_dir / "package.json"
+    with open(pkg, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _compute_integrity(path: Path) -> str:
+    """Compute sha512 integrity hash in SRI format."""
+    import base64
+
+    h = hashlib.sha512()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    digest = base64.b64encode(h.digest()).decode("ascii")
+    return f"sha512-{digest}"
+
+
+# ---------------------------------------------------------------------------
+# Pipeline steps
+# ---------------------------------------------------------------------------
+
+
+def step_validate(plugin_dir: Path) -> dict:
+    """Step 1: Validate plugin directory has package.json."""
+    pkg_path = plugin_dir / "package.json"
+    if not plugin_dir.is_dir():
+        raise SystemExit(f"Plugin directory does not exist: {plugin_dir}")
+    if not pkg_path.is_file():
+        raise SystemExit(f"No package.json found in {plugin_dir}")
+    data = _read_package_json(plugin_dir)
+    name = data.get("name", "<unknown>")
+    version = data.get("version", "<unknown>")
+    _log_ok(f"Validated {name}@{version}")
+    return {"name": name, "version": version}
+
+
+def step_build(plugin_dir: Path) -> None:
+    """Step 1 cont: yarn build + yarn tsc."""
+    _log_step("Step 1: Build plugin")
+    _log_info("Running yarn build …")
+    _run(["yarn", "build"], cwd=plugin_dir)
+    _log_ok("yarn build succeeded")
+
+    _log_info("Running yarn tsc …")
+    _run(["yarn", "tsc"], cwd=plugin_dir)
+    _log_ok("yarn tsc succeeded")
+
+
+def step_clean(plugin_dir: Path) -> None:
+    """Remove dist/ and dist-dynamic/ for idempotent rebuilds."""
+    for name in ("dist", "dist-dynamic"):
+        target = plugin_dir / name
+        if target.exists():
+            shutil.rmtree(target)
+            _log_info(f"Removed {target}")
+
+
+def step_export(
+    plugin_dir: Path,
+    *,
+    shared_packages: list[str],
+    embed_packages: list[str],
+) -> None:
+    """Step 2: Export as dynamic plugin via RHDH CLI."""
+    _log_step("Step 2: Export as dynamic plugin")
+    cmd = ["npx", "@red-hat-developer-hub/cli@latest", "plugin", "export"]
+    for pkg in shared_packages:
+        cmd.extend(["--shared-package", pkg])
+    for pkg in embed_packages:
+        cmd.extend(["--embed-package", pkg])
+    _log_info(f"Running: {' '.join(cmd)}")
+    _run(cmd, cwd=plugin_dir)
+    dist_dyn = plugin_dir / "dist-dynamic"
+    if not dist_dyn.is_dir():
+        raise SystemExit("Export failed: dist-dynamic/ was not created")
+    _log_ok("Export created dist-dynamic/")
+
+
+def step_package_oci(
+    plugin_dir: Path,
+    *,
+    tag: str,
+    container_tool: str,
+) -> dict:
+    """Step 3 (OCI): Package as container image."""
+    _log_step("Step 3: Package as OCI image")
+    cmd = [
+        "npx",
+        "@red-hat-developer-hub/cli@latest",
+        "plugin",
+        "package",
+        "--container-tool",
+        container_tool,
+        "--tag",
+        tag,
+    ]
+    _log_info(f"Running: {' '.join(cmd)}")
+    _run(cmd, cwd=plugin_dir)
+    _log_ok(f"Image tagged: {tag}")
+    return {"format": "oci", "tag": tag, "container_tool": container_tool}
+
+
+def step_package_tgz(plugin_dir: Path) -> dict:
+    """Step 3 (tgz): npm pack in dist-dynamic/."""
+    _log_step("Step 3: Package as tgz archive")
+    dist_dyn = plugin_dir / "dist-dynamic"
+    result = _run(["npm", "pack", "--json"], cwd=dist_dyn, capture=True)
+    pack_info = json.loads(result.stdout)
+    if isinstance(pack_info, list):
+        pack_info = pack_info[0]
+    filename = pack_info.get("filename", "")
+    tgz_path = dist_dyn / filename
+    integrity = pack_info.get("integrity", "")
+    if not integrity and tgz_path.is_file():
+        integrity = _compute_integrity(tgz_path)
+    _log_ok(f"Archive: {tgz_path}")
+    _log_info(f"Integrity: {integrity}")
+    return {
+        "format": "tgz",
+        "path": str(tgz_path),
+        "filename": filename,
+        "integrity": integrity,
+    }
+
+
+def step_package_npm(plugin_dir: Path) -> dict:
+    """Step 3 (npm): npm publish from dist-dynamic/ (dry-run info only)."""
+    _log_step("Step 3: Package as npm (publish)")
+    dist_dyn = plugin_dir / "dist-dynamic"
+    _log_info("Publishing via npm publish …")
+    _run(["npm", "publish"], cwd=dist_dyn)
+    _log_ok("Published to npm registry")
+    return {"format": "npm"}
+
+
+def step_push(tag: str, container_tool: str) -> dict:
+    """Step 4: Push OCI image to registry."""
+    _log_step("Step 4: Push to registry")
+    cmd = [container_tool, "push", tag]
+    _log_info(f"Running: {' '.join(cmd)}")
+    _run(cmd)
+    _log_ok(f"Pushed {tag}")
+
+    # Try to get digest
+    digest = ""
+    try:
+        result = _run(
+            [container_tool, "inspect", "--format={{.Digest}}", tag],
+            capture=True,
+        )
+        digest = result.stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
+
+    if digest:
+        _log_info(f"Digest: {digest}")
+    return {"pushed": True, "tag": tag, "digest": digest}
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Export, package, and optionally push a Backstage plugin "
+            "as an RHDH dynamic plugin. Automates Steps 1-4 of the "
+            "export-and-package workflow."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  %(prog)s --tag quay.io/ns/my-plugin:v0.1.0\n"
+            "  %(prog)s --format tgz --clean\n"
+            "  %(prog)s --tag quay.io/ns/my-plugin:v0.1.0 --push\n"
+            "  %(prog)s --plugin-dir plugins/my-backend --tag quay.io/ns/x:v1 "
+            "--shared-package '!/@backstage/plugin-notifications/' "
+            "--embed-package @internal/common\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--plugin-dir",
+        type=Path,
+        default=Path.cwd(),
+        help="Path to the plugin directory (default: current directory)",
+    )
+    parser.add_argument(
+        "--tag",
+        help=(
+            "OCI image tag, e.g. 'quay.io/namespace/plugin:v0.1.0'. "
+            "Required when --format=oci."
+        ),
+    )
+    parser.add_argument(
+        "--format",
+        choices=("oci", "tgz", "npm"),
+        default="oci",
+        help="Packaging format (default: oci)",
+    )
+    parser.add_argument(
+        "--container-tool",
+        choices=("podman", "docker", "buildah"),
+        default=None,
+        help="Container tool for OCI operations (default: auto-detect)",
+    )
+    parser.add_argument(
+        "--push",
+        action="store_true",
+        help="Push OCI image to registry after packaging",
+    )
+    parser.add_argument(
+        "--clean",
+        action="store_true",
+        help="Remove dist/ and dist-dynamic/ before building (idempotent rebuild)",
+    )
+    parser.add_argument(
+        "--shared-package",
+        action="append",
+        default=[],
+        metavar="PKG",
+        help=(
+            "Override shared dependency behaviour during export. "
+            "Repeatable. E.g. '!/@backstage/plugin-notifications/'"
+        ),
+    )
+    parser.add_argument(
+        "--embed-package",
+        action="append",
+        default=[],
+        metavar="PKG",
+        help=(
+            "Embed a workspace or third-party package during export. "
+            "Repeatable. E.g. '@my-org/plugin-common'"
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output structured JSON instead of human-readable text",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    plugin_dir: Path = args.plugin_dir.resolve()
+    fmt: str = args.format
+    tag: str | None = args.tag
+    do_push: bool = args.push
+    do_clean: bool = args.clean
+    use_json: bool = args.json_output
+    shared_packages: list[str] = args.shared_package
+    embed_packages: list[str] = args.embed_package
+    container_tool: str | None = args.container_tool
+
+    # --- Argument validation ------------------------------------------------
+
+    if fmt == "oci" and not tag:
+        parser.error("--tag is required when --format=oci")
+
+    if do_push and fmt != "oci":
+        parser.error("--push is only supported with --format=oci")
+
+    if fmt == "oci":
+        if container_tool is None:
+            container_tool = _detect_container_tool()
+        if container_tool is None:
+            parser.error(
+                "No container tool found (podman/docker/buildah). "
+                "Install one or specify --container-tool."
+            )
+
+    # --- Collect results for JSON output ------------------------------------
+    result: dict[str, Any] = {
+        "plugin_dir": str(plugin_dir),
+        "format": fmt,
+    }
+    if tag:
+        result["tag"] = tag
+
+    try:
+        # Step 0: Validate
+        if not use_json:
+            _log_step("Validating plugin directory")
+        pkg_info = step_validate(plugin_dir)
+        result["plugin"] = pkg_info
+
+        # Optional clean
+        if do_clean:
+            if not use_json:
+                _log_step("Cleaning previous build artifacts")
+            step_clean(plugin_dir)
+
+        # Step 1: Build
+        if not use_json:
+            step_build(plugin_dir)
+        else:
+            _run(["yarn", "build"], cwd=plugin_dir)
+            _run(["yarn", "tsc"], cwd=plugin_dir)
+        result["build"] = "ok"
+
+        # Step 2: Export
+        if not use_json:
+            step_export(
+                plugin_dir,
+                shared_packages=shared_packages,
+                embed_packages=embed_packages,
+            )
+        else:
+            cmd = [
+                "npx",
+                "@red-hat-developer-hub/cli@latest",
+                "plugin",
+                "export",
+            ]
+            for pkg in shared_packages:
+                cmd.extend(["--shared-package", pkg])
+            for pkg in embed_packages:
+                cmd.extend(["--embed-package", pkg])
+            _run(cmd, cwd=plugin_dir)
+            dist_dyn = plugin_dir / "dist-dynamic"
+            if not dist_dyn.is_dir():
+                raise SystemExit("Export failed: dist-dynamic/ not created")
+        result["export"] = "ok"
+
+        # Step 3: Package
+        if fmt == "oci":
+            assert container_tool is not None
+            pkg_result = step_package_oci(
+                plugin_dir, tag=tag, container_tool=container_tool  # type: ignore[arg-type]
+            )
+        elif fmt == "tgz":
+            pkg_result = step_package_tgz(plugin_dir)
+        elif fmt == "npm":
+            pkg_result = step_package_npm(plugin_dir)
+        else:
+            raise SystemExit(f"Unknown format: {fmt}")
+        result["package"] = pkg_result
+
+        # Step 4: Push (OCI only)
+        if do_push:
+            assert container_tool is not None
+            push_result = step_push(tag, container_tool)  # type: ignore[arg-type]
+            result["push"] = push_result
+
+        # --- Final output ---------------------------------------------------
+        result["success"] = True
+
+        if use_json:
+            print(json.dumps(result, indent=2))
+        else:
+            _log_step("Done ✓")
+            print(f"\n  Plugin:  {pkg_info['name']}@{pkg_info['version']}")
+            print(f"  Format:  {fmt}")
+            if tag:
+                print(f"  Tag:     {tag}")
+            if fmt == "tgz" and "integrity" in pkg_result:
+                print(f"  Hash:    {pkg_result['integrity']}")
+            if do_push and "digest" in result.get("push", {}):
+                digest = result["push"]["digest"]
+                if digest:
+                    print(f"  Digest:  {digest}")
+
+        return 0
+
+    except subprocess.CalledProcessError as exc:
+        err_msg = f"Command failed: {' '.join(str(a) for a in exc.cmd)}"
+        stderr_out = ""
+        if exc.stderr:
+            stderr_out = exc.stderr.strip()
+        if use_json:
+            result["success"] = False
+            result["error"] = {
+                "code": "COMMAND_FAILED",
+                "message": err_msg,
+                "stderr": stderr_out,
+                "returncode": exc.returncode,
+            }
+            print(json.dumps(result, indent=2))
+        else:
+            _log_fail(err_msg)
+            if stderr_out:
+                print(stderr_out, file=sys.stderr)
+        return 1
+
+    except SystemExit as exc:
+        # argparse calls sys.exit(2) for usage errors
+        if isinstance(exc.code, int):
+            return exc.code
+        msg = str(exc.code) if exc.code else "Unknown error"
+        if use_json:
+            result["success"] = False
+            result["error"] = {"code": "VALIDATION_ERROR", "message": msg}
+            print(json.dumps(result, indent=2))
+        else:
+            _log_fail(msg)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/generate-frontend-wiring/SKILL.md
+++ b/skills/generate-frontend-wiring/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Generate Frontend Wiring
+name: generate-frontend-wiring
 description: This skill should be used when the user asks to "generate frontend wiring", "show frontend wiring", "create RHDH binding", "generate dynamic plugin config", "show plugin wiring for RHDH", "create app-config for frontend plugin", or wants to generate the RHDH dynamic plugin wiring configuration for an existing Backstage frontend plugin. The skill analyzes the plugin's source code and generates the appropriate configuration.
 ---
 
@@ -30,7 +30,7 @@ The plugin directory must contain:
 Find and read the essential plugin files:
 
 1. **`package.json`** - Get package name
-2. **`src/plugin.ts`** - Find exported extensions (pages, cards)
+2. **`src/plugin.ts`** or **`src/plugin.tsx`** - Find exported extensions (pages, cards)
 3. **`src/index.ts`** - Find public exports (APIs, components)
 4. **`dist-dynamic/dist-scalprum/plugin-manifest.json`** - Get scalprum name if built
 
@@ -231,6 +231,20 @@ appIcons:
   - name: myIcon
     importName: MyIcon
 ```
+
+## Gotchas
+
+### Plugin File Extensions
+
+The plugin definition may be in `src/plugin.ts` or `src/plugin.tsx`. Always check both extensions when searching for plugin exports.
+
+### Unscoped Package Names
+
+The scalprum name derivation in Step 2 assumes scoped packages (`@org/name`). For unscoped packages (e.g., `backstage-plugin-foo`), the scalprum name is the package name as-is — no dot-separated transformation needed.
+
+### New vs Legacy Frontend System
+
+Plugins using the new Backstage frontend system (`createPlugin` from `@backstage/frontend-plugin-api`) have different export patterns than the legacy system (`createPlugin` from `@backstage/core-plugin-api`). Check which system the plugin uses — new system plugins export extensions via `createExtension` rather than `createRoutableExtension`/`createComponentExtension`.
 
 ## Notes
 

--- a/skills/overlay/SKILL.md
+++ b/skills/overlay/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: overlay
-description: Use when working with the rhdh-plugin-export-overlays repository — onboarding plugins to the Extensions Catalog, updating plugin versions, fixing overlay build failures, triaging and analyzing PRs, triggering publishes, or managing plugin workspaces.
+description: Manages the rhdh-plugin-export-overlays repository — onboards plugins to the Extensions Catalog, updates plugin versions, fixes overlay build failures, triages and analyzes PRs, triggers publishes, and manages plugin workspaces. Use when working with overlays, importing plugins, debugging CI, checking PRs, or bumping versions.
 ---
 
 <cli_setup>
@@ -136,7 +136,7 @@ gh pr view <number> --repo $REPO --json statusCheckRollup \
 2. No `do-not-merge` label
 3. Publish check not already successful
 
-See `references/github-reference.md` (in rhdh skill) for full patterns.
+See `../rhdh/references/github-reference.md` for full patterns.
 </inline_publish_trigger>
 
 <reference_index>

--- a/skills/overlay/scripts/analyze-pr.py
+++ b/skills/overlay/scripts/analyze-pr.py
@@ -505,6 +505,10 @@ def main():
     )
     args = parser.parse_args()
 
+    # Ensure UTF-8 output on Windows (emoji in priority labels)
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")
+
     analysis = build_analysis(args.pr_number, args.repo)
 
     if args.json_output:

--- a/skills/overlay/scripts/analyze-pr.py
+++ b/skills/overlay/scripts/analyze-pr.py
@@ -30,9 +30,7 @@ def run_gh(args, check=True):
     """Run a gh CLI command and return parsed JSON output."""
     cmd = ["gh"] + args
     try:
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, check=check, timeout=30
-        )
+        result = subprocess.run(cmd, capture_output=True, text=True, check=check, timeout=30)
         if result.stdout.strip():
             return json.loads(result.stdout)
         return None
@@ -53,9 +51,7 @@ def run_gh_raw(args, check=True):
     """Run a gh CLI command and return raw stdout."""
     cmd = ["gh"] + args
     try:
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, check=check, timeout=30
-        )
+        result = subprocess.run(cmd, capture_output=True, text=True, check=check, timeout=30)
         return result.stdout.strip()
     except subprocess.CalledProcessError as exc:
         print(f"Error running: {' '.join(cmd)}", file=sys.stderr)
@@ -74,18 +70,30 @@ def fetch_pr_context(pr_number, repo):
         "number,title,state,author,labels,assignees,reviewRequests,"
         "reviews,statusCheckRollup,files,updatedAt,createdAt,mergeable,body"
     )
-    return run_gh([
-        "pr", "view", str(pr_number), "--repo", repo,
-        "--json", fields,
-    ])
+    return run_gh(
+        [
+            "pr",
+            "view",
+            str(pr_number),
+            "--repo",
+            repo,
+            "--json",
+            fields,
+        ]
+    )
 
 
 def fetch_codeowners(repo):
     """Fetch CODEOWNERS file content."""
-    result = run_gh_raw([
-        "api", f"repos/{repo}/contents/CODEOWNERS",
-        "--jq", ".content",
-    ], check=False)
+    result = run_gh_raw(
+        [
+            "api",
+            f"repos/{repo}/contents/CODEOWNERS",
+            "--jq",
+            ".content",
+        ],
+        check=False,
+    )
     if result:
         try:
             return base64.b64decode(result).decode("utf-8", errors="replace")
@@ -117,7 +125,7 @@ def classify_priority(labels):
 def extract_workspaces(files):
     """Extract workspace names from changed files."""
     workspaces = set()
-    for f in (files or []):
+    for f in files or []:
         path = f.get("path", "")
         if path.startswith("workspaces/"):
             parts = path.split("/")
@@ -130,9 +138,7 @@ def assess_assignment(pr_data):
     """Assess assignment status."""
     assignees = [a.get("login", "") for a in (pr_data.get("assignees") or [])]
     review_requests = pr_data.get("reviewRequests") or []
-    individual_reviewers = [
-        r.get("login", "") for r in review_requests if r.get("login")
-    ]
+    individual_reviewers = [r.get("login", "") for r in review_requests if r.get("login")]
     team_reviewers = [
         r.get("name", "") for r in review_requests if r.get("name") and not r.get("login")
     ]
@@ -206,11 +212,7 @@ def check_codeowners_modified(files):
 
 def check_source_json_modified(files):
     """Check if any source.json is modified."""
-    return [
-        f.get("path", "")
-        for f in (files or [])
-        if f.get("path", "").endswith("source.json")
-    ]
+    return [f.get("path", "") for f in (files or []) if f.get("path", "").endswith("source.json")]
 
 
 def compute_staleness(updated_at, priority_key):
@@ -244,7 +246,9 @@ def get_approvals(pr_data):
     return approvals
 
 
-def determine_merge_readiness(pr_data, checks, assignment, priority_key, codeowners_modified, is_addition):
+def determine_merge_readiness(
+    pr_data, checks, assignment, priority_key, codeowners_modified, is_addition
+):
     """Determine merge readiness checklist."""
     items = []
 
@@ -260,9 +264,7 @@ def determine_merge_readiness(pr_data, checks, assignment, priority_key, codeown
     # Smoke tests (optional)
     smoke_keys = [k for k in checks if "smoke" in k.lower() or "workspace-test" in k.lower()]
     if smoke_keys:
-        smoke_passed = all(
-            checks[k].get("conclusion", "").lower() == "success" for k in smoke_keys
-        )
+        smoke_passed = all(checks[k].get("conclusion", "").lower() == "success" for k in smoke_keys)
         items.append(("Smoke tests passed", smoke_passed))
 
     # Has individual assignee
@@ -433,7 +435,9 @@ def format_markdown(analysis):
     lines.append("|--------|---------|")
     asgn = a["assignment"]
     lines.append(f"| Assignees | {', '.join('@' + u for u in asgn['assignees']) or '(none)'} |")
-    lines.append(f"| Individual Reviewers | {', '.join('@' + u for u in asgn['individual_reviewers']) or '(none)'} |")
+    lines.append(
+        f"| Individual Reviewers | {', '.join('@' + u for u in asgn['individual_reviewers']) or '(none)'} |"
+    )
     if asgn["team_reviewers"]:
         lines.append(f"| Team Reviewers | {', '.join(asgn['team_reviewers'])} |")
     lines.append(f"| Verdict | {asgn['status']} |")
@@ -448,7 +452,9 @@ def format_markdown(analysis):
             else:
                 lines.append(f"- `{ws}`: ❌ No entry found")
         if a.get("source_json_modified"):
-            lines.append(f"- CODEOWNERS modified in PR: {'✅ Yes' if a['codeowners_modified'] else '❌ No'}")
+            lines.append(
+                f"- CODEOWNERS modified in PR: {'✅ Yes' if a['codeowners_modified'] else '❌ No'}"
+            )
         lines.append("")
 
     # Checks
@@ -485,15 +491,16 @@ def main():
         description="Analyze a single overlay repository PR.",
         epilog="Example: %(prog)s 1234 --json",
     )
+    parser.add_argument("pr_number", type=int, help="PR number to analyze")
     parser.add_argument(
-        "pr_number", type=int, help="PR number to analyze"
-    )
-    parser.add_argument(
-        "--repo", default=DEFAULT_REPO,
+        "--repo",
+        default=DEFAULT_REPO,
         help=f"GitHub repository (default: {DEFAULT_REPO})",
     )
     parser.add_argument(
-        "--json", dest="json_output", action="store_true",
+        "--json",
+        dest="json_output",
+        action="store_true",
         help="Output structured JSON instead of markdown",
     )
     args = parser.parse_args()

--- a/skills/overlay/scripts/analyze-pr.py
+++ b/skills/overlay/scripts/analyze-pr.py
@@ -1,0 +1,509 @@
+#!/usr/bin/env python3
+"""Analyze a single overlay repository PR.
+
+Consolidates ~8 sequential gh API calls into one script.
+Gathers PR metadata, checks, workspace, CODEOWNERS, and produces
+a structured analysis with priority, assignment, and merge readiness.
+"""
+
+import argparse
+import base64
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+
+DEFAULT_REPO = "redhat-developer/rhdh-plugin-export-overlays"
+
+STALENESS_THRESHOLDS = {
+    "critical": {"warn": 2, "alert": 5},
+    "medium": {"warn": 5, "alert": 10},
+    "low": {"warn": 14, "alert": 30},
+    "skip": {"warn": 999, "alert": 999},
+    "unknown": {"warn": 7, "alert": 14},
+}
+
+
+def run_gh(args, check=True):
+    """Run a gh CLI command and return parsed JSON output."""
+    cmd = ["gh"] + args
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, check=check, timeout=30
+        )
+        if result.stdout.strip():
+            return json.loads(result.stdout)
+        return None
+    except subprocess.CalledProcessError as exc:
+        print(f"Error running: {' '.join(cmd)}", file=sys.stderr)
+        print(exc.stderr, file=sys.stderr)
+        if check:
+            sys.exit(1)
+        return None
+    except json.JSONDecodeError:
+        return result.stdout.strip()
+    except FileNotFoundError:
+        print("Error: gh CLI not found. Install from https://cli.github.com/", file=sys.stderr)
+        sys.exit(1)
+
+
+def run_gh_raw(args, check=True):
+    """Run a gh CLI command and return raw stdout."""
+    cmd = ["gh"] + args
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, check=check, timeout=30
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as exc:
+        print(f"Error running: {' '.join(cmd)}", file=sys.stderr)
+        print(exc.stderr, file=sys.stderr)
+        if check:
+            sys.exit(1)
+        return ""
+    except FileNotFoundError:
+        print("Error: gh CLI not found.", file=sys.stderr)
+        sys.exit(1)
+
+
+def fetch_pr_context(pr_number, repo):
+    """Fetch full PR context in one gh call."""
+    fields = (
+        "number,title,state,author,labels,assignees,reviewRequests,"
+        "reviews,statusCheckRollup,files,updatedAt,createdAt,mergeable,body"
+    )
+    return run_gh([
+        "pr", "view", str(pr_number), "--repo", repo,
+        "--json", fields,
+    ])
+
+
+def fetch_codeowners(repo):
+    """Fetch CODEOWNERS file content."""
+    result = run_gh_raw([
+        "api", f"repos/{repo}/contents/CODEOWNERS",
+        "--jq", ".content",
+    ], check=False)
+    if result:
+        try:
+            return base64.b64decode(result).decode("utf-8", errors="replace")
+        except Exception:
+            pass
+    return ""
+
+
+def classify_priority(labels):
+    """Classify PR priority based on labels."""
+    names = [l["name"] for l in labels] if labels else []
+
+    if "do-not-merge" in names:
+        return "skip", "⚫ Skip (do-not-merge)"
+
+    is_mandatory = "mandatory-workspace" in names
+    is_update = "workspace-update" in names
+    is_addition = "workspace-addition" in names
+
+    if is_mandatory and is_update:
+        return "critical", "🔴 Critical (mandatory-workspace + workspace-update)"
+    if is_mandatory and is_addition:
+        return "medium", "🟡 Medium (mandatory-workspace + workspace-addition)"
+    if is_addition:
+        return "low", "🟢 Low (workspace-addition)"
+    return "unknown", "❓ Unknown (manual review needed)"
+
+
+def extract_workspaces(files):
+    """Extract workspace names from changed files."""
+    workspaces = set()
+    for f in (files or []):
+        path = f.get("path", "")
+        if path.startswith("workspaces/"):
+            parts = path.split("/")
+            if len(parts) >= 2:
+                workspaces.add(parts[1])
+    return sorted(workspaces)
+
+
+def assess_assignment(pr_data):
+    """Assess assignment status."""
+    assignees = [a.get("login", "") for a in (pr_data.get("assignees") or [])]
+    review_requests = pr_data.get("reviewRequests") or []
+    individual_reviewers = [
+        r.get("login", "") for r in review_requests if r.get("login")
+    ]
+    team_reviewers = [
+        r.get("name", "") for r in review_requests if r.get("name") and not r.get("login")
+    ]
+
+    if assignees:
+        status = "✅ Clear ownership"
+        verdict = "assigned"
+    elif individual_reviewers:
+        status = "⚠️ Reviewer but no assignee"
+        verdict = "reviewer_only"
+    elif team_reviewers:
+        status = "⚠️ Only team requested — responsibility diluted"
+        verdict = "team_only"
+    else:
+        status = "❌ Orphan — no assignee or reviewer"
+        verdict = "orphan"
+
+    return {
+        "assignees": assignees,
+        "individual_reviewers": individual_reviewers,
+        "team_reviewers": team_reviewers,
+        "status": status,
+        "verdict": verdict,
+    }
+
+
+def find_codeowner(workspaces, codeowners_content):
+    """Find CODEOWNERS entry for workspaces."""
+    results = {}
+    for ws in workspaces:
+        matches = []
+        for line in codeowners_content.splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if ws in line:
+                matches.append(line)
+        results[ws] = matches
+    return results
+
+
+def assess_checks(pr_data):
+    """Assess status checks."""
+    checks = pr_data.get("statusCheckRollup") or []
+    result = {}
+    for c in checks:
+        name = c.get("name", c.get("context", "unknown"))
+        conclusion = c.get("conclusion", "")
+        status = c.get("status", "")
+        if conclusion == "SUCCESS" or conclusion == "success":
+            icon = "✅"
+        elif conclusion == "FAILURE" or conclusion == "failure":
+            icon = "❌"
+        elif status == "IN_PROGRESS" or status == "QUEUED":
+            icon = "⏳"
+        else:
+            icon = "⚪"
+        result[name] = {
+            "conclusion": conclusion,
+            "status": status,
+            "icon": icon,
+            "display": f"{icon} {conclusion or status}",
+        }
+    return result
+
+
+def check_codeowners_modified(files):
+    """Check if CODEOWNERS file is in the changeset."""
+    return any(f.get("path", "") == "CODEOWNERS" for f in (files or []))
+
+
+def check_source_json_modified(files):
+    """Check if any source.json is modified."""
+    return [
+        f.get("path", "")
+        for f in (files or [])
+        if f.get("path", "").endswith("source.json")
+    ]
+
+
+def compute_staleness(updated_at, priority_key):
+    """Compute staleness from updatedAt timestamp."""
+    try:
+        updated = datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
+        now = datetime.now(timezone.utc)
+        days = (now - updated).days
+    except (ValueError, AttributeError):
+        days = -1
+
+    thresholds = STALENESS_THRESHOLDS.get(priority_key, STALENESS_THRESHOLDS["unknown"])
+    if days >= thresholds["alert"]:
+        level = "🚨 ALERT"
+    elif days >= thresholds["warn"]:
+        level = "⚠️ WARN"
+    else:
+        level = "✅ Fresh"
+
+    return {"days": days, "level": level}
+
+
+def get_approvals(pr_data):
+    """Extract approval reviews."""
+    reviews = pr_data.get("reviews") or []
+    approvals = []
+    for r in reviews:
+        if r.get("state") == "APPROVED":
+            author = r.get("author", {}).get("login", "unknown")
+            approvals.append(author)
+    return approvals
+
+
+def determine_merge_readiness(pr_data, checks, assignment, priority_key, codeowners_modified, is_addition):
+    """Determine merge readiness checklist."""
+    items = []
+
+    # PR is open
+    is_open = pr_data.get("state") == "OPEN"
+    items.append(("PR is open", is_open))
+
+    # Publish passed
+    publish = checks.get("publish", {})
+    publish_passed = publish.get("conclusion", "").lower() == "success"
+    items.append(("Publish passed", publish_passed))
+
+    # Smoke tests (optional)
+    smoke_keys = [k for k in checks if "smoke" in k.lower() or "workspace-test" in k.lower()]
+    if smoke_keys:
+        smoke_passed = all(
+            checks[k].get("conclusion", "").lower() == "success" for k in smoke_keys
+        )
+        items.append(("Smoke tests passed", smoke_passed))
+
+    # Has individual assignee
+    has_assignee = len(assignment["assignees"]) > 0
+    items.append(("Assignee present", has_assignee))
+
+    # CODEOWNERS for additions
+    if is_addition:
+        items.append(("CODEOWNERS entry (addition)", codeowners_modified))
+
+    # Approved
+    approvals = get_approvals(pr_data)
+    has_approval = len(approvals) > 0
+    items.append(("Approved", has_approval))
+
+    # No conflicts
+    mergeable = pr_data.get("mergeable", "UNKNOWN")
+    no_conflicts = mergeable != "CONFLICTING"
+    items.append(("No conflicts", no_conflicts))
+
+    all_pass = all(ok for _, ok in items)
+    blockers = [name for name, ok in items if not ok]
+
+    if all_pass:
+        badge = "✅ Ready to merge — all checks passing"
+    elif len(blockers) <= 2:
+        badge = f"⚠️ Almost ready — needs: {', '.join(blockers)}"
+    else:
+        badge = f"❌ Blocked — {', '.join(blockers)}"
+
+    return {
+        "badge": badge,
+        "items": items,
+        "approvals": approvals,
+        "blockers": blockers,
+        "ready": all_pass,
+    }
+
+
+def format_relative_time(iso_str):
+    """Format ISO timestamp as relative time."""
+    try:
+        dt = datetime.fromisoformat(iso_str.replace("Z", "+00:00"))
+        now = datetime.now(timezone.utc)
+        delta = now - dt
+        days = delta.days
+        if days == 0:
+            hours = delta.seconds // 3600
+            return f"{hours} hours ago" if hours > 0 else "just now"
+        if days == 1:
+            return "1 day ago"
+        return f"{days} days ago"
+    except (ValueError, AttributeError):
+        return iso_str or "unknown"
+
+
+def suggest_action(readiness, assignment, priority_key, staleness, checks):
+    """Generate suggested action."""
+    if readiness["ready"]:
+        return "Merge when ready, or wait for additional review if desired."
+
+    suggestions = []
+    for name, ok in readiness["items"]:
+        if ok:
+            continue
+        if name == "Publish passed":
+            publish_check = checks.get("publish", {})
+            if not publish_check:
+                suggestions.append("Trigger `/publish` comment on the PR.")
+            else:
+                suggestions.append("Investigate publish failure.")
+        elif name == "Assignee present":
+            suggestions.append("Assign an individual owner from CODEOWNERS.")
+        elif name == "CODEOWNERS entry (addition)":
+            suggestions.append("Request CODEOWNERS entry from contributor.")
+        elif name == "Approved":
+            suggestions.append("Request review from assigned reviewer.")
+        elif name == "No conflicts":
+            suggestions.append("Rebase PR to resolve merge conflicts.")
+        elif name == "Smoke tests passed":
+            suggestions.append("Investigate smoke test failures.")
+
+    if staleness["days"] >= STALENESS_THRESHOLDS.get(priority_key, {}).get("alert", 14):
+        suggestions.append(f"PR is {staleness['days']} days stale — consider pinging the author.")
+
+    return "\n".join(f"- {s}" for s in suggestions) if suggestions else "Review blockers above."
+
+
+def build_analysis(pr_number, repo):
+    """Build full analysis data structure."""
+    pr_data = fetch_pr_context(pr_number, repo)
+    if not pr_data:
+        print(f"Error: Could not fetch PR #{pr_number}", file=sys.stderr)
+        sys.exit(1)
+
+    labels = pr_data.get("labels") or []
+    files = pr_data.get("files") or []
+    priority_key, priority_label = classify_priority(labels)
+    workspaces = extract_workspaces(files)
+    assignment = assess_assignment(pr_data)
+    checks = assess_checks(pr_data)
+    codeowners_content = fetch_codeowners(repo)
+    codeowner_entries = find_codeowner(workspaces, codeowners_content)
+    codeowners_modified = check_codeowners_modified(files)
+    source_json_files = check_source_json_modified(files)
+    is_addition = any(l["name"] == "workspace-addition" for l in labels)
+    staleness = compute_staleness(pr_data.get("updatedAt", ""), priority_key)
+    approvals = get_approvals(pr_data)
+    readiness = determine_merge_readiness(
+        pr_data, checks, assignment, priority_key, codeowners_modified, is_addition
+    )
+    action = suggest_action(readiness, assignment, priority_key, staleness, checks)
+
+    author = pr_data.get("author", {}).get("login", "unknown")
+
+    return {
+        "pr_number": pr_data.get("number", pr_number),
+        "title": pr_data.get("title", ""),
+        "author": author,
+        "state": pr_data.get("state", ""),
+        "priority_key": priority_key,
+        "priority_label": priority_label,
+        "labels": [l["name"] for l in labels],
+        "workspaces": workspaces,
+        "created_at": pr_data.get("createdAt", ""),
+        "updated_at": pr_data.get("updatedAt", ""),
+        "created_relative": format_relative_time(pr_data.get("createdAt", "")),
+        "updated_relative": format_relative_time(pr_data.get("updatedAt", "")),
+        "staleness": staleness,
+        "assignment": assignment,
+        "codeowner_entries": codeowner_entries,
+        "codeowners_modified": codeowners_modified,
+        "source_json_modified": source_json_files,
+        "checks": {
+            name: {"conclusion": v["conclusion"], "status": v["status"], "display": v["display"]}
+            for name, v in checks.items()
+        },
+        "approvals": approvals,
+        "mergeable": pr_data.get("mergeable", "UNKNOWN"),
+        "readiness": {
+            "badge": readiness["badge"],
+            "ready": readiness["ready"],
+            "checklist": [{"item": name, "passed": ok} for name, ok in readiness["items"]],
+            "blockers": readiness["blockers"],
+        },
+        "suggested_action": action,
+    }
+
+
+def format_markdown(analysis):
+    """Format analysis as human-readable markdown."""
+    a = analysis
+    lines = []
+    lines.append(f"## PR #{a['pr_number']} Analysis\n")
+    lines.append(f"**Title:** {a['title']}")
+    lines.append(f"**Author:** @{a['author']}")
+    lines.append(f"**Priority:** {a['priority_label']}")
+    lines.append(f"**Created:** {a['created_relative']}")
+    lines.append(f"**Last Activity:** {a['updated_relative']}")
+    if a["workspaces"]:
+        lines.append(f"**Workspaces:** {', '.join(a['workspaces'])}")
+    lines.append(f"**Staleness:** {a['staleness']['level']} ({a['staleness']['days']} days)")
+    lines.append("")
+
+    # Assignment
+    lines.append("### Assignment")
+    lines.append("| Status | Details |")
+    lines.append("|--------|---------|")
+    asgn = a["assignment"]
+    lines.append(f"| Assignees | {', '.join('@' + u for u in asgn['assignees']) or '(none)'} |")
+    lines.append(f"| Individual Reviewers | {', '.join('@' + u for u in asgn['individual_reviewers']) or '(none)'} |")
+    if asgn["team_reviewers"]:
+        lines.append(f"| Team Reviewers | {', '.join(asgn['team_reviewers'])} |")
+    lines.append(f"| Verdict | {asgn['status']} |")
+    lines.append("")
+
+    # CODEOWNERS
+    if a["codeowner_entries"]:
+        lines.append("### CODEOWNERS")
+        for ws, entries in a["codeowner_entries"].items():
+            if entries:
+                lines.append(f"- `{ws}`: {', '.join(entries)}")
+            else:
+                lines.append(f"- `{ws}`: ❌ No entry found")
+        if a.get("source_json_modified"):
+            lines.append(f"- CODEOWNERS modified in PR: {'✅ Yes' if a['codeowners_modified'] else '❌ No'}")
+        lines.append("")
+
+    # Checks
+    lines.append("### Checks")
+    if a["checks"]:
+        lines.append("| Check | Status |")
+        lines.append("|-------|--------|")
+        for name, info in a["checks"].items():
+            lines.append(f"| {name} | {info['display']} |")
+    else:
+        lines.append("No status checks found.")
+    lines.append("")
+
+    # Merge readiness
+    lines.append("### Merge Readiness")
+    lines.append(f"{a['readiness']['badge']}\n")
+    for item in a["readiness"]["checklist"]:
+        check = "x" if item["passed"] else " "
+        lines.append(f"- [{check}] {item['item']}")
+    if a["approvals"]:
+        lines.append(f"\nApproved by: {', '.join('@' + u for u in a['approvals'])}")
+    lines.append("")
+
+    # Suggested action
+    lines.append("### Suggested Action")
+    lines.append(a["suggested_action"])
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Analyze a single overlay repository PR.",
+        epilog="Example: %(prog)s 1234 --json",
+    )
+    parser.add_argument(
+        "pr_number", type=int, help="PR number to analyze"
+    )
+    parser.add_argument(
+        "--repo", default=DEFAULT_REPO,
+        help=f"GitHub repository (default: {DEFAULT_REPO})",
+    )
+    parser.add_argument(
+        "--json", dest="json_output", action="store_true",
+        help="Output structured JSON instead of markdown",
+    )
+    args = parser.parse_args()
+
+    analysis = build_analysis(args.pr_number, args.repo)
+
+    if args.json_output:
+        print(json.dumps(analysis, indent=2))
+    else:
+        print(format_markdown(analysis))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/overlay/scripts/analyze-pr.py
+++ b/skills/overlay/scripts/analyze-pr.py
@@ -6,13 +6,14 @@ Gathers PR metadata, checks, workspace, CODEOWNERS, and produces
 a structured analysis with priority, assignment, and merge readiness.
 """
 
+from __future__ import annotations
+
 import argparse
 import base64
 import json
 import subprocess
 import sys
 from datetime import datetime, timezone
-
 
 DEFAULT_REPO = "redhat-developer/rhdh-plugin-export-overlays"
 
@@ -95,7 +96,7 @@ def fetch_codeowners(repo):
 
 def classify_priority(labels):
     """Classify PR priority based on labels."""
-    names = [l["name"] for l in labels] if labels else []
+    names = [lbl["name"] for lbl in labels] if labels else []
 
     if "do-not-merge" in names:
         return "skip", "⚫ Skip (do-not-merge)"
@@ -367,7 +368,7 @@ def build_analysis(pr_number, repo):
     codeowner_entries = find_codeowner(workspaces, codeowners_content)
     codeowners_modified = check_codeowners_modified(files)
     source_json_files = check_source_json_modified(files)
-    is_addition = any(l["name"] == "workspace-addition" for l in labels)
+    is_addition = any(lbl["name"] == "workspace-addition" for lbl in labels)
     staleness = compute_staleness(pr_data.get("updatedAt", ""), priority_key)
     approvals = get_approvals(pr_data)
     readiness = determine_merge_readiness(
@@ -384,7 +385,7 @@ def build_analysis(pr_number, repo):
         "state": pr_data.get("state", ""),
         "priority_key": priority_key,
         "priority_label": priority_label,
-        "labels": [l["name"] for l in labels],
+        "labels": [lbl["name"] for lbl in labels],
         "workspaces": workspaces,
         "created_at": pr_data.get("createdAt", ""),
         "updated_at": pr_data.get("updatedAt", ""),

--- a/skills/overlay/scripts/triage-prs.py
+++ b/skills/overlay/scripts/triage-prs.py
@@ -28,9 +28,7 @@ def run_gh(args, check=True):
     """Run a gh CLI command and return parsed JSON output."""
     cmd = ["gh"] + args
     try:
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, check=check, timeout=60
-        )
+        result = subprocess.run(cmd, capture_output=True, text=True, check=check, timeout=60)
         if result.stdout.strip():
             return json.loads(result.stdout)
         return None
@@ -49,11 +47,23 @@ def run_gh(args, check=True):
 
 def fetch_open_prs(repo):
     """Fetch all open PRs with context."""
-    return run_gh([
-        "pr", "list", "--repo", repo, "--state", "open", "--limit", "100",
-        "--json",
-        "number,title,labels,assignees,updatedAt,createdAt,author,reviewRequests",
-    ]) or []
+    return (
+        run_gh(
+            [
+                "pr",
+                "list",
+                "--repo",
+                repo,
+                "--state",
+                "open",
+                "--limit",
+                "100",
+                "--json",
+                "number,title,labels,assignees,updatedAt,createdAt,author,reviewRequests",
+            ]
+        )
+        or []
+    )
 
 
 def classify_priority(labels):
@@ -101,7 +111,9 @@ def assess_assignment(pr):
     assignees = [a.get("login", "") for a in (pr.get("assignees") or []) if a.get("login")]
     review_requests = pr.get("reviewRequests") or []
     individual_reviewers = [r.get("login", "") for r in review_requests if r.get("login")]
-    team_reviewers = [r.get("name", "") for r in review_requests if r.get("name") and not r.get("login")]
+    team_reviewers = [
+        r.get("name", "") for r in review_requests if r.get("name") and not r.get("login")
+    ]
 
     if assignees:
         return ", ".join(f"@{u}" for u in assignees), "✅"
@@ -118,7 +130,7 @@ def extract_workspace_from_title(title):
     lower = title.lower()
     for prefix in ["update ", "add "]:
         if lower.startswith(prefix):
-            rest = title[len(prefix):]
+            rest = title[len(prefix) :]
             # Take first word or up to " workspace"
             idx = rest.lower().find(" workspace")
             if idx > 0:
@@ -224,7 +236,11 @@ def format_markdown(categorized, total, repo):
         lines.append("| PR | Plugin | Days Stale | Assignee | Action |")
         lines.append("|----|--------|------------|----------|--------|")
         for pr in categorized["critical"]:
-            stale_col = f"{pr['stale_icon']} {pr['days_stale']}" if pr["stale_icon"] else str(pr["days_stale"])
+            stale_col = (
+                f"{pr['stale_icon']} {pr['days_stale']}"
+                if pr["stale_icon"]
+                else str(pr["days_stale"])
+            )
             lines.append(
                 f"| #{pr['number']} | {pr['plugin']} | {stale_col} "
                 f"| {pr['assignee_icon']} {pr['assignee_display']} | {pr['action']} |"
@@ -239,7 +255,11 @@ def format_markdown(categorized, total, repo):
         lines.append("| PR | Plugin | Days Stale | Assignee | Action |")
         lines.append("|----|--------|------------|----------|--------|")
         for pr in categorized["medium"]:
-            stale_col = f"{pr['stale_icon']} {pr['days_stale']}" if pr["stale_icon"] else str(pr["days_stale"])
+            stale_col = (
+                f"{pr['stale_icon']} {pr['days_stale']}"
+                if pr["stale_icon"]
+                else str(pr["days_stale"])
+            )
             lines.append(
                 f"| #{pr['number']} | {pr['plugin']} | {stale_col} "
                 f"| {pr['assignee_icon']} {pr['assignee_display']} | {pr['action']} |"
@@ -254,7 +274,11 @@ def format_markdown(categorized, total, repo):
         lines.append("| PR | Plugin | Days Stale | Assignee | Action |")
         lines.append("|----|--------|------------|----------|--------|")
         for pr in categorized["low"]:
-            stale_col = f"{pr['stale_icon']} {pr['days_stale']}" if pr["stale_icon"] else str(pr["days_stale"])
+            stale_col = (
+                f"{pr['stale_icon']} {pr['days_stale']}"
+                if pr["stale_icon"]
+                else str(pr["days_stale"])
+            )
             lines.append(
                 f"| #{pr['number']} | {pr['plugin']} | {stale_col} "
                 f"| {pr['assignee_icon']} {pr['assignee_display']} | {pr['action']} |"
@@ -328,11 +352,14 @@ def main():
         epilog="Example: %(prog)s --json",
     )
     parser.add_argument(
-        "--repo", default=DEFAULT_REPO,
+        "--repo",
+        default=DEFAULT_REPO,
         help=f"GitHub repository (default: {DEFAULT_REPO})",
     )
     parser.add_argument(
-        "--json", dest="json_output", action="store_true",
+        "--json",
+        dest="json_output",
+        action="store_true",
         help="Output structured JSON instead of markdown",
     )
     args = parser.parse_args()

--- a/skills/overlay/scripts/triage-prs.py
+++ b/skills/overlay/scripts/triage-prs.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Triage all open overlay repository PRs.
+
+Fetches open PRs, classifies by priority tier, checks staleness,
+evaluates assignment status, and generates a grouped triage report.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+
+DEFAULT_REPO = "redhat-developer/rhdh-plugin-export-overlays"
+
+STALENESS_THRESHOLDS = {
+    "critical": {"warn": 2, "alert": 5},
+    "medium": {"warn": 5, "alert": 10},
+    "low": {"warn": 14, "alert": 30},
+    "skip": {"warn": 999, "alert": 999},
+    "unknown": {"warn": 7, "alert": 14},
+}
+
+
+def run_gh(args, check=True):
+    """Run a gh CLI command and return parsed JSON output."""
+    cmd = ["gh"] + args
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, check=check, timeout=60
+        )
+        if result.stdout.strip():
+            return json.loads(result.stdout)
+        return None
+    except subprocess.CalledProcessError as exc:
+        print(f"Error running: {' '.join(cmd)}", file=sys.stderr)
+        print(exc.stderr, file=sys.stderr)
+        if check:
+            sys.exit(1)
+        return None
+    except json.JSONDecodeError:
+        return None
+    except FileNotFoundError:
+        print("Error: gh CLI not found. Install from https://cli.github.com/", file=sys.stderr)
+        sys.exit(1)
+
+
+def fetch_open_prs(repo):
+    """Fetch all open PRs with context."""
+    return run_gh([
+        "pr", "list", "--repo", repo, "--state", "open", "--limit", "100",
+        "--json",
+        "number,title,labels,assignees,updatedAt,createdAt,author,reviewRequests",
+    ]) or []
+
+
+def classify_priority(labels):
+    """Classify PR priority based on labels."""
+    names = [l["name"] for l in labels] if labels else []
+
+    if "do-not-merge" in names:
+        return "skip", "⚫ Skip"
+
+    is_mandatory = "mandatory-workspace" in names
+    is_update = "workspace-update" in names
+    is_addition = "workspace-addition" in names
+
+    if is_mandatory and is_update:
+        return "critical", "🔴 Critical"
+    if is_mandatory and is_addition:
+        return "medium", "🟡 Medium"
+    if is_addition:
+        return "low", "🟢 Low"
+    return "unknown", "❓ Unknown"
+
+
+def compute_staleness(updated_at, priority_key):
+    """Compute days since last update and staleness level."""
+    try:
+        updated = datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
+        now = datetime.now(timezone.utc)
+        days = (now - updated).days
+    except (ValueError, AttributeError):
+        days = -1
+
+    thresholds = STALENESS_THRESHOLDS.get(priority_key, STALENESS_THRESHOLDS["unknown"])
+    if days >= thresholds["alert"]:
+        level = "🚨"
+    elif days >= thresholds["warn"]:
+        level = "⚠️"
+    else:
+        level = ""
+
+    return days, level
+
+
+def assess_assignment(pr):
+    """Assess assignment status of a PR."""
+    assignees = [a.get("login", "") for a in (pr.get("assignees") or []) if a.get("login")]
+    review_requests = pr.get("reviewRequests") or []
+    individual_reviewers = [r.get("login", "") for r in review_requests if r.get("login")]
+    team_reviewers = [r.get("name", "") for r in review_requests if r.get("name") and not r.get("login")]
+
+    if assignees:
+        return ", ".join(f"@{u}" for u in assignees), "✅"
+    if individual_reviewers:
+        return ", ".join(f"@{u}" for u in individual_reviewers) + " (reviewer)", "⚠️"
+    if team_reviewers:
+        return ", ".join(team_reviewers) + " (team)", "⚠️"
+    return "(none)", "❌"
+
+
+def extract_workspace_from_title(title):
+    """Best-effort workspace extraction from PR title."""
+    # Titles often follow: "Update <workspace> workspace to ..." or "Add <workspace> workspace"
+    lower = title.lower()
+    for prefix in ["update ", "add "]:
+        if lower.startswith(prefix):
+            rest = title[len(prefix):]
+            # Take first word or up to " workspace"
+            idx = rest.lower().find(" workspace")
+            if idx > 0:
+                return rest[:idx].strip()
+            parts = rest.split()
+            if parts:
+                return parts[0].strip()
+    # Fallback: first significant word
+    return title.split(":")[0].strip() if ":" in title else title[:40]
+
+
+def suggest_action(pr_info):
+    """Suggest action for a PR based on its state."""
+    priority = pr_info["priority_key"]
+    assignee_status = pr_info["assignee_icon"]
+    days = pr_info["days_stale"]
+
+    if priority == "skip":
+        return "No action (OCI only)"
+
+    actions = []
+    if assignee_status == "❌":
+        actions.append("Assign owner")
+    if days >= STALENESS_THRESHOLDS.get(priority, {}).get("alert", 14):
+        actions.append("Escalate (stale)")
+    elif days >= STALENESS_THRESHOLDS.get(priority, {}).get("warn", 7):
+        actions.append("Ping author")
+
+    if not actions:
+        actions.append("Monitor")
+
+    return " + ".join(actions)
+
+
+def build_triage(repo):
+    """Build triage data for all open PRs."""
+    prs = fetch_open_prs(repo)
+
+    categorized = {
+        "critical": [],
+        "medium": [],
+        "low": [],
+        "skip": [],
+        "unknown": [],
+    }
+
+    for pr in prs:
+        labels = pr.get("labels") or []
+        priority_key, priority_label = classify_priority(labels)
+        days, stale_icon = compute_staleness(pr.get("updatedAt", ""), priority_key)
+        assignee_display, assignee_icon = assess_assignment(pr)
+        plugin = extract_workspace_from_title(pr.get("title", ""))
+        author = pr.get("author", {}).get("login", "unknown")
+
+        info = {
+            "number": pr.get("number"),
+            "title": pr.get("title", ""),
+            "author": author,
+            "priority_key": priority_key,
+            "priority_label": priority_label,
+            "labels": [l["name"] for l in labels],
+            "plugin": plugin,
+            "days_stale": days,
+            "stale_icon": stale_icon,
+            "assignee_display": assignee_display,
+            "assignee_icon": assignee_icon,
+            "updated_at": pr.get("updatedAt", ""),
+            "created_at": pr.get("createdAt", ""),
+        }
+        info["action"] = suggest_action(info)
+        categorized[priority_key].append(info)
+
+    # Sort each tier by staleness descending (most stale first)
+    for key in categorized:
+        categorized[key].sort(key=lambda x: x["days_stale"], reverse=True)
+
+    return categorized, len(prs)
+
+
+def format_markdown(categorized, total, repo):
+    """Format triage report as markdown."""
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    lines = []
+    lines.append("## Overlay PR Triage Report")
+    lines.append(f"Generated: {now}")
+    lines.append(f"Repository: `{repo}`")
+    lines.append(f"Total open PRs: {total}")
+    lines.append("")
+
+    # Summary counts
+    lines.append("### Summary")
+    lines.append(f"- 🔴 Critical: {len(categorized['critical'])}")
+    lines.append(f"- 🟡 Medium: {len(categorized['medium'])}")
+    lines.append(f"- 🟢 Low: {len(categorized['low'])}")
+    lines.append(f"- ⚫ Skip: {len(categorized['skip'])}")
+    if categorized["unknown"]:
+        lines.append(f"- ❓ Unknown: {len(categorized['unknown'])}")
+    lines.append("")
+
+    # Critical
+    lines.append("### 🔴 Critical — Mandatory Workspace Updates\n")
+    if categorized["critical"]:
+        lines.append("| PR | Plugin | Days Stale | Assignee | Action |")
+        lines.append("|----|--------|------------|----------|--------|")
+        for pr in categorized["critical"]:
+            stale_col = f"{pr['stale_icon']} {pr['days_stale']}" if pr["stale_icon"] else str(pr["days_stale"])
+            lines.append(
+                f"| #{pr['number']} | {pr['plugin']} | {stale_col} "
+                f"| {pr['assignee_icon']} {pr['assignee_display']} | {pr['action']} |"
+            )
+    else:
+        lines.append("No critical PRs. ✅")
+    lines.append("")
+
+    # Medium
+    lines.append("### 🟡 Medium — Mandatory Workspace Additions\n")
+    if categorized["medium"]:
+        lines.append("| PR | Plugin | Days Stale | Assignee | Action |")
+        lines.append("|----|--------|------------|----------|--------|")
+        for pr in categorized["medium"]:
+            stale_col = f"{pr['stale_icon']} {pr['days_stale']}" if pr["stale_icon"] else str(pr["days_stale"])
+            lines.append(
+                f"| #{pr['number']} | {pr['plugin']} | {stale_col} "
+                f"| {pr['assignee_icon']} {pr['assignee_display']} | {pr['action']} |"
+            )
+    else:
+        lines.append("No medium-priority PRs.")
+    lines.append("")
+
+    # Low
+    lines.append("### 🟢 Low — Community Additions\n")
+    if categorized["low"]:
+        lines.append("| PR | Plugin | Days Stale | Assignee | Action |")
+        lines.append("|----|--------|------------|----------|--------|")
+        for pr in categorized["low"]:
+            stale_col = f"{pr['stale_icon']} {pr['days_stale']}" if pr["stale_icon"] else str(pr["days_stale"])
+            lines.append(
+                f"| #{pr['number']} | {pr['plugin']} | {stale_col} "
+                f"| {pr['assignee_icon']} {pr['assignee_display']} | {pr['action']} |"
+            )
+    else:
+        lines.append("No low-priority PRs.")
+    lines.append("")
+
+    # Skip
+    lines.append("### ⚫ Skipped — Do Not Merge\n")
+    if categorized["skip"]:
+        lines.append("| PR | Plugin | Reason |")
+        lines.append("|----|--------|--------|")
+        for pr in categorized["skip"]:
+            lines.append(f"| #{pr['number']} | {pr['plugin']} | OCI artifact only |")
+    else:
+        lines.append("No skipped PRs.")
+    lines.append("")
+
+    # Unknown
+    if categorized["unknown"]:
+        lines.append("### ❓ Unknown — Needs Labels\n")
+        lines.append("| PR | Title | Days Stale | Author |")
+        lines.append("|----|-------|------------|--------|")
+        for pr in categorized["unknown"]:
+            lines.append(
+                f"| #{pr['number']} | {pr['title'][:50]} | {pr['days_stale']} | @{pr['author']} |"
+            )
+        lines.append("")
+
+    # Suggested actions
+    action_items = []
+    for tier in ["critical", "medium", "low"]:
+        for pr in categorized[tier]:
+            if pr["action"] != "Monitor":
+                action_items.append(pr)
+
+    if action_items:
+        lines.append("---\n")
+        lines.append("## Suggested Actions\n")
+        for i, pr in enumerate(action_items, 1):
+            lines.append(
+                f"{i}. [ ] **{pr['action']}** — PR #{pr['number']} "
+                f"({pr['plugin']}, {pr['days_stale']} days stale)"
+            )
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def format_json(categorized, total, repo):
+    """Format triage data as JSON."""
+    return {
+        "repo": repo,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "total_open": total,
+        "summary": {
+            "critical": len(categorized["critical"]),
+            "medium": len(categorized["medium"]),
+            "low": len(categorized["low"]),
+            "skip": len(categorized["skip"]),
+            "unknown": len(categorized["unknown"]),
+        },
+        "prs": categorized,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Triage all open overlay repository PRs.",
+        epilog="Example: %(prog)s --json",
+    )
+    parser.add_argument(
+        "--repo", default=DEFAULT_REPO,
+        help=f"GitHub repository (default: {DEFAULT_REPO})",
+    )
+    parser.add_argument(
+        "--json", dest="json_output", action="store_true",
+        help="Output structured JSON instead of markdown",
+    )
+    args = parser.parse_args()
+
+    categorized, total = build_triage(args.repo)
+
+    if args.json_output:
+        print(json.dumps(format_json(categorized, total, args.repo), indent=2))
+    else:
+        print(format_markdown(categorized, total, args.repo))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/overlay/scripts/triage-prs.py
+++ b/skills/overlay/scripts/triage-prs.py
@@ -364,6 +364,10 @@ def main():
     )
     args = parser.parse_args()
 
+    # Ensure UTF-8 output on Windows (emoji in priority labels)
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")
+
     categorized, total = build_triage(args.repo)
 
     if args.json_output:

--- a/skills/overlay/scripts/triage-prs.py
+++ b/skills/overlay/scripts/triage-prs.py
@@ -5,12 +5,13 @@ Fetches open PRs, classifies by priority tier, checks staleness,
 evaluates assignment status, and generates a grouped triage report.
 """
 
+from __future__ import annotations
+
 import argparse
 import json
 import subprocess
 import sys
 from datetime import datetime, timezone
-
 
 DEFAULT_REPO = "redhat-developer/rhdh-plugin-export-overlays"
 
@@ -57,7 +58,7 @@ def fetch_open_prs(repo):
 
 def classify_priority(labels):
     """Classify PR priority based on labels."""
-    names = [l["name"] for l in labels] if labels else []
+    names = [lbl["name"] for lbl in labels] if labels else []
 
     if "do-not-merge" in names:
         return "skip", "⚫ Skip"
@@ -178,7 +179,7 @@ def build_triage(repo):
             "author": author,
             "priority_key": priority_key,
             "priority_label": priority_label,
-            "labels": [l["name"] for l in labels],
+            "labels": [lbl["name"] for lbl in labels],
             "plugin": plugin,
             "days_stale": days,
             "stale_icon": stale_icon,

--- a/skills/overlay/workflows/analyze-pr.md
+++ b/skills/overlay/workflows/analyze-pr.md
@@ -2,10 +2,29 @@
 
 Deep-dive analysis of a single overlay repository PR — check assignment, compatibility, and merge readiness.
 
+## Quick Start (Script)
+
+Use the consolidated script as the primary method:
+
+```bash
+# Human-readable markdown report
+python skills/overlay/scripts/analyze-pr.py 1234
+
+# Structured JSON for programmatic use
+python skills/overlay/scripts/analyze-pr.py 1234 --json
+
+# Custom repo
+python skills/overlay/scripts/analyze-pr.py 1234 --repo owner/repo
+```
+
+The script consolidates all `gh` API calls below into a single pass and produces
+the output template from Step 8. Use the manual steps below only when debugging
+or when the script output needs deeper investigation.
+
 <required_reading>
 **Read these reference files NOW:**
 
-1. `references/github-queries.md` — gh CLI patterns
+1. `../../rhdh/references/github-reference.md` — gh CLI patterns
 2. `references/label-priority.md` — Priority classification
 </required_reading>
 
@@ -226,25 +245,25 @@ Log PR analysis for tracking review patterns:
 
 ```bash
 # Analysis complete
-rhdh-plugin log add "Analyzed PR #<number>: <status> (<plugin-name>)" --tag analyze-pr --tag <plugin-name>
+$RHDH log add "Analyzed PR #<number>: <status> (<plugin-name>)" --tag analyze-pr --tag <plugin-name>
 
 # Actions taken
-rhdh-plugin log add "Triggered /publish on PR #<number>" --tag analyze-pr --tag publish
-rhdh-plugin log add "Requested changes on PR #<number>: <reason>" --tag analyze-pr --tag review
-rhdh-plugin log add "Approved PR #<number>" --tag analyze-pr --tag review
+$RHDH log add "Triggered /publish on PR #<number>" --tag analyze-pr --tag publish
+$RHDH log add "Requested changes on PR #<number>: <reason>" --tag analyze-pr --tag review
+$RHDH log add "Approved PR #<number>" --tag analyze-pr --tag review
 ```
 
 ## Follow-up Todos
 
 ```bash
 # If PR needs external input
-rhdh-plugin todo add "Request CODEOWNERS entry from @<author> on PR #<number>" --context "PR #<number>"
+$RHDH todo add "Request CODEOWNERS entry from @<author> on PR #<number>" --context "PR #<number>"
 
 # If compatibility concern
-rhdh-plugin todo add "Verify <plugin> compat after backstage bump" --context "PR #<number>"
+$RHDH todo add "Verify <plugin> compat after backstage bump" --context "PR #<number>"
 
 # If waiting on contributor
-rhdh-plugin todo add "Follow up with @<author> on PR #<number> feedback" --context "PR #<number>"
+$RHDH todo add "Follow up with @<author> on PR #<number> feedback" --context "PR #<number>"
 ```
 
 </tracking>

--- a/skills/overlay/workflows/analyze-pr.md
+++ b/skills/overlay/workflows/analyze-pr.md
@@ -2,24 +2,14 @@
 
 Deep-dive analysis of a single overlay repository PR — check assignment, compatibility, and merge readiness.
 
-## Quick Start (Script)
-
-Use the consolidated script as the primary method:
+Run the analysis script to get a full report in one pass:
 
 ```bash
-# Human-readable markdown report
-python skills/overlay/scripts/analyze-pr.py 1234
-
-# Structured JSON for programmatic use
-python skills/overlay/scripts/analyze-pr.py 1234 --json
-
-# Custom repo
-python skills/overlay/scripts/analyze-pr.py 1234 --repo owner/repo
+python scripts/analyze-pr.py <pr-number>           # markdown report
+python scripts/analyze-pr.py <pr-number> --json     # structured JSON
 ```
 
-The script consolidates all `gh` API calls below into a single pass and produces
-the output template from Step 8. Use the manual steps below only when debugging
-or when the script output needs deeper investigation.
+The steps below explain the manual approach for debugging or deeper investigation.
 
 <required_reading>
 **Read these reference files NOW:**

--- a/skills/overlay/workflows/doctor.md
+++ b/skills/overlay/workflows/doctor.md
@@ -12,12 +12,12 @@ Diagnose and fix environment issues for the RHDH Plugin skill.
 ## Fastest Path
 
 ```bash
-rhdh-plugin setup submodule add --all
+$RHDH setup submodule add --all
 ```
 
 Creates `repo/` directory with required repositories as git submodules.
 
-Run `rhdh-plugin` to verify setup, then continue with your original task.
+Run `$RHDH` to verify setup, then continue with your original task.
 </quick_start>
 
 <process>
@@ -25,9 +25,9 @@ Run `rhdh-plugin` to verify setup, then continue with your original task.
 ## Option 1: Submodules (Recommended)
 
 ```bash
-rhdh-plugin setup submodule list      # Check status
-rhdh-plugin setup submodule add --all # Add required repos
-rhdh-plugin                           # Verify
+$RHDH setup submodule list      # Check status
+$RHDH setup submodule add --all # Add required repos
+$RHDH                           # Verify
 ```
 
 ## Option 2: Existing Checkouts
@@ -35,9 +35,9 @@ rhdh-plugin                           # Verify
 Point to repositories you've already cloned:
 
 ```bash
-rhdh-plugin config set repos.overlay /path/to/rhdh-plugin-export-overlays
-rhdh-plugin config set repos.local /path/to/rhdh-local
-rhdh-plugin                           # Verify
+$RHDH config set repos.overlay /path/to/rhdh-plugin-export-overlays
+$RHDH config set repos.local /path/to/rhdh-local
+$RHDH                           # Verify
 ```
 
 ## Option 3: Environment Variables
@@ -59,23 +59,23 @@ Log setup events for troubleshooting:
 
 ```bash
 # Initial setup
-rhdh-plugin log add "Environment setup complete" --tag setup
+$RHDH log add "Environment setup complete" --tag setup
 
 # Configuration changes
-rhdh-plugin log add "Configured overlay repo: <path>" --tag setup --tag config
-rhdh-plugin log add "Configured rhdh-local: <path>" --tag setup --tag config
+$RHDH log add "Configured overlay repo: <path>" --tag setup --tag config
+$RHDH log add "Configured rhdh-local: <path>" --tag setup --tag config
 ```
 
 ## Follow-up Todos
 
 ```bash
 # If setup blocked
-rhdh-plugin todo add "Request access to overlay repo" --context "setup"
-rhdh-plugin todo add "Set up GitHub SSH keys" --context "setup"
+$RHDH todo add "Request access to overlay repo" --context "setup"
+$RHDH todo add "Set up GitHub SSH keys" --context "setup"
 ```
 
 </tracking>
 
 <success_criteria>
-Setup complete when `rhdh-plugin` shows `needs_setup: false`.
+Setup complete when `$RHDH` shows `needs_setup: false`.
 </success_criteria>

--- a/skills/overlay/workflows/fix-build.md
+++ b/skills/overlay/workflows/fix-build.md
@@ -72,26 +72,26 @@ Log fix attempts for debugging patterns:
 
 ```bash
 # Problem identified
-rhdh-plugin log add "Build failure: <error-type> on <workspace>" --tag fix-build --tag <workspace>
+$RHDH log add "Build failure: <error-type> on <workspace>" --tag fix-build --tag <workspace>
 
 # Fix applied
-rhdh-plugin log add "Applied fix: <what-was-fixed> on <workspace>" --tag fix-build --tag <workspace>
+$RHDH log add "Applied fix: <what-was-fixed> on <workspace>" --tag fix-build --tag <workspace>
 
 # Resolution
-rhdh-plugin log add "Build fixed: <workspace> now passing" --tag fix-build --tag <workspace>
+$RHDH log add "Build fixed: <workspace> now passing" --tag fix-build --tag <workspace>
 ```
 
 ## Follow-up Todos
 
 ```bash
 # If fix requires upstream change
-rhdh-plugin todo add "Open upstream issue for <problem>" --context "<workspace>"
+$RHDH todo add "Open upstream issue for <problem>" --context "<workspace>"
 
 # If fix is a workaround
-rhdh-plugin todo add "Remove workaround when upstream releases <version>" --context "<workspace>"
+$RHDH todo add "Remove workaround when upstream releases <version>" --context "<workspace>"
 
 # Track flaky builds
-rhdh-plugin todo add "Investigate flaky build on <workspace>" --context "<workspace>"
+$RHDH todo add "Investigate flaky build on <workspace>" --context "<workspace>"
 ```
 
 </tracking>

--- a/skills/overlay/workflows/onboard-plugin.md
+++ b/skills/overlay/workflows/onboard-plugin.md
@@ -391,7 +391,7 @@ If tracking this work in JIRA, update the ticket after merge.
 
 **Reference:** See [RHIDP-11137](https://issues.redhat.com/browse/RHIDP-11137) for an example of how plugin onboarding was tracked.
 
-**Details:** `references/jira-reference.md` has CLI patterns if needed.
+**Details:** `../../rhdh/references/jira-reference.md` has CLI patterns if needed.
 
 </process>
 
@@ -412,15 +412,15 @@ Log key milestones to maintain context across sessions:
 
 ```bash
 # Starting onboard
-rhdh-plugin log add "Started onboard: <plugin-name> from <upstream-url>" --tag onboard --tag <plugin-name>
+$RHDH log add "Started onboard: <plugin-name> from <upstream-url>" --tag onboard --tag <plugin-name>
 
 # Phase completions
-rhdh-plugin log add "Phase 1 complete: <plugin-name> approved for onboard" --tag onboard --tag <plugin-name>
-rhdh-plugin log add "Phase 2 complete: workspace created for <plugin-name>" --tag onboard --tag <plugin-name>
-rhdh-plugin log add "Phase 3 complete: PR opened #<number>" --tag onboard --tag <plugin-name>
-rhdh-plugin log add "Phase 4 complete: metadata added for <plugin-name>" --tag onboard --tag <plugin-name>
-rhdh-plugin log add "Phase 5 complete: <plugin-name> verified locally" --tag onboard --tag <plugin-name>
-rhdh-plugin log add "Onboard complete: <plugin-name> merged" --tag onboard --tag <plugin-name>
+$RHDH log add "Phase 1 complete: <plugin-name> approved for onboard" --tag onboard --tag <plugin-name>
+$RHDH log add "Phase 2 complete: workspace created for <plugin-name>" --tag onboard --tag <plugin-name>
+$RHDH log add "Phase 3 complete: PR opened #<number>" --tag onboard --tag <plugin-name>
+$RHDH log add "Phase 4 complete: metadata added for <plugin-name>" --tag onboard --tag <plugin-name>
+$RHDH log add "Phase 5 complete: <plugin-name> verified locally" --tag onboard --tag <plugin-name>
+$RHDH log add "Onboard complete: <plugin-name> merged" --tag onboard --tag <plugin-name>
 ```
 
 ## Follow-up Todos
@@ -429,29 +429,29 @@ Create todos when blocked or when follow-up is needed:
 
 ```bash
 # License unclear
-rhdh-plugin todo add "Check license with legal for <plugin-name>" --context "<plugin-name>"
+$RHDH todo add "Check license with legal for <plugin-name>" --context "<plugin-name>"
 
 # Waiting on external response
-rhdh-plugin todo add "Follow up with upstream maintainer on <issue>" --context "<plugin-name>"
+$RHDH todo add "Follow up with upstream maintainer on <issue>" --context "<plugin-name>"
 
 # Post-merge follow-up
-rhdh-plugin todo add "Verify <plugin-name> in next RHDH release" --context "<plugin-name>"
+$RHDH todo add "Verify <plugin-name> in next RHDH release" --context "<plugin-name>"
 
 # Add notes to existing todo
-rhdh-plugin todo note <slug> "Sent email to legal@redhat.com"
-rhdh-plugin todo note <slug> "Response: approved with attribution"
-rhdh-plugin todo done <slug>
+$RHDH todo note <slug> "Sent email to legal@redhat.com"
+$RHDH todo note <slug> "Response: approved with attribution"
+$RHDH todo done <slug>
 ```
 
 ## Viewing History
 
 ```bash
 # Find all onboard activity
-rhdh-plugin log search "onboard"
-rhdh-plugin log search "<plugin-name>"
+$RHDH log search "onboard"
+$RHDH log search "<plugin-name>"
 
 # Check pending todos
-rhdh-plugin todo list --pending
+$RHDH todo list --pending
 ```
 
 </tracking>

--- a/skills/overlay/workflows/triage-prs.md
+++ b/skills/overlay/workflows/triage-prs.md
@@ -2,6 +2,25 @@
 
 Prioritize open PRs in the overlay repository by criticality and surface actionable next steps.
 
+## Quick Start (Script)
+
+Use the consolidated script as the primary method:
+
+```bash
+# Human-readable markdown triage report
+python skills/overlay/scripts/triage-prs.py
+
+# Structured JSON for programmatic use
+python skills/overlay/scripts/triage-prs.py --json
+
+# Custom repo
+python skills/overlay/scripts/triage-prs.py --repo owner/repo
+```
+
+The script fetches all open PRs, classifies by priority, checks staleness, and
+generates the grouped report from Phase 4. Use the manual steps below only when
+debugging or when taking actions described in Phase 5.
+
 <required_reading>
 **Read these reference files NOW:**
 

--- a/skills/overlay/workflows/triage-prs.md
+++ b/skills/overlay/workflows/triage-prs.md
@@ -2,24 +2,14 @@
 
 Prioritize open PRs in the overlay repository by criticality and surface actionable next steps.
 
-## Quick Start (Script)
-
-Use the consolidated script as the primary method:
+Run the triage script to generate a full prioritized report:
 
 ```bash
-# Human-readable markdown triage report
-python skills/overlay/scripts/triage-prs.py
-
-# Structured JSON for programmatic use
-python skills/overlay/scripts/triage-prs.py --json
-
-# Custom repo
-python skills/overlay/scripts/triage-prs.py --repo owner/repo
+python scripts/triage-prs.py              # markdown report
+python scripts/triage-prs.py --json        # structured JSON
 ```
 
-The script fetches all open PRs, classifies by priority, checks staleness, and
-generates the grouped report from Phase 4. Use the manual steps below only when
-debugging or when taking actions described in Phase 5.
+The manual phases below explain the classification logic and cover Phase 5 (taking action).
 
 <required_reading>
 **Read these reference files NOW:**

--- a/skills/overlay/workflows/update-plugin.md
+++ b/skills/overlay/workflows/update-plugin.md
@@ -75,26 +75,26 @@ Log version updates for release tracking:
 
 ```bash
 # Update started
-rhdh-plugin log add "Updating <plugin-name>: <old-ref> → <new-ref>" --tag update --tag <plugin-name>
+$RHDH log add "Updating <plugin-name>: <old-ref> → <new-ref>" --tag update --tag <plugin-name>
 
 # PR created
-rhdh-plugin log add "Update PR opened: #<number> for <plugin-name>" --tag update --tag <plugin-name>
+$RHDH log add "Update PR opened: #<number> for <plugin-name>" --tag update --tag <plugin-name>
 
 # Update complete
-rhdh-plugin log add "Update complete: <plugin-name> now at <new-ref>" --tag update --tag <plugin-name>
+$RHDH log add "Update complete: <plugin-name> now at <new-ref>" --tag update --tag <plugin-name>
 ```
 
 ## Follow-up Todos
 
 ```bash
 # If update blocked by compatibility
-rhdh-plugin todo add "Wait for RHDH backstage bump before updating <plugin>" --context "<plugin-name>"
+$RHDH todo add "Wait for RHDH backstage bump before updating <plugin>" --context "<plugin-name>"
 
 # If upstream has breaking changes
-rhdh-plugin todo add "Review breaking changes in <plugin> <version>" --context "<plugin-name>"
+$RHDH todo add "Review breaking changes in <plugin> <version>" --context "<plugin-name>"
 
 # Post-update verification
-rhdh-plugin todo add "Verify <plugin> in staging after release" --context "<plugin-name>"
+$RHDH todo add "Verify <plugin> in staging after release" --context "<plugin-name>"
 ```
 
 </tracking>

--- a/skills/rhdh-local/SKILL.md
+++ b/skills/rhdh-local/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rhdh-local
-description: Skill for testing RHDH plugins locally using the rhdh-local-setup customization system. Covers enabling/disabling plugins, switching modes, and running end-to-end plugin tests.
+description: Skill for testing RHDH plugins locally using the rhdh-local-setup customization system. Covers enabling/disabling plugins, switching modes, running end-to-end plugin tests, starting/stopping RHDH (up/down), health checks, troubleshooting errors (504, startup failures), and backup/restore of configurations.
 ---
 
 <essential_principles>

--- a/skills/rhdh-local/references/env-reference.md
+++ b/skills/rhdh-local/references/env-reference.md
@@ -67,8 +67,8 @@ Override to pin specific RHDH versions.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `RHDH_IMAGE` | `quay.io/rhdh-community/rhdh:1.9` | RHDH container image |
-| `CATALOG_INDEX_IMAGE` | `quay.io/rhdh/plugin-catalog-index:1.9` | Extensions Catalog image |
+| `RHDH_IMAGE` | `quay.io/rhdh-community/rhdh:<version>` | RHDH container image (check `rhdh-local/default.env` for current default) |
+| `CATALOG_INDEX_IMAGE` | `quay.io/rhdh/plugin-catalog-index:<version>` | Extensions Catalog image (check `rhdh-local/default.env` for current default) |
 | `CATALOG_ENTITIES_EXTRACT_DIR` | `/extensions` | Catalog entities extract path |
 
 ## Lightspeed / AI

--- a/skills/rhdh-local/rhdh_local/sync.py
+++ b/skills/rhdh-local/rhdh_local/sync.py
@@ -66,7 +66,7 @@ def apply_customizations(workspace: Path) -> SyncResult:
         for src_file in src.glob(pattern):
             if not src_file.is_file():
                 continue
-            rel = str(src_file.relative_to(src))
+            rel = src_file.relative_to(src).as_posix()
             _copy_file(src_file, dst / rel, rel, result)
 
     return result
@@ -98,7 +98,7 @@ def remove_customizations(workspace: Path) -> SyncResult:
             for src_file in src.glob(pattern):
                 if not src_file.is_file():
                     continue
-                rel = str(src_file.relative_to(src))
+                rel = src_file.relative_to(src).as_posix()
                 _remove_file(dst / rel, rel, result)
 
     return result

--- a/skills/rhdh-local/scripts/fetch-plugin-metadata.py
+++ b/skills/rhdh-local/scripts/fetch-plugin-metadata.py
@@ -24,10 +24,7 @@ _CONTENTS_URL = (
     "https://api.github.com/repos/redhat-developer/rhdh-plugin-export-overlays"
     "/contents/catalog-entities/extensions/plugins"
 )
-_RAW_BASE = (
-    "https://raw.githubusercontent.com/redhat-developer/"
-    "rhdh-plugin-export-overlays/main"
-)
+_RAW_BASE = "https://raw.githubusercontent.com/redhat-developer/rhdh-plugin-export-overlays/main"
 
 # ANSI helpers
 _RED = "\033[0;31m"
@@ -41,6 +38,7 @@ _NC = "\033[0m"
 # ---------------------------------------------------------------------------
 # Minimal YAML parser (stdlib-only)
 # ---------------------------------------------------------------------------
+
 
 def _parse_yaml(text: str) -> dict[str, Any]:
     """Parse the subset of YAML used in plugin-export-overlays files.
@@ -154,7 +152,7 @@ def _parse_mapping(lines: list[str], idx: int, base_indent: int) -> tuple[dict[s
             continue
 
         key = stripped[:colon_pos].strip()
-        after_colon = stripped[colon_pos + 1:].strip()
+        after_colon = stripped[colon_pos + 1 :].strip()
 
         if after_colon and not after_colon.startswith("#"):
             # Inline scalar value
@@ -240,7 +238,7 @@ def _parse_list(lines: list[str], idx: int, base_indent: int) -> tuple[list[Any]
             # Inline mapping item – first key:value is on this line
             colon_pos = item_text.find(":")
             first_key = item_text[:colon_pos].strip()
-            first_val_str = item_text[colon_pos + 1:].strip()
+            first_val_str = item_text[colon_pos + 1 :].strip()
 
             item_dict: dict[str, Any] = {}
 
@@ -292,6 +290,7 @@ def _parse_list(lines: list[str], idx: int, base_indent: int) -> tuple[list[Any]
 # HTTP helpers
 # ---------------------------------------------------------------------------
 
+
 def _fetch(url: str) -> bytes:
     """Fetch *url* and return the response body bytes."""
     req = urllib.request.Request(url, headers={"User-Agent": "rhdh-skill/0.1"})
@@ -310,6 +309,7 @@ def _fetch_yaml(url: str) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 # Core logic
 # ---------------------------------------------------------------------------
+
 
 def list_plugins() -> list[str]:
     """Return sorted list of available plugin names."""
@@ -374,14 +374,14 @@ def _normalize_pkg_name(name: str) -> str:
         "@red-hat-developer-hub/",
     ):
         if n.startswith(pfx):
-            n = n[len(pfx):]
+            n = n[len(pfx) :]
             break
 
     # Strip vendor insertions (e.g. "redhat-") that appear before
     # the plugin's core name
     for vendor in ("redhat-", "red-hat-"):
         if n.startswith(vendor):
-            n = n[len(vendor):]
+            n = n[len(vendor) :]
             break
 
     return n
@@ -429,9 +429,7 @@ def fetch_plugin_metadata(plugin_name: str) -> dict[str, Any]:
     Returns a structured dict with plugin info and package details.
     """
     # Step 1: plugin definition
-    plugin_url = (
-        f"{_RAW_BASE}/catalog-entities/extensions/plugins/{plugin_name}.yaml"
-    )
+    plugin_url = f"{_RAW_BASE}/catalog-entities/extensions/plugins/{plugin_name}.yaml"
     try:
         plugin_def = _fetch_yaml(plugin_url)
     except urllib.error.HTTPError as exc:
@@ -447,9 +445,11 @@ def fetch_plugin_metadata(plugin_name: str) -> dict[str, Any]:
     annotations = _get(plugin_def, "metadata", "annotations", default={})
     pre_installed = False
     if isinstance(annotations, dict):
-        pre_installed = annotations.get(
-            "extensions.backstage.io/pre-installed", ""
-        ) in ("true", "True", True)
+        pre_installed = annotations.get("extensions.backstage.io/pre-installed", "") in (
+            "true",
+            "True",
+            True,
+        )
 
     # Step 2: per-package metadata
     # Pre-fetch the workspace metadata directory listing for the primary workspace
@@ -480,9 +480,7 @@ def fetch_plugin_metadata(plugin_name: str) -> dict[str, Any]:
 
         if match is not None:
             ws, file_name = match
-            pkg_url = (
-                f"{_RAW_BASE}/workspaces/{ws}/metadata/{file_name}.yaml"
-            )
+            pkg_url = f"{_RAW_BASE}/workspaces/{ws}/metadata/{file_name}.yaml"
             try:
                 pkg_def = _fetch_yaml(pkg_url)
             except urllib.error.HTTPError:
@@ -490,9 +488,7 @@ def fetch_plugin_metadata(plugin_name: str) -> dict[str, Any]:
 
         dynamic_artifact = _get(pkg_def, "spec", "dynamicArtifact", default=None)
         role = _get(pkg_def, "spec", "backstage", "role", default=None)
-        app_config_examples = _get(
-            pkg_def, "spec", "appConfigExamples", default=None
-        )
+        app_config_examples = _get(pkg_def, "spec", "appConfigExamples", default=None)
         part_of = _get(pkg_def, "spec", "partOf", default=None)
 
         pkg_result: dict[str, Any] = {"name": pkg_name}
@@ -532,12 +528,12 @@ def _derive_workspace(package_name: str) -> str | None:
         "janus-idp-backstage-plugin-",
     ):
         if name.startswith(prefix):
-            name = name[len(prefix):]
+            name = name[len(prefix) :]
             break
     # Strip vendor insertions
     for vendor in ("redhat-", "red-hat-"):
         if name.startswith(vendor):
-            name = name[len(vendor):]
+            name = name[len(vendor) :]
             break
     for suffix in ("-backend", "-common", "-react", "-module", "-node"):
         if name.endswith(suffix):
@@ -549,6 +545,7 @@ def _derive_workspace(package_name: str) -> str | None:
 # ---------------------------------------------------------------------------
 # Output helpers
 # ---------------------------------------------------------------------------
+
 
 def _print_human_list(plugins: list[str]) -> None:
     print(f"{_BOLD}Available plugins ({len(plugins)}):{_NC}\n")
@@ -598,6 +595,7 @@ def _print_human_metadata(data: dict[str, Any]) -> None:
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
+
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(

--- a/skills/rhdh-local/scripts/fetch-plugin-metadata.py
+++ b/skills/rhdh-local/scripts/fetch-plugin-metadata.py
@@ -1,0 +1,682 @@
+#!/usr/bin/env python3
+"""Fetch RHDH plugin metadata from the plugin-export-overlays repository.
+
+Replaces the manual 3-step curl chain in the enable-plugin workflow.
+Fetches plugin definition YAML + per-package metadata and outputs
+a structured summary (human-readable or JSON).
+
+Uses only Python stdlib (no PyYAML, no external deps).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# GitHub URLs
+# ---------------------------------------------------------------------------
+_CONTENTS_URL = (
+    "https://api.github.com/repos/redhat-developer/rhdh-plugin-export-overlays"
+    "/contents/catalog-entities/extensions/plugins"
+)
+_RAW_BASE = (
+    "https://raw.githubusercontent.com/redhat-developer/"
+    "rhdh-plugin-export-overlays/main"
+)
+
+# ANSI helpers
+_RED = "\033[0;31m"
+_GREEN = "\033[0;32m"
+_YELLOW = "\033[1;33m"
+_BLUE = "\033[0;34m"
+_BOLD = "\033[1m"
+_NC = "\033[0m"
+
+
+# ---------------------------------------------------------------------------
+# Minimal YAML parser (stdlib-only)
+# ---------------------------------------------------------------------------
+
+def _parse_yaml(text: str) -> dict[str, Any]:
+    """Parse the subset of YAML used in plugin-export-overlays files.
+
+    Handles:
+      - key: value scalars (strings, numbers, booleans)
+      - Nested mappings (indentation-based)
+      - Lists with ``- item`` syntax (scalar items and mapping items)
+      - Block scalars following a bare ``key:`` line (collected as string)
+      - Quoted strings (single and double)
+      - YAML document separators (``---``)
+
+    Does NOT handle: anchors/aliases, flow sequences ``[a, b]``,
+    multi-document streams, merge keys, complex keys, tags.
+    """
+    lines = text.splitlines()
+    return _parse_mapping(lines, 0, 0)[0]
+
+
+def _indent_of(line: str) -> int:
+    return len(line) - len(line.lstrip())
+
+
+def _strip_quotes(val: str) -> str:
+    if len(val) >= 2 and val[0] == val[-1] and val[0] in ("'", '"'):
+        return val[1:-1]
+    return val
+
+
+def _strip_inline_comment(val: str) -> str:
+    """Remove a trailing ``# comment`` from a scalar value.
+
+    Respects quoted strings — only strips if the ``#`` is preceded by
+    whitespace and is outside of quotes.
+    """
+    in_single = False
+    in_double = False
+    prev_space = False
+    for i, ch in enumerate(val):
+        if ch == "'" and not in_double:
+            in_single = not in_single
+        elif ch == '"' and not in_single:
+            in_double = not in_double
+        elif ch == "#" and not in_single and not in_double and prev_space:
+            return val[:i].rstrip()
+        prev_space = ch == " "
+    return val
+
+
+def _scalar(val: str) -> Any:
+    """Convert a YAML scalar string to a Python object."""
+    v = _strip_inline_comment(val).strip()
+    if v in ("true", "True", "yes"):
+        return True
+    if v in ("false", "False", "no"):
+        return False
+    if v in ("null", "~", ""):
+        return None
+    try:
+        return int(v)
+    except ValueError:
+        pass
+    try:
+        return float(v)
+    except ValueError:
+        pass
+    # Handle flow sequences/mappings (minimal)
+    if v == "[]":
+        return []
+    if v == "{}":
+        return {}
+    return _strip_quotes(v)
+
+
+def _parse_mapping(lines: list[str], idx: int, base_indent: int) -> tuple[dict[str, Any], int]:
+    """Parse a YAML mapping starting at *idx* with indentation *base_indent*."""
+    result: dict[str, Any] = {}
+
+    while idx < len(lines):
+        line = lines[idx]
+
+        # Skip blanks, comments, document separators
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or stripped == "---":
+            idx += 1
+            continue
+
+        cur_indent = _indent_of(line)
+
+        # Done with this mapping if we've dedented
+        if cur_indent < base_indent:
+            break
+
+        # Skip lines at deeper indent (shouldn't happen in well-formed input
+        # since we consume children, but guard anyway)
+        if cur_indent > base_indent:
+            idx += 1
+            continue
+
+        # List item at mapping level? This happens when the mapping value
+        # is implicitly a list.  We shouldn't get here normally because
+        # lists are consumed by _parse_list, but be safe.
+        if stripped.startswith("- "):
+            idx += 1
+            continue
+
+        # Must be a key line
+        colon_pos = stripped.find(":")
+        if colon_pos == -1:
+            idx += 1
+            continue
+
+        key = stripped[:colon_pos].strip()
+        after_colon = stripped[colon_pos + 1:].strip()
+
+        if after_colon and not after_colon.startswith("#"):
+            # Inline scalar value
+            result[key] = _scalar(after_colon)
+            idx += 1
+        else:
+            # Look ahead for child content
+            child_indent = None
+            peek = idx + 1
+            while peek < len(lines):
+                pl = lines[peek]
+                ps = pl.strip()
+                if ps and not ps.startswith("#") and ps != "---":
+                    child_indent = _indent_of(pl)
+                    break
+                peek += 1
+
+            if child_indent is None or child_indent <= cur_indent:
+                # No child block → null / empty
+                result[key] = None
+                idx += 1
+            elif lines[peek].strip().startswith("- "):
+                # Child is a list
+                result[key], idx = _parse_list(lines, peek, child_indent)
+            else:
+                # Check if it looks like a block scalar (no colon in children)
+                first_child = lines[peek].strip()
+                if ":" in first_child:
+                    # Nested mapping
+                    result[key], idx = _parse_mapping(lines, peek, child_indent)
+                else:
+                    # Block scalar – collect all indented lines
+                    block_lines: list[str] = []
+                    bi = peek
+                    while bi < len(lines):
+                        bl = lines[bi]
+                        bs = bl.strip()
+                        if not bs or bs.startswith("#"):
+                            block_lines.append("")
+                            bi += 1
+                            continue
+                        if _indent_of(bl) < child_indent:
+                            break
+                        block_lines.append(bl.strip())
+                        bi += 1
+                    # Trim trailing blanks
+                    while block_lines and not block_lines[-1]:
+                        block_lines.pop()
+                    result[key] = "\n".join(block_lines)
+                    idx = bi
+
+    return result, idx
+
+
+def _parse_list(lines: list[str], idx: int, base_indent: int) -> tuple[list[Any], int]:
+    """Parse a YAML list starting at *idx*."""
+    result: list[Any] = []
+
+    while idx < len(lines):
+        line = lines[idx]
+        stripped = line.strip()
+
+        if not stripped or stripped.startswith("#") or stripped == "---":
+            idx += 1
+            continue
+
+        cur_indent = _indent_of(line)
+        if cur_indent < base_indent:
+            break
+        if cur_indent > base_indent:
+            # Continuation of previous item (nested) – skip, already consumed
+            idx += 1
+            continue
+
+        if not stripped.startswith("- "):
+            # Not a list item – end of list
+            break
+
+        item_text = stripped[2:].strip()
+
+        # Check if item is a mapping (has a colon)
+        if ":" in item_text:
+            # Inline mapping item – first key:value is on this line
+            colon_pos = item_text.find(":")
+            first_key = item_text[:colon_pos].strip()
+            first_val_str = item_text[colon_pos + 1:].strip()
+
+            item_dict: dict[str, Any] = {}
+
+            # The effective indent for continuation keys is dash_indent + 2
+            item_indent = cur_indent + 2
+
+            if first_val_str and not first_val_str.startswith("#"):
+                item_dict[first_key] = _scalar(first_val_str)
+                idx += 1
+            else:
+                # Value on subsequent lines
+                peek = idx + 1
+                child_indent = None
+                while peek < len(lines):
+                    pl = lines[peek]
+                    ps = pl.strip()
+                    if ps and not ps.startswith("#") and ps != "---":
+                        child_indent = _indent_of(pl)
+                        break
+                    peek += 1
+
+                if child_indent is not None and child_indent > item_indent:
+                    if lines[peek].strip().startswith("- "):
+                        item_dict[first_key], idx = _parse_list(lines, peek, child_indent)
+                    else:
+                        first_child = lines[peek].strip()
+                        if ":" in first_child:
+                            item_dict[first_key], idx = _parse_mapping(lines, peek, child_indent)
+                        else:
+                            item_dict[first_key] = _scalar(first_child)
+                            idx = peek + 1
+                else:
+                    item_dict[first_key] = None
+                    idx += 1
+
+            # Continue reading sibling keys at item_indent
+            rest, idx = _parse_mapping(lines, idx, item_indent)
+            item_dict.update(rest)
+            result.append(item_dict)
+        else:
+            # Simple scalar item
+            result.append(_scalar(item_text))
+            idx += 1
+
+    return result, idx
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
+
+def _fetch(url: str) -> bytes:
+    """Fetch *url* and return the response body bytes."""
+    req = urllib.request.Request(url, headers={"User-Agent": "rhdh-skill/0.1"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return resp.read()
+
+
+def _fetch_json(url: str) -> Any:
+    return json.loads(_fetch(url))
+
+
+def _fetch_yaml(url: str) -> dict[str, Any]:
+    return _parse_yaml(_fetch(url).decode("utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Core logic
+# ---------------------------------------------------------------------------
+
+def list_plugins() -> list[str]:
+    """Return sorted list of available plugin names."""
+    entries = _fetch_json(_CONTENTS_URL)
+    names: list[str] = []
+    for entry in entries:
+        name = entry.get("name", "")
+        if name.endswith(".yaml"):
+            names.append(name[: -len(".yaml")])
+    names.sort()
+    return names
+
+
+def _get(d: dict, *keys: str, default: Any = None) -> Any:
+    """Nested dict get."""
+    cur: Any = d
+    for k in keys:
+        if not isinstance(cur, dict):
+            return default
+        cur = cur.get(k, default)
+    return cur
+
+
+def _list_workspace_metadata(workspace: str) -> list[str]:
+    """List metadata file names (without .yaml) in a workspace.
+
+    Returns an empty list if the workspace or metadata dir doesn't exist.
+    """
+    url = (
+        f"https://api.github.com/repos/redhat-developer/"
+        f"rhdh-plugin-export-overlays/contents/workspaces/{workspace}/metadata"
+    )
+    try:
+        entries = _fetch_json(url)
+    except urllib.error.HTTPError:
+        return []
+    names: list[str] = []
+    for entry in entries:
+        fname = entry.get("name", "")
+        if fname.endswith(".yaml"):
+            names.append(fname[: -len(".yaml")])
+    return names
+
+
+def _normalize_pkg_name(name: str) -> str:
+    """Normalize a package name for fuzzy matching.
+
+    Strips common prefixes/vendor names and suffixes so that
+    ``backstage-community-plugin-redhat-argocd-backend`` and
+    ``backstage-community-plugin-argocd-backend`` produce the same
+    core identifier.
+    """
+    n = name
+    # Strip common prefixes
+    for pfx in (
+        "backstage-community-plugin-",
+        "backstage-plugin-",
+        "janus-idp-backstage-plugin-",
+        "@backstage-community/plugin-",
+        "@backstage/plugin-",
+        "@janus-idp/",
+        "@red-hat-developer-hub/",
+    ):
+        if n.startswith(pfx):
+            n = n[len(pfx):]
+            break
+
+    # Strip vendor insertions (e.g. "redhat-") that appear before
+    # the plugin's core name
+    for vendor in ("redhat-", "red-hat-"):
+        if n.startswith(vendor):
+            n = n[len(vendor):]
+            break
+
+    return n
+
+
+def _find_metadata_file(
+    pkg_name: str,
+    workspace: str,
+    available: list[str],
+) -> tuple[str, str] | None:
+    """Find the metadata file for *pkg_name* in *workspace*.
+
+    Tries exact match first, then normalizes both sides and picks the
+    best fuzzy match (handles the redhat-argocd → argocd mapping where
+    metadata file is ``backstage-community-plugin-argocd`` but the
+    package is ``backstage-community-plugin-redhat-argocd``).
+
+    Returns ``(workspace, matched_file_name)`` or ``None``.
+    """
+    if pkg_name in available:
+        return workspace, pkg_name
+
+    # Normalize and match
+    norm_pkg = _normalize_pkg_name(pkg_name)
+    best: str | None = None
+    best_len = 0
+    for candidate in available:
+        norm_cand = _normalize_pkg_name(candidate)
+        if norm_cand == norm_pkg:
+            return workspace, candidate
+        # Partial: one contains the other after normalization
+        if norm_cand in norm_pkg or norm_pkg in norm_cand:
+            if len(candidate) > best_len:
+                best = candidate
+                best_len = len(candidate)
+    if best:
+        return workspace, best
+
+    return None
+
+
+def fetch_plugin_metadata(plugin_name: str) -> dict[str, Any]:
+    """Fetch plugin definition + per-package metadata.
+
+    Returns a structured dict with plugin info and package details.
+    """
+    # Step 1: plugin definition
+    plugin_url = (
+        f"{_RAW_BASE}/catalog-entities/extensions/plugins/{plugin_name}.yaml"
+    )
+    try:
+        plugin_def = _fetch_yaml(plugin_url)
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return {"error": "not_found", "plugin": plugin_name}
+        raise
+
+    metadata_name = _get(plugin_def, "metadata", "name", default=plugin_name)
+    packages = _get(plugin_def, "spec", "packages", default=[])
+    categories = _get(plugin_def, "spec", "categories", default=[])
+
+    # Detect pre-installed
+    annotations = _get(plugin_def, "metadata", "annotations", default={})
+    pre_installed = False
+    if isinstance(annotations, dict):
+        pre_installed = annotations.get(
+            "extensions.backstage.io/pre-installed", ""
+        ) in ("true", "True", True)
+
+    # Step 2: per-package metadata
+    # Pre-fetch the workspace metadata directory listing for the primary workspace
+    primary_available = _list_workspace_metadata(plugin_name)
+
+    package_results: list[dict[str, Any]] = []
+    for pkg in packages:
+        pkg_name = pkg if isinstance(pkg, str) else str(pkg)
+        pkg_def: dict[str, Any] = {}
+
+        # Try to find the metadata file in the primary workspace
+        match = _find_metadata_file(pkg_name, plugin_name, primary_available)
+
+        # Fallback: try workspaces derived from the package name,
+        # plus the "backstage" workspace (home of many core plugins)
+        if match is None:
+            fallback_workspaces: list[str] = []
+            alt_ws = _derive_workspace(pkg_name)
+            if alt_ws and alt_ws != plugin_name:
+                fallback_workspaces.append(alt_ws)
+            if "backstage" not in (plugin_name, alt_ws):
+                fallback_workspaces.append("backstage")
+            for ws in fallback_workspaces:
+                alt_available = _list_workspace_metadata(ws)
+                match = _find_metadata_file(pkg_name, ws, alt_available)
+                if match is not None:
+                    break
+
+        if match is not None:
+            ws, file_name = match
+            pkg_url = (
+                f"{_RAW_BASE}/workspaces/{ws}/metadata/{file_name}.yaml"
+            )
+            try:
+                pkg_def = _fetch_yaml(pkg_url)
+            except urllib.error.HTTPError:
+                pkg_def = {}
+
+        dynamic_artifact = _get(pkg_def, "spec", "dynamicArtifact", default=None)
+        role = _get(pkg_def, "spec", "backstage", "role", default=None)
+        app_config_examples = _get(
+            pkg_def, "spec", "appConfigExamples", default=None
+        )
+        part_of = _get(pkg_def, "spec", "partOf", default=None)
+
+        pkg_result: dict[str, Any] = {"name": pkg_name}
+        if dynamic_artifact:
+            pkg_result["dynamicArtifact"] = dynamic_artifact
+        if role:
+            pkg_result["role"] = role
+        if app_config_examples:
+            pkg_result["appConfigExamples"] = app_config_examples
+        if part_of:
+            pkg_result["partOf"] = part_of
+
+        package_results.append(pkg_result)
+
+    return {
+        "plugin": metadata_name,
+        "categories": categories,
+        "preInstalled": pre_installed,
+        "packages": package_results,
+    }
+
+
+def _derive_workspace(package_name: str) -> str | None:
+    """Best-effort workspace name from a package name.
+
+    Strips common prefixes like ``backstage-plugin-`` and suffixes like
+    ``-backend``, ``-common``, ``-react`` to guess the workspace directory.
+    """
+    name = package_name
+    for prefix in (
+        "@red-hat-developer-hub/",
+        "@backstage-community/plugin-",
+        "@backstage/plugin-",
+        "@janus-idp/",
+        "backstage-community-plugin-",
+        "backstage-plugin-",
+        "janus-idp-backstage-plugin-",
+    ):
+        if name.startswith(prefix):
+            name = name[len(prefix):]
+            break
+    # Strip vendor insertions
+    for vendor in ("redhat-", "red-hat-"):
+        if name.startswith(vendor):
+            name = name[len(vendor):]
+            break
+    for suffix in ("-backend", "-common", "-react", "-module", "-node"):
+        if name.endswith(suffix):
+            name = name[: -len(suffix)]
+            break
+    return name or None
+
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
+
+def _print_human_list(plugins: list[str]) -> None:
+    print(f"{_BOLD}Available plugins ({len(plugins)}):{_NC}\n")
+    for name in plugins:
+        print(f"  {name}")
+
+
+def _print_human_metadata(data: dict[str, Any]) -> None:
+    if "error" in data:
+        print(
+            f"{_RED}Plugin not found:{_NC} {data['plugin']}",
+            file=sys.stderr,
+        )
+        return
+
+    print(f"{_BOLD}Plugin:{_NC} {data['plugin']}")
+    if data.get("categories"):
+        cats = data["categories"]
+        if isinstance(cats, list):
+            print(f"{_BOLD}Categories:{_NC} {', '.join(str(c) for c in cats)}")
+        else:
+            print(f"{_BOLD}Categories:{_NC} {cats}")
+
+    if data.get("preInstalled"):
+        print(f"{_YELLOW}! Pre-installed (bundled with RHDH){_NC}")
+
+    print(f"\n{_BOLD}Packages ({len(data.get('packages', []))}):{_NC}")
+    for pkg in data.get("packages", []):
+        role = pkg.get("role", "unknown")
+        role_color = _BLUE if "frontend" in str(role) else _GREEN
+        print(f"\n  {_BOLD}{pkg['name']}{_NC}")
+        print(f"    Role: {role_color}{role}{_NC}")
+        artifact = pkg.get("dynamicArtifact")
+        if artifact:
+            print(f"    Artifact: {artifact}")
+        part_of = pkg.get("partOf")
+        if part_of:
+            if isinstance(part_of, list):
+                print(f"    Part of: {', '.join(str(p) for p in part_of)}")
+            else:
+                print(f"    Part of: {part_of}")
+        examples = pkg.get("appConfigExamples")
+        if examples:
+            print(f"    {_YELLOW}Has appConfigExamples{_NC}")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="fetch-plugin-metadata",
+        description=(
+            "Fetch RHDH plugin metadata from the plugin-export-overlays "
+            "repository. Lists available plugins or retrieves detailed "
+            "metadata (OCI artifacts, roles, config examples) for a "
+            "specific plugin."
+        ),
+    )
+    parser.add_argument(
+        "plugin",
+        nargs="?",
+        help="Plugin name to fetch metadata for (e.g. argocd, kubernetes)",
+    )
+    parser.add_argument(
+        "--json",
+        dest="json_output",
+        action="store_true",
+        default=False,
+        help="Output structured JSON instead of human-readable text",
+    )
+    parser.add_argument(
+        "--list",
+        dest="list_plugins",
+        action="store_true",
+        default=False,
+        help="List all available plugins",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.list_plugins:
+        try:
+            plugins = list_plugins()
+        except (urllib.error.URLError, OSError) as exc:
+            if args.json_output:
+                print(json.dumps({"success": False, "error": str(exc)}, indent=2))
+            else:
+                print(f"{_RED}Error:{_NC} {exc}", file=sys.stderr)
+            return 1
+
+        if args.json_output:
+            print(json.dumps({"success": True, "plugins": plugins}, indent=2))
+        else:
+            _print_human_list(plugins)
+        return 0
+
+    if not args.plugin:
+        parser.error("plugin name is required (or use --list)")
+        return 2  # argparse exits on error, but be explicit
+
+    try:
+        data = fetch_plugin_metadata(args.plugin)
+    except (urllib.error.URLError, OSError) as exc:
+        if args.json_output:
+            print(json.dumps({"success": False, "error": str(exc)}, indent=2))
+        else:
+            print(f"{_RED}Error:{_NC} {exc}", file=sys.stderr)
+        return 1
+
+    if "error" in data:
+        if args.json_output:
+            print(json.dumps({"success": False, **data}, indent=2))
+        else:
+            _print_human_metadata(data)
+        return 1
+
+    if args.json_output:
+        print(json.dumps({"success": True, **data}, indent=2))
+    else:
+        _print_human_metadata(data)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/rhdh-local/workflows/enable-plugin.md
+++ b/skills/rhdh-local/workflows/enable-plugin.md
@@ -9,54 +9,75 @@ Read before starting:
 </required_reading>
 
 <process>
-## Step 1: Identify the Plugin
 
-Ask the user which plugin to enable. If unsure, list available plugins:
+> **Note:** This sequence involves multiple API calls to GitHub. If any step fails, check GitHub API rate limits and authentication.
 
-> **Pre-installed vs OCI plugins:** Check the plugin YAML for `extensions.backstage.io/pre-installed: 'true'`.
+## Steps 1–3: Identify Plugin & Fetch Metadata
+
+Ask the user which plugin to enable. Use the `fetch-plugin-metadata.py` script to list plugins and retrieve all metadata in one step:
+
+**List available plugins:**
+
+```bash
+python "$SKILL_DIR/scripts/fetch-plugin-metadata.py" --list
+```
+
+**Fetch full metadata for a plugin (human-readable):**
+
+```bash
+python "$SKILL_DIR/scripts/fetch-plugin-metadata.py" <plugin-name>
+```
+
+**Fetch full metadata as structured JSON:**
+
+```bash
+python "$SKILL_DIR/scripts/fetch-plugin-metadata.py" <plugin-name> --json
+```
+
+The script fetches the plugin definition and all per-package metadata (OCI artifacts, roles, appConfigExamples) automatically. It handles cross-workspace package resolution.
+
+Validate the plugin name exists. If not found (exit code 1), try similar names and ask user to confirm.
+
+> **Pre-installed vs OCI plugins:** Check the output for the pre-installed flag or the `preInstalled` JSON field.
 >
 > - **Pre-installed** — bundled with RHDH, `spec.dynamicArtifact` is a local path like `./dynamic-plugins/dist/...`. No download needed, but may have version-specific issues in a given RHDH build (e.g. `PluginRoot not found`). The `rhdh-local` `CHANGELOG` or known-issues list is the authoritative source.
 > - **OCI** — fetched from `ghcr.io` at startup, always the exact tested version. More reliable for third-party plugins.
+
+From the output, extract:
+
+- `plugin` / `metadata.name` — canonical plugin name
+- `packages` — list of packages with `dynamicArtifact`, `role`, `appConfigExamples`, `partOf`
+- `categories` — plugin category
+
+<details>
+<summary>Manual alternative (curl chain)</summary>
+
+**Step 1 — List plugins:**
 
 ```bash
 curl -s https://api.github.com/repos/redhat-developer/rhdh-plugin-export-overlays/contents/catalog-entities/extensions/plugins \
   | jq -r '.[].name' | sed 's/\.yaml$//'
 ```
 
-Validate the plugin name exists. If not found, try similar names and ask user to confirm.
-
----
-
-## Step 2: Fetch Plugin Definition
+**Step 2 — Fetch plugin definition:**
 
 ```bash
 curl -s https://raw.githubusercontent.com/redhat-developer/rhdh-plugin-export-overlays/main/catalog-entities/extensions/plugins/<plugin-name>.yaml
 ```
 
-Extract:
+Extract: `metadata.name`, `spec.packages`, `spec.categories`
 
-- `metadata.name` — canonical plugin name
-- `spec.packages` — list of package names that make up this plugin
-- `spec.categories` — plugin category
-
----
-
-## Step 3: Fetch Package Metadata
-
-For each package in `spec.packages`:
+**Step 3 — Fetch package metadata** (for each package in `spec.packages`):
 
 ```bash
 curl -s https://raw.githubusercontent.com/redhat-developer/rhdh-plugin-export-overlays/main/workspaces/<plugin-name>/metadata/<package-name>.yaml
 ```
 
-Extract from each:
+Extract: `spec.dynamicArtifact`, `spec.backstage.role`, `spec.appConfigExamples`, `spec.partOf`
 
-- `spec.dynamicArtifact` — the OCI reference to use (e.g. `oci://ghcr.io/...`)
-- `spec.backstage.role` — `frontend-plugin`, `backend-plugin`, or `backend-plugin-module`
-- `spec.appConfigExamples` — example configuration snippets
-- `spec.partOf` — which plugin(s) this package belongs to
+> **Note:** Some packages live in a different workspace. If not found under `<plugin-name>`, try the workspace derived from the package name (e.g. `backstage-plugin-kubernetes-backend` → `workspaces/backstage/`) or the `backstage` workspace as a fallback.
 
-> **Note:** Some packages live in a different workspace. If not found under `<plugin-name>`, try the workspace derived from the package name (e.g. `backstage-plugin-kubernetes-backend` → `workspaces/kubernetes/`).
+</details>
 
 ---
 

--- a/skills/rhdh-local/workflows/enable-plugin.md
+++ b/skills/rhdh-local/workflows/enable-plugin.md
@@ -12,7 +12,7 @@ Read before starting:
 
 > **Note:** This sequence involves multiple API calls to GitHub. If any step fails, check GitHub API rate limits and authentication.
 
-## Steps 1–3: Identify Plugin & Fetch Metadata
+## Step 1: Identify Plugin & Fetch Metadata
 
 Ask the user which plugin to enable. Use the `fetch-plugin-metadata.py` script to list plugins and retrieve all metadata in one step:
 
@@ -81,7 +81,7 @@ Extract: `spec.dynamicArtifact`, `spec.backstage.role`, `spec.appConfigExamples`
 
 ---
 
-## Step 4: Add to `dynamic-plugins.override.yaml`
+## Step 2: Add to `dynamic-plugins.override.yaml`
 
 Edit `rhdh-customizations/configs/dynamic-plugins/dynamic-plugins.override.yaml`.
 
@@ -130,7 +130,7 @@ Backend plugins should be listed before their corresponding frontend plugins.
 
 ---
 
-## Step 5: Add Backend Configuration (if needed)
+## Step 3: Add Backend Configuration (if needed)
 
 If `spec.appConfigExamples` includes configuration outside the `dynamicPlugins` key, add it to:
 `rhdh-customizations/configs/app-config/app-config.local.yaml`
@@ -150,7 +150,7 @@ argocd:
 
 ---
 
-## Step 6: Set Required Environment Variables
+## Step 4: Set Required Environment Variables
 
 If backend config references `${VAR_NAME}` variables, tell the user to add them to `rhdh-customizations/.env` (bare format — no `export`, no quotes):
 
@@ -163,18 +163,18 @@ This file overrides `rhdh-local/default.env`.
 
 ---
 
-## Step 7: Present Summary
+## Step 5: Present Summary
 
 Before applying, show the user:
 
 - Which packages were added to `dynamic-plugins.override.yaml`
 - What app-config was added (if any)
 - What environment variables need to be set in `.env`
-- The commands from Step 8
+- The commands from Step 6
 
 ---
 
-## Step 8: Apply and Restart
+## Step 6: Apply and Restart
 
 ```bash
 rhdh local apply

--- a/skills/rhdh-local/workflows/enable-plugin.md
+++ b/skills/rhdh-local/workflows/enable-plugin.md
@@ -14,29 +14,14 @@ Read before starting:
 
 ## Step 1: Identify Plugin & Fetch Metadata
 
-Ask the user which plugin to enable. Use the `fetch-plugin-metadata.py` script to list plugins and retrieve all metadata in one step:
-
-**List available plugins:**
+Ask the user which plugin to enable, then fetch its metadata:
 
 ```bash
-python "$SKILL_DIR/scripts/fetch-plugin-metadata.py" --list
+python "$SKILL_DIR/scripts/fetch-plugin-metadata.py" --list          # list available plugins
+python "$SKILL_DIR/scripts/fetch-plugin-metadata.py" <plugin-name>    # fetch metadata
 ```
 
-**Fetch full metadata for a plugin (human-readable):**
-
-```bash
-python "$SKILL_DIR/scripts/fetch-plugin-metadata.py" <plugin-name>
-```
-
-**Fetch full metadata as structured JSON:**
-
-```bash
-python "$SKILL_DIR/scripts/fetch-plugin-metadata.py" <plugin-name> --json
-```
-
-The script fetches the plugin definition and all per-package metadata (OCI artifacts, roles, appConfigExamples) automatically. It handles cross-workspace package resolution.
-
-Validate the plugin name exists. If not found (exit code 1), try similar names and ask user to confirm.
+Add `--json` for structured output. If exit code 1 (not found), try similar names and ask user to confirm.
 
 > **Pre-installed vs OCI plugins:** Check the output for the pre-installed flag or the `preInstalled` JSON field.
 >
@@ -48,36 +33,6 @@ From the output, extract:
 - `plugin` / `metadata.name` — canonical plugin name
 - `packages` — list of packages with `dynamicArtifact`, `role`, `appConfigExamples`, `partOf`
 - `categories` — plugin category
-
-<details>
-<summary>Manual alternative (curl chain)</summary>
-
-**Step 1 — List plugins:**
-
-```bash
-curl -s https://api.github.com/repos/redhat-developer/rhdh-plugin-export-overlays/contents/catalog-entities/extensions/plugins \
-  | jq -r '.[].name' | sed 's/\.yaml$//'
-```
-
-**Step 2 — Fetch plugin definition:**
-
-```bash
-curl -s https://raw.githubusercontent.com/redhat-developer/rhdh-plugin-export-overlays/main/catalog-entities/extensions/plugins/<plugin-name>.yaml
-```
-
-Extract: `metadata.name`, `spec.packages`, `spec.categories`
-
-**Step 3 — Fetch package metadata** (for each package in `spec.packages`):
-
-```bash
-curl -s https://raw.githubusercontent.com/redhat-developer/rhdh-plugin-export-overlays/main/workspaces/<plugin-name>/metadata/<package-name>.yaml
-```
-
-Extract: `spec.dynamicArtifact`, `spec.backstage.role`, `spec.appConfigExamples`, `spec.partOf`
-
-> **Note:** Some packages live in a different workspace. If not found under `<plugin-name>`, try the workspace derived from the package name (e.g. `backstage-plugin-kubernetes-backend` → `workspaces/backstage/`) or the `backstage` workspace as a fallback.
-
-</details>
 
 ---
 

--- a/skills/rhdh/SKILL.md
+++ b/skills/rhdh/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rhdh
-description: Use for ANY work related to "RHDH", "Red Hat Developer Hub", or "Developer Hub". This is the primary entry point for all RHDH tasks — plugin development, overlay management, environment setup, repo navigation, version compatibility, CI/CD, configuration, debugging, and general RHDH ecosystem knowledge. Routes to specialized sub-skills as needed.
+description: Handles all RHDH-related work — "RHDH", "Red Hat Developer Hub", or "Developer Hub". Primary entry point for plugin development, overlay management, environment setup, repo navigation, version compatibility, CI/CD, configuration, debugging, and general RHDH ecosystem knowledge. Routes to specialized sub-skills as needed.
 ---
 
 <cli_setup>
@@ -294,6 +294,8 @@ Todos must be **self-contained**—a new session should understand the task with
 **GitHub CLI (PRs, CI, workflows):** references/github-reference.md
 **JIRA CLI (issues, JQL, comments):** references/jira-reference.md
 **JIRA Structure (projects, issue types, filing rules):** references/jira-structure.md
+**Version Matrix:** references/versions.md — RHDH/Backstage version compatibility, create-app versions
+**Slack Notifications:** references/slack-notification.md — Slack ping templates, handle mapping, channel routing
 </reference_index>
 
 <skills_index>

--- a/tests/unit/test_local_commands.py
+++ b/tests/unit/test_local_commands.py
@@ -389,8 +389,12 @@ class TestLocalSkillFiles:
 
     def test_entry_point_is_executable(self, local_skill_dir):
         """rhdh-local entry point must have execute permission."""
+        import os
         import stat
 
+        if os.name == "nt":
+            # Windows doesn't support Unix permission bits; skip gracefully.
+            return
         path = local_skill_dir / "scripts" / "rhdh-local"
         assert path.stat().st_mode & stat.S_IXUSR, "rhdh-local is not user-executable"
 


### PR DESCRIPTION
## Summary

Reviewed all 7 RHDH skills against the [Agent Skills open standard](https://agentskills.io/specification) and fixed all flagged issues.

### Metadata & Reference Fixes
- Fix all frontmatter `name` fields to lowercase-hyphens (spec requirement)
- Rewrite descriptions to third person per spec
- Fix broken reference paths across overlay workflows
- Normalize CLI naming (`rhdh-plugin` → `$RHDH`) in 5 workflow files
- Add missing `reference_index` entries in rhdh skill (`versions.md`, `slack-notification.md`)
- Fix stale hardcoded `:1.9` version tags in env-reference.md
- Add missing gotchas to `create-frontend-plugin` (Scalprum name mismatch) and `generate-frontend-wiring` (file extensions, unscoped packages, new frontend system)

### New Automation Scripts (stdlib-only Python, per ADR-0002)

| Skill | Script | Purpose |
|---|---|---|
| `rhdh-local` | `fetch-plugin-metadata.py` | Replaces fragile 3-step curl chain for fetching plugin metadata |
| `create-backend-plugin` | `scaffold.py` | Automates Backstage app creation + backend plugin scaffolding |
| `create-frontend-plugin` | `scaffold.py` | Automates frontend plugin scaffolding with optional theme support |
| `overlay` | `analyze-pr.py` | Consolidates ~8 sequential `gh` API calls into single-pass PR analysis |
| `overlay` | `triage-prs.py` | Automates PR classification, staleness checking, and report generation |
| `export-and-package` | `export-plugin.py` | Full export → package → push pipeline |

All scripts: `#!/usr/bin/env python3`, `argparse` with `--help`, `--json` output, proper exit codes, cross-platform.

### Bug Fixes
- Fix Windows path separator inconsistency in `sync.py` (`.as_posix()` for glob-discovered paths)
- Skip Unix permission check (`S_IXUSR`) on Windows in test suite

### Testing
- All 245 tests passing (0 failures)
- All 6 new scripts compile cleanly (`py_compile`)
