### PR TITLE
feat: add rhdh-jira skill for Jira interaction via acli

### DIFF
--- a/skills/rhdh-jira/SKILL.md
+++ b/skills/rhdh-jira/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: rhdh-jira
+description: |
+  Interact with RHDH Jira projects (RHIDP, RHDHPLAN, RHDHBUGS, RHDHSUPP) using the Atlassian CLI (acli). Use when the user needs to search, create, view, edit, transition, comment on, or link Jira issues for Red Hat Developer Hub. Also use when the user asks about Jira workflows, exit criteria, issue templates, custom fields, boards, sprints, or JQL queries in the RHDH context. Trigger when the user mentions Jira issue keys like RHIDP-1234, RHDHPLAN-567, RHDHBUGS-890, or any RHDH project key. Also trigger for support case bug filing, feature request creation, or release planning in Jira. Covers acli setup, authentication, and troubleshooting.
+compatibility: "acli (Atlassian CLI) on PATH. Python 3 for scripts. Windows, macOS, Linux."
+---
+
+# RHDH Jira
+
+Foundational skill for interacting with RHDH's Jira instance via the Atlassian CLI (`acli`). Covers all four active projects, issue types, workflows, custom fields, and JQL patterns.
+
+## Prerequisites
+
+Run `scripts/setup.py` to verify everything is configured:
+
+```bash
+python scripts/setup.py
+```
+
+The script checks:
+1. `acli` binary on PATH
+2. Jira API token auth configured (`~/.config/acli/jira_config.yaml`)
+3. Smoke test against `redhat.atlassian.net`
+
+If `acli` is not installed, download from [Atlassian CLI](https://developer.atlassian.com/cloud/acli/). Authenticate with `acli auth login` or configure an API token.
+
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `scripts/setup.py` | Verify acli install + auth. Run with `--json` for structured output. |
+| `scripts/parse_issues.py` | Flatten, enrich, and filter acli JSON output. Solves the core problem: `acli search --json` can't return custom fields (team, story points, sprint). Pipe search results in, get clean data out. Use `--enrich` to fetch full fields, `-f team="X"` to filter by team. |
+
+## Projects
+
+| Key | Purpose | Issue Types |
+|-----|---------|-------------|
+| RHIDP | Engineering work | Epic, Story, Task, Sub-task, Vulnerability |
+| RHDHPLAN | Program planning | Feature, Outcome, Feature Request, Sub-task |
+| RHDHBUGS | Product defects | Bug, Sub-task |
+| RHDHSUPP | Support-engineering interactions | Bug |
+
+RHDHPAI (Plugins and AI) is **archived** — JQL queries against it will fail.
+
+### Issue type selection
+
+- **Story** — end-user facing work (API, UI changes)
+- **Task** — not end-user facing (tests, CI/CD, refactoring, code organization)
+- **Epic** — collection of Stories/Tasks toward a deliverable
+- **Feature** — program-level planning item in RHDHPLAN
+- **Bug** — product defect (RHDHBUGS) or support case tracking (RHDHSUPP)
+- **Sub-task** — child of any issue type above
+- **Vulnerability** — CVE tracking in RHIDP (Product Security)
+
+## Reference Files
+
+Load only what the current task requires.
+
+| File | Load when... |
+|------|-------------|
+| `references/acli-commands.md` | Running an acli command you haven't used before, or hitting unexpected flag behavior. Quick reference for syntax, flag differences, and output formats. |
+| `references/fields.md` | Need to know a field name, custom field ID, accepted values, or label conventions. Custom fields, labels, link types, components, priorities. |
+| `references/workflows.md` | Transitioning issues, checking exit criteria, or verifying readiness for the next status. |
+| `references/templates.md` | Creating new issues. Also load `references/workflows.md` for required fields at entry status. |
+| `references/support.md` | Handling support cases, filing bugs from customer cases, or creating feature requests from support. |
+| `references/jql-patterns.md` | Building a JQL query, finding a board ID, or looking up sprint information. JQL cookbook with 23+ tested queries. |
+
+## Common Gotchas
+
+1. **`acli auth status` lies.** It checks OAuth, not API token auth. Always returns "unauthorized" with token auth even when Jira works fine. Use `acli jira project list --recent 1` as a smoke test instead.
+2. **`view` uses positional arg, everything else uses `--key`.** `acli jira workitem view RHIDP-123` but `acli jira workitem edit --key RHIDP-123 ...`.
+3. **`--yes` is mandatory for mutations.** All `edit`, `transition`, `assign`, and `link create` commands prompt interactively without it. Always pass `--yes`.
+4. **`--fields` is restrictive on search.** Only accepts `key`, `summary`, `status`, `assignee`, `issuetype`, `priority`, `description`, `labels`. For components, sprint, fixVersions, and all custom fields — use `--json` or `scripts/parse_issues.py --enrich`.
+5. **Team field is NOT JQL-filterable.** `customfield_10001` cannot be used in JQL WHERE clauses. Fetch all issues, filter by `customfield_10001.name` in post-processing.
+6. **ADF vs plain text.** Reading descriptions via `--json` returns Atlassian Document Format (nested JSON). Creating/editing with `--description` accepts plain text. Don't try to round-trip ADF through `--description`.
+7. **Acceptance Criteria field is almost always null.** Scan the description for "Requirements", "Acceptance Criteria", or bullet-style criteria instead of checking `customfield_10718`.
+
+## Error Handling
+
+| Error | Action |
+|-------|--------|
+| `acli` not on PATH | Run `scripts/setup.py`. Install from Atlassian if missing. |
+| "unauthorized" from `auth status` | Ignore. Check `jira_config.yaml` exists. Run smoke test. |
+| "required flag(s) not set" | Command syntax wrong. Run `acli jira <subcommand> --help`. |
+| "field X is not allowed" | Use `--json` instead of `--fields` for that field. |
+| "the value X does not exist for the field 'project'" | Project key is wrong or project is archived (e.g., RHDHPAI). |
+| Rate limiting (429) | Wait 5 seconds, retry once. |
+| Interactive prompt hangs | Missing `--yes` flag on a mutating command. |
+
+## Common Workflows
+
+### Creating an issue
+1. Load `references/templates.md` for the body template
+2. Load `references/workflows.md` for required fields at New status
+3. Run `acli jira workitem create` (see `references/acli-commands.md` if unsure of syntax)
+
+### Searching with custom fields (team, story points, sprint)
+1. Build JQL using patterns from `references/jql-patterns.md`
+2. Pipe results through `scripts/parse_issues.py --enrich` for full field data
+3. Use `-f team="X"` to filter by team (not possible in JQL)
+
+### Transitioning an issue
+1. Load `references/workflows.md` for exit criteria at the target status
+2. Verify required fields are set before transitioning
+3. Run `acli jira workitem transition --key KEY --status "X" --yes`
+
+## When NOT to Use
+
+- **Non-RHDH Jira projects** — this skill's field mappings, workflows, and JQL patterns are specific to RHIDP/RHDHPLAN/RHDHBUGS/RHDHSUPP
+- **Jira REST API directly** — this skill covers `acli` CLI only

--- a/skills/rhdh-jira/references/acli-commands.md
+++ b/skills/rhdh-jira/references/acli-commands.md
@@ -1,0 +1,233 @@
+# acli Jira Command Reference
+
+Cheat sheet for `acli jira` commands. For full flag details, run `acli jira <subcommand> --help`.
+
+## Key Syntax Rules
+
+1. **`view` takes a positional arg.** Everything else uses `--key`.
+2. **Always pass `--yes`** on mutating commands (`edit`, `transition`, `assign`, `link create`) to skip interactive prompts.
+3. **Use `--json`** when you need fields beyond `key`, `summary`, `status`, `assignee`, `issuetype`, `priority`, `description`. The `--fields` flag rejects `components`, `sprint`, `labels`, `fixVersions`.
+4. **Use `--csv`** for search results you want to pipe or parse.
+5. **Use `--paginate`** to fetch all results beyond the default page size.
+
+## Work Items
+
+### Search
+
+```bash
+# JQL search with field selection
+acli jira workitem search --jql "project = RHIDP AND status = 'In Progress'" --fields "key,summary,status,assignee" --limit 50
+
+# JSON output for full field data
+acli jira workitem search --jql "project = RHIDP" --limit 20 --json
+
+# Count only
+acli jira workitem search --jql "project = RHDHBUGS AND status not in (Closed)" --count
+
+# CSV export
+acli jira workitem search --jql "project = RHIDP" --fields "key,summary,status" --csv
+
+# Fetch all results (paginated)
+acli jira workitem search --jql "project = RHIDP AND sprint in openSprints()" --paginate
+```
+
+### View
+
+```bash
+# View issue (positional arg — NOT --key)
+acli jira workitem view RHIDP-123
+
+# Specific fields
+acli jira workitem view RHIDP-123 --fields "summary,description,status"
+
+# All fields
+acli jira workitem view RHIDP-123 --fields "*all"
+
+# JSON for full data (components, sprint, custom fields)
+acli jira workitem view RHIDP-123 --json
+
+# Open in browser
+acli jira workitem view RHIDP-123 --web
+```
+
+### Create
+
+```bash
+# Basic creation
+acli jira workitem create --project RHIDP --type Story --summary "Implement auth plugin" --description "As a user..." --assignee "@me"
+
+# With labels
+acli jira workitem create --project RHDHBUGS --type Bug --summary "Login fails" --label "rhdh-customer,ci-fail"
+
+# With parent (sub-task or child of epic)
+acli jira workitem create --project RHIDP --type Task --summary "Write tests" --parent RHIDP-12968
+
+# From JSON file (complex issues)
+acli jira workitem create --from-json workitem.json --project RHIDP --type Epic
+
+# Generate JSON template
+acli jira workitem create --generate-json
+
+# From description file
+acli jira workitem create --project RHIDP --type Story --summary "New feature" --description-file story.txt
+```
+
+### Edit
+
+```bash
+# Edit summary (--key flag, NOT positional)
+acli jira workitem edit --key RHIDP-123 --summary "Updated summary" --yes
+
+# Edit multiple issues
+acli jira workitem edit --key "RHIDP-123,RHIDP-124" --assignee "jdoe@example.com" --yes
+
+# Edit by JQL (batch)
+acli jira workitem edit --jql "project = RHIDP AND labels = 'needs-info'" --labels "needs-pm" --yes
+
+# Add/remove labels
+acli jira workitem edit --key RHIDP-123 --labels "demo,test-day" --yes
+acli jira workitem edit --key RHIDP-123 --remove-labels "needs-info" --yes
+
+# Edit description from file
+acli jira workitem edit --key RHIDP-123 --description-file updated.txt --yes
+
+# Edit issue type
+acli jira workitem edit --key RHIDP-123 --type Task --yes
+```
+
+### Transition
+
+```bash
+# Move to status (--key flag)
+acli jira workitem transition --key RHIDP-123 --status "In Progress" --yes
+
+# Batch transition by JQL
+acli jira workitem transition --jql "project = RHIDP AND status = 'Review'" --status "Closed" --yes
+
+# Ignore errors on batch (some may not have valid transition)
+acli jira workitem transition --jql "..." --status "To Do" --yes --ignore-errors
+```
+
+### Assign
+
+```bash
+# Assign to self
+acli jira workitem assign --key RHIDP-123 --assignee "@me" --yes
+
+# Assign to user
+acli jira workitem assign --key RHIDP-123 --assignee "jdoe@example.com" --yes
+
+# Assign to project default
+acli jira workitem assign --key RHIDP-123 --assignee "default" --yes
+```
+
+### Comment
+
+```bash
+# Add comment
+acli jira workitem comment create --key RHIDP-123 --body "Investigation complete. Root cause: ..."
+
+# List comments
+acli jira workitem comment list --key RHIDP-123
+
+# Update comment
+acli jira workitem comment update --key RHIDP-123 --id 12345 --body "Updated findings"
+
+# Delete comment
+acli jira workitem comment delete --key RHIDP-123 --id 12345
+```
+
+### Links
+
+```bash
+# List available link types
+acli jira workitem link type
+
+# Create link (--out = source, --in = target)
+acli jira workitem link create --out RHIDP-123 --in RHIDP-456 --type "Blocks" --yes
+
+# List links on an issue
+acli jira workitem link list --key RHIDP-123
+
+# Delete link (by link ID only, no --key needed)
+acli jira workitem link delete --id 12345 --yes
+```
+
+### Attachments
+
+```bash
+# List attachments (note: attachment upload is not available via acli)
+acli jira workitem attachment list --key RHIDP-123
+
+# Delete attachment
+acli jira workitem attachment delete --key RHIDP-123 --id 12345
+```
+
+## Boards
+
+```bash
+# Search boards by project
+acli jira board search --project RHIDP
+
+# Search by name
+acli jira board search --name "RHDH Cope"
+
+# Get board details
+acli jira board get --id 11374
+
+# List sprints for a board (--id, NOT --board-id)
+acli jira board list-sprints --id 11374
+
+# Active sprints only
+acli jira board list-sprints --id 11374 --state active
+```
+
+## Sprints
+
+```bash
+# View sprint details
+acli jira sprint view --id 65456
+
+# List work items in a sprint
+acli jira sprint list-workitems --sprint 65456 --board 11374
+
+# Create sprint
+acli jira sprint create --name "RHDH COPE 3292" --board 11374
+```
+
+## Projects
+
+```bash
+# List recent projects
+acli jira project list --recent 10
+
+# View project details
+acli jira project view --key RHIDP
+```
+
+## Filters
+
+```bash
+# Search for saved filters
+acli jira filter search --name "RHDH"
+
+# List my/favourite filters
+acli jira filter list --my
+acli jira filter list --favourite
+
+# Get filter details (includes JQL)
+acli jira filter get --id 10001
+```
+
+## Output Format Differences
+
+| Behavior | Table (default) | `--json` |
+|----------|----------------|----------|
+| Description | Plain text | ADF (Atlassian Document Format) |
+| Team field | String name | Complex object `{id, name, avatarUrl, ...}` |
+| Sprint field | Not shown | Array of sprint objects |
+| Components | Not available via `--fields` | Full objects |
+| Labels | Not available via `--fields` | Array of strings |
+| Fix versions | Not available via `--fields` | Array of version objects |
+
+When writing descriptions, use `--description "plain text"`. When reading, be aware `--json` returns ADF — don't try to round-trip it.

--- a/skills/rhdh-jira/references/fields.md
+++ b/skills/rhdh-jira/references/fields.md
@@ -1,0 +1,115 @@
+# Fields, Labels, Links, Components & Priorities
+
+## Custom Fields
+
+| Field | ID | Type | Notes |
+|-------|-----|------|-------|
+| Team | `customfield_10001` | `atlassian-team` | **NOT JQL-filterable.** Fetch all, filter by `.name` in post-processing. Returns complex object in JSON: `{id, name, title, avatarUrl, isShared, ...}` |
+| Size | `customfield_10795` | dropdown | T-shirt sizing: XS, S, M, L, XL. Returns `{value: "M"}` in JSON. |
+| Story Points | `customfield_10028` | number | Primary estimation field. |
+| DEV Story Points | `customfield_10506` | number | Inconsistently populated. |
+| QE Story Points | `customfield_10572` | number | Inconsistently populated. |
+| DOC Story Points | `customfield_10510` | number | Inconsistently populated. |
+| Epic Link | `customfield_10014` | issue key | Legacy field — prefer `parent` for new hierarchy. |
+| Parent Link | `customfield_10018` | issue key | Links Epic → Feature cross-project. |
+| Sprint(s) | `customfield_10020` | array | Array of sprint objects with `name`, `state`, `startDate`, `endDate`. Not available via `--fields` — use `--json`. |
+| Release Note Type | `customfield_10785` | dropdown | Values: Feature, Enhancement, Developer Preview, Deprecated Functionality, Removed Functionality, Release Note Not Required. |
+| Release Note Text | `customfield_10783` | textarea (ADF) | Actual release note content. Should be populated when RN Type is customer-facing. |
+| Acceptance Criteria | `customfield_10718` | textarea | **Almost always null.** Check description and comments instead for "Requirements", "Acceptance Criteria", or bullet-style criteria. |
+| Feature Status | `customfield_10807` | dropdown | Found on RHDHPLAN Features. Values include `Proposed`. |
+| Rank | `customfield_10019` | string | Lexorank ordering. Generally not needed for agent operations. |
+
+### Custom field JQL syntax
+
+Use `cf[ID]` syntax in JQL for custom fields:
+
+```jql
+-- Story points empty
+cf[10028] is EMPTY
+
+-- Size is set
+cf[10795] is not EMPTY
+
+-- Release Note Type missing
+cf[10785] is EMPTY
+```
+
+## Standard Fields
+
+| Field | JQL Name | Notes |
+|-------|----------|-------|
+| Fix Version | `fixVersion` | Version targeting. `fixVersion = '1.10.0'` |
+| Affects Version | `affectedVersion` | Used in RHDHBUGS for bug version tracking. |
+| Components | `component` | JQL-filterable: `component = 'Documentation'`. Not available via `--fields` — use `--json`. |
+| Parent | `parent` | Native hierarchy: sub-task → parent, epic → feature. `parent = RHDHPLAN-382` |
+| Security Level | `security` | Present on RHIDP/RHDHPLAN (`"Red Hat Employee"`), typically null on RHDHBUGS/RHDHSUPP. **NOT JQL-filterable** — `security is not EMPTY` returns parse error. |
+
+## Labels
+
+All lowercase, hyphen-separated. Labels are global to the Jira instance.
+
+| Label | Usage |
+|-------|-------|
+| `demo` | Customer-facing Features/Epics requiring a feature demo |
+| `needs-info` | Release planning — needs more information |
+| `needs-pm` | Release planning — needs product management input |
+| `stretch` | Feature is a stretch goal for a release |
+| `test-day` | Feature is a Test Day candidate |
+| `rhdh-n.n-candidate` | Feature is a candidate for release n.n (e.g., `rhdh-1.10-candidate`) |
+| `ci-fail` | Identifies CI failures |
+| `must-have` | Documentation team — must-have for release doc plan |
+| `nice-to-have` | Documentation team — nice-to-have for release doc plan |
+| `rhdh-customer` | Issues from customer interactions (support cases, engagements) |
+| `ga-support` | Target support level: GA (generally available) |
+| `tp-support` | Target support level: Tech Preview |
+| `dp-support` | Target support level: Developer Preview |
+
+## Link Types
+
+Match by **name** in `issuelinks`, not by ID.
+
+| Name | Use | Direction | Notes |
+|------|-----|-----------|-------|
+| Blocks | Yes — dependency tracking | inward: "is blocked by", outward: "blocks" | |
+| Depend | Yes — dependency tracking | inward: "is depended on by", outward: "depends on" | |
+| Related | Yes — feature-to-epic mapping | bidirectional | For cross-team deps, only include when target is outside RHDHPLAN/RHIDP |
+| Cloners | **IGNORE** | — | Noise from cross-release cloning |
+| Issue split | Informational only | — | |
+| Duplicate | **IGNORE** | — | |
+
+List all available link types with: `acli jira workitem link type`
+
+## Components (RHIDP)
+
+Heavily used for filtering and routing. Key components:
+
+Key components (run `acli jira workitem search --jql "project = RHIDP AND component = 'X'" --count` for current counts):
+
+Documentation, Security, UI, Lightspeed, Orchestrator, Continuous Improvement, Plugins, Topology
+
+Query by component: `project = RHIDP AND component = 'Documentation'`
+
+Components are not available via `--fields` on search. Use `--json` to get component data.
+
+## Priorities
+
+| Priority | Notes |
+|----------|-------|
+| Blocker | Highest. Used for critical z-stream fixes. |
+| Critical | High urgency. |
+| Major | Standard priority for most work. |
+| Normal | Used in RHDHSUPP. Not a standard Jira default. |
+| Minor | Low priority. |
+| Undefined | **Most common in RHIDP** (~300 open issues). Hygiene signal — should be set. |
+
+## Hierarchy Model
+
+Three JQL fields for hierarchy with subtly different behavior:
+
+| JQL Field | What It Returns | When to Use |
+|-----------|----------------|-------------|
+| `parent = KEY` | Native Jira hierarchy (sub-task → task, epic → feature) | **Preferred.** Use for all new queries. |
+| `'Epic Link' = KEY` | Legacy field — stories linked to an epic | Use only for older data that hasn't migrated. |
+| `parentEpic = KEY` | Similar to Epic Link but slightly different results | Avoid unless specifically needed. |
+
+Safest approach: always use `parent = KEY`.

--- a/skills/rhdh-jira/references/jql-patterns.md
+++ b/skills/rhdh-jira/references/jql-patterns.md
@@ -1,0 +1,182 @@
+# JQL Patterns & Board Reference
+
+All queries tested live against `redhat.atlassian.net`.
+
+## Core Queries
+
+```jql
+-- My open issues across all RHDH projects
+assignee = currentUser() AND project in (RHIDP, RHDHPLAN, RHDHBUGS, RHDHSUPP) AND status not in (Closed)
+
+-- All open issues (cross-project)
+project in (RHIDP, RHDHPLAN, RHDHBUGS, RHDHSUPP) AND status not in (Closed)
+
+-- Issues in active sprint
+project = RHIDP AND sprint in openSprints()
+
+-- Unassigned in active sprint
+project = RHIDP AND sprint in openSprints() AND assignee is EMPTY
+
+-- Issues in future sprints
+project = RHIDP AND sprint in futureSprints()
+
+-- Recently updated (last 7 days)
+project = RHIDP AND updated >= -7d ORDER BY updated DESC
+
+-- Recently created bugs (last 14 days)
+project = RHDHBUGS AND created >= -14d ORDER BY created DESC
+
+-- Issues by fix version
+project = RHIDP AND fixVersion = '1.10.0'
+
+-- Issues by component
+project = RHIDP AND component = 'Documentation'
+```
+
+## Hygiene Queries
+
+```jql
+-- Unrefined stories/tasks (no story points, New status)
+project = RHIDP AND status = New AND cf[10028] is EMPTY AND issuetype in (Story, Task)
+
+-- Features missing T-shirt size
+project = RHDHPLAN AND issuetype = Feature AND cf[10795] is EMPTY AND status not in (Closed)
+
+-- Bugs without fix version
+project = RHDHBUGS AND issuetype = Bug AND fixVersion is EMPTY AND status not in (Closed)
+
+-- Open blocker bugs
+project = RHDHBUGS AND status not in (Closed) AND priority = Blocker
+
+-- Overdue issues (released version, still open)
+project = RHIDP AND fixVersion in releasedVersions() AND status not in (Closed)
+
+-- Open vulnerabilities (CVE tracking)
+project = RHIDP AND issuetype = Vulnerability AND status not in (Closed) ORDER BY priority DESC
+```
+
+## Hierarchy & Relationship Queries
+
+```jql
+-- Children of a Feature (epics under it)
+parent = RHDHPLAN-100
+
+-- Children of an Epic (stories/tasks under it)
+parent = RHIDP-5000
+
+-- Legacy: Epic Link (older data)
+'Epic Link' = RHIDP-5000
+
+-- Legacy: parentEpic (slightly different results than Epic Link)
+parentEpic = RHIDP-5000
+
+-- Orphan stories (no parent)
+project = RHIDP AND issuetype = Story AND 'Parent Link' is EMPTY AND 'Epic Link' is EMPTY AND status not in (Closed)
+```
+
+Use `parent = KEY` for all new queries. `Epic Link` and `parentEpic` are legacy.
+
+## Release & Planning Queries
+
+```jql
+-- Features by candidate label
+project = RHDHPLAN AND labels = 'rhdh-1.10-candidate'
+
+-- Features in Release Pending missing release notes
+project = RHDHPLAN AND issuetype = Feature AND status = 'Release Pending' AND cf[10785] is EMPTY
+
+-- Epics in Dev Complete (delivery tracking)
+project = RHIDP AND issuetype = Epic AND status = 'Dev Complete'
+
+-- Features with stretch label
+project = RHDHPLAN AND issuetype = Feature AND labels = stretch AND status not in (Closed)
+```
+
+## Queries That DON'T Work
+
+```jql
+-- FAILS: issueFunction is a ScriptRunner add-on, not available
+issueFunction in hasLinks()
+
+-- FAILS: security field not queryable via JQL
+security is not EMPTY
+
+-- FAILS: childIssuesOf function not available
+issuekey in childIssuesOf('RHIDP-5000')
+
+-- FAILS: RHDHPAI project is archived
+project = RHDHPAI
+```
+
+## Team Filtering
+
+The Team field (`customfield_10001`) cannot be used in JQL. Use `scripts/parse_issues.py`:
+
+```bash
+acli jira workitem search --jql "project = RHIDP AND sprint in openSprints()" --json \
+  | python scripts/parse_issues.py --enrich -f team="RHDH Install" -s key,summary,status,story_points
+```
+
+For acli search command syntax, see `references/acli-commands.md`.
+For custom field IDs and `cf[]` JQL syntax, see `references/fields.md`.
+
+---
+
+## Boards
+
+### Active Scrum Boards
+
+| Board | ID | Team/Purpose |
+|-------|----|-------------|
+| RHDH Cope | 11374 | COPE team sprint board |
+| RHDH Install | 11462 | Install team |
+| RHDH Plugins | 11549 | Plugins team |
+| RHDH Frontend Plugins & UI | 11525 | Frontend/UI team |
+| RHDH AI Sprint | 10725 | AI team |
+| RHDH Documentation Sprint | 10851 | Documentation team |
+| RHDH Security | 11497 | Security team |
+| RHIDP Sprints | 9736 | General RHIDP sprint board |
+| Perf&Scale | 4783 | Performance and scale testing |
+| RHIDP QE Sprints | 10444 | QE team |
+
+### Active Kanban Boards
+
+| Board | ID | Purpose |
+|-------|----|---------|
+| RHDH support bugs (RHDHSUPP) | 4116 | Support bug tracking |
+| RHDH support bugs (RHDHBUGS) | 5367 | Bug tracking |
+| RHIDP Feature Requests | 9795 | Feature request tracking |
+| RHDH Program Features | 10870 | Program feature tracking |
+| RHDH Outcomes | 11124 | Outcomes tracking |
+| RHDH AI Triage & Refinement | 10695 | AI triage |
+| RHIDP | 10154 | General RHIDP kanban |
+
+### BMPTEMP Boards
+
+Boards linked to the `Board Migration Project (BMPTEMP)` are migration artifacts. Most are inactive, but some may still have active sprints. Check with `acli jira board list-sprints --id <ID> --state active` before assuming they're dead.
+
+## Sprints
+
+### Naming Convention
+
+Sprints follow: `{Team Name} {Sprint Number}` (e.g., "RHDH COPE 3291", "RHDH Install 3291"). Sprint numbers are shared across teams for the same sprint cycle.
+
+### Finding Current Sprint
+
+```bash
+# List active sprints for a board
+acli jira board list-sprints --id 11374 --state active
+
+# List work items in a sprint
+acli jira sprint list-workitems --sprint 65456 --board 11374
+```
+
+### Saved Filters
+
+Pre-built JQL filters exist in the instance. Search for them:
+
+```bash
+acli jira filter search --name "RHDH"
+```
+
+These may be more efficient than building JQL from scratch for common queries.

--- a/skills/rhdh-jira/references/support.md
+++ b/skills/rhdh-jira/references/support.md
@@ -1,0 +1,104 @@
+# RHDH Support Workflow
+
+How support cases flow between RHDHSUPP, RHDHBUGS, and RHDHPLAN.
+
+## Overview
+
+1. Customer creates request on Customer Portal (access.redhat.com)
+2. Support team investigates, reviews documentation and KCS articles
+3. If engineering help needed → Support creates **RHDHSUPP Bug** to track discussion
+4. Investigation continues until resolution
+5. Resolution may produce a **RHDHBUGS Bug** (defect) or **RHDHPLAN Feature Request**
+
+## RHDHSUPP → RHDHBUGS (Defect Path)
+
+When a product defect is identified during support investigation:
+
+1. Create `Bug` in **RHDHBUGS** with:
+   - Priority, Component (use `Documentation` for doc defects)
+   - Bug template filled out (reproduction steps, expected behavior)
+   - **No customer information** — RHDHBUGS is a public project
+   - Link to Customer Case via SFDC Cases Links
+2. Comment on the RHDHSUPP issue with the RHDHBUGS link
+3. This tells the customer when the fix is expected
+
+```bash
+# Create the bug
+acli jira workitem create --project RHDHBUGS --type Bug \
+  --summary "Login fails when SSO token expires during session" \
+  --description-file bug_description.txt \
+  --label "rhdh-customer" \
+  --assignee "@me"
+
+# Link it to the support issue
+acli jira workitem link create --out RHDHSUPP-456 --in RHDHBUGS-789 --type "Related" --yes
+
+# Comment on support issue with the link
+acli jira workitem comment create --key RHDHSUPP-456 \
+  --body "Defect captured in RHDHBUGS-789. Fix targeted for next y-stream release."
+```
+
+## RHDHSUPP → RHDHPLAN (Feature Request Path)
+
+When a support case reveals a missing capability:
+
+1. Create `Feature Request` in **RHDHPLAN** with:
+   - Priority, Component
+   - Feature Request template filled out
+   - Link to Customer Case via SFDC Cases Links
+2. Encourage customer to follow up with their account team to prioritize with Product Management
+
+```bash
+acli jira workitem create --project RHDHPLAN --type "Feature Request" \
+  --summary "Support OIDC token refresh in admin console" \
+  --description-file feature_request.txt
+
+acli jira workitem link create --out RHDHSUPP-456 --in RHDHPLAN-123 --type "Related" --yes
+```
+
+## Bug Fix Prioritization
+
+| Scenario | Target Release | Priority |
+|----------|---------------|----------|
+| Default | Next y-stream (e.g., 1.11.0) | As determined by triage |
+| Critical to customer | Current z-stream (e.g., 1.10.4) | Set to **Blocker** |
+| Customer request, not urgent | Future y-stream | As determined by triage |
+
+For z-stream targeting, discuss with the engineer to prioritize. If committed, set Priority to Blocker and the target fix version.
+
+## Closing RHDHSUPP Issues
+
+Close the RHDHSUPP Bug when:
+- Investigation is resolved, OR
+- No response from customer within SLA
+
+On close, set **Story Points** to capture the effort spent on the investigation. See the sizing guide for reference.
+
+## Communication Channels
+
+| Channel | Purpose |
+|---------|---------|
+| `#rhdh-support` | Engineering and Developer Hub support team communication |
+| `#rhdh-support-cases` | Notification channel for new RHDHSUPP bugs from support |
+
+## Ticket SLA
+
+SLA depends on case severity:
+
+| Severity | Response Time | Notes |
+|----------|--------------|-------|
+| Sev 1 | 1 hour | 24x7 support. Handed over between GEO teams. |
+| Sev 2 | 2 hours | 24x7 support. |
+| Sev 3 | 4 business hours | Business hours only. |
+| Sev 4 | 1 business day | Business hours only. |
+
+SLA may be negotiated (Negotiated Entitlement Process) or adjusted when a workaround is found.
+
+## Special Case Types
+
+| Type | Handling |
+|------|---------|
+| **Strategic customer** | Extra attention — opportunity to expand Red Hat relationship |
+| **TAM customer** | Technical Account Manager assists with implementation |
+| **Consulting/Partner** | Cases opened during project implementation |
+| **CSE customer** | Customer Success Executive helps communication (non-technical) |

--- a/skills/rhdh-jira/references/templates.md
+++ b/skills/rhdh-jira/references/templates.md
@@ -1,0 +1,237 @@
+# Issue Templates
+
+Jira wiki markup templates for each issue type. Use with `--description` or `--description-file` when creating issues via `acli jira workitem create`.
+
+## Outcome Template
+
+Project: RHDHPLAN | Type: Outcome
+
+```
+h3. *Description:*
+
+_Provide a quick overview of the goal and key background or context._
+<your text here>
+
+h3. *Benefits/Value:*
+
+_What are the benefits or value for our customers if we do this?_
+ *  
+
+h3. *Acceptance Criteria:*
+
+_What must be true for this to be considered complete?_
+ *  
+
+h3. *Out of Scope:*
+
+_If there are significant scope constraints, note them so goals and non-goals are clear._
+ *  
+
+h3. *Metrics:*
+
+_What metrics and telemetry data influence this and either help inform this work, or could help us understand its impact?_
+ *  
+
+h3. *Dependencies:*
+
+_Note any major team or technology dependencies outside of our direct control that we may need to plan around._
+ *  
+```
+
+## Feature Template
+
+Project: RHDHPLAN | Type: Feature
+
+```
+h1. *Feature Overview (aka. Goal Summary)*
+
+An elevator pitch (value statement) that describes the Feature in a clear, concise way.
+
+<your text here>
+
+h3. *Goals (aka. expected user outcomes)*
+
+The observable functionality that the user now has as a result of receiving this feature. Include the anticipated primary user type/persona and which existing features, if any, will be expanded.
+
+<your text here>
+
+h3. *Requirements (aka. Acceptance Criteria):*
+
+A list of specific needs or objectives that a feature must deliver in order to be considered complete. If the feature spans across releases then good to have scope for each release with acceptance criteria. Be sure to include nonfunctional requirements such as security, reliability, performance, maintainability, scalability, usability, etc.
+
+<enter general Feature acceptance here>
+
+h3. *Out of Scope (Optional)*
+
+High-level list of items that are out of scope.
+
+<your text here>
+
+h3. *Customer Considerations (Optional)*
+
+Provide any additional customer-specific considerations that must be made when designing and delivering the Feature. Initial completion during Refinement status.
+
+<your text here>
+
+h3. *Documentation Considerations*
+
+Provide information that needs to be considered and planned so that documentation will meet customer needs. If the feature extends existing functionality, provide a link to its current documentation.
+
+<your text here>
+
+h3. *Upstream engagement*
+
+Review ideas/need with upstream SIGs to determine how best to interact with community
+```
+
+## Epic Template
+
+Project: RHIDP | Type: Epic
+
+```
+h1. EPIC Goal
+
+What are we trying to solve here?
+
+h2. *Background/Feature Origin*
+
+h2. *Why is this important?*
+
+h2. *User Scenarios*
+
+h2. *Dependencies (internal and external)*
+
+h2. *Acceptance Criteria*
+
+(?) Release Enablement/Demo - Provide necessary release enablement details and documents
+(?) DEV - Upstream code and tests merged: <link to meaningful PR or GitHub Issue>
+(?) DEV - Upstream documentation merged: <link to meaningful PR or GitHub Issue>
+(?) DEV - Downstream build attached to advisory: <link to errata>
+(?) QE - Test plans in Playwright: <link or reference to playwright>
+(?) QE - Automated tests merged: <link or reference to automated tests>
+(?) DOC - Downstream documentation merged: <link to meaningful PR>
+```
+
+## Story Template
+
+Project: RHIDP | Type: Story
+
+```
+h1. Story
+
+As a user of RHDH, I want to <ACTION> so that <THIS OUTCOME>
+
+h2. *Background*
+
+h2. *Dependencies and Blockers*
+(?) QE impacted work
+(?) Documentation impacted work
+
+h2. *Acceptance Criteria*
+(?) upstream documentation updates (design docs, release notes etc)
+(?) Technical enablement / Demo
+```
+
+## Task Template
+
+Project: RHIDP | Type: Task
+
+```
+h1. Task
+
+As an engineer working on RHDH, I want to <ACTION> so that <THIS OUTCOME>
+
+h2. *Background*
+
+h2. *Dependencies and Blockers*
+(?) QE impacted work
+(?) Documentation impacted work
+
+h2. *Acceptance Criteria*
+```
+
+## Bug Template
+
+Project: RHDHBUGS | Type: Bug
+
+```
+h2. *Description of problem:*
+
+h2. *Prerequisites (if any, like setup, operators/versions):*
+
+h2. *Steps to Reproduce*
+ # <steps>
+
+h2. *Actual results:*
+
+h2. *Expected results:*
+
+h2. *Reproducibility (Always/Intermittent/Only Once):*
+
+h2. *Build Details:*
+
+h2. *Additional info (Such as Logs, Screenshots, etc):*
+```
+
+**Important for support-originated bugs:** Do not include any customer-related information in RHDHBUGS issues. RHDHBUGS is a public project. Customer details stay in RHDHSUPP.
+
+## Feature Request Template
+
+Project: RHDHPLAN | Type: Feature Request
+
+```
+h1. Requested Feature Overview (aka. Goal Summary)
+
+An elevator pitch (value statement) that describes the desired Feature in a clear, concise way.
+
+<your text here>
+
+h3. Goals (aka. expected user outcomes)
+
+The observable functionality that the user would have as a result of receiving this feature. Include the anticipated primary user type/persona.
+
+<your text here>
+
+h3. Requirements (aka. Acceptance Criteria):
+
+A list of specific needs, objectives, or user stories that must be delivered in order to be considered complete.
+
+<enter general Feature acceptance here>
+
+h3. Out of Scope (Optional)
+
+High-level list of items that are out of scope.
+
+<your text here>
+
+h3. Customer Considerations (Optional)
+
+Provide any additional customer-specific considerations that must be made when designing and delivering the Feature.
+
+<your text here>
+```
+
+## Usage Example
+
+Save a template to a file and create the issue:
+
+```bash
+# Write template to file, fill in details
+cat > epic.txt << 'EOF'
+h1. EPIC Goal
+Implement SSO integration for RHDH admin console.
+h2. *Background/Feature Origin*
+Customer requests for enterprise SSO support.
+h2. *Acceptance Criteria*
+(?) DEV - SSO login flow working with OIDC providers
+(?) QE - E2E tests for SSO login/logout
+(?) DOC - Admin guide updated with SSO configuration steps
+EOF
+
+# Create the issue
+acli jira workitem create --project RHIDP --type Epic \
+  --summary "SSO Integration for Admin Console" \
+  --description-file epic.txt \
+  --assignee "@me" \
+  --label "must-have"
+```

--- a/skills/rhdh-jira/references/workflows.md
+++ b/skills/rhdh-jira/references/workflows.md
@@ -1,0 +1,130 @@
+# Jira Workflows & Exit Criteria
+
+Exit criteria are **operational requirements** — fields that must be set before transitioning an issue to the next status. Transitioning without meeting these criteria results in broken issue state.
+
+## Feature Workflow (RHDHPLAN)
+
+```
+New → Refinement → Backlog → In Progress → Release Pending → Closed
+```
+
+| Status | Required Fields Before Entry |
+|--------|----------------------------|
+| New | Assignee, Priority, Team |
+| Refinement | Architect, QA Contact, Doc Contact, Link to Feature Request and/or Design Doc, Size (T-shirt) |
+| Backlog | Candidate Version label (`rhdh-n.n-candidate`), Delivery Epics (Eng, QE, Doc) defined. Optional: `stretch` label for stretch goals. |
+| In Progress | Fix Version set. At least one child Epic is In Progress, Dev Complete, Release Pending, or Closed. |
+| Release Pending | Link to Feature Demo(s). ALL child Epics in Release Pending or Closed. |
+| Closed | Target Version publicly available. |
+
+### Definition of Ready (DoR)
+
+Completion of all exit criteria from New, Refinement, and Backlog before moving to In Progress.
+
+### Definition of Done (DoD)
+
+Completion of all exit criteria for all statuses before moving to Closed.
+
+---
+
+## Epic Workflow (RHIDP)
+
+```
+New → Planning → To Do → In Progress → Dev Complete → Release Pending → Closed
+```
+
+| Status | Required Fields Before Entry |
+|--------|----------------------------|
+| New | Assignee, Team, Priority, Component |
+| Planning | Description (including Acceptance Criteria), Size (T-shirt). Epic is refined; owner is defining stories/tasks. |
+| To Do | All expected Stories/Tasks defined within the Epic. |
+| In Progress | Stories are in progress. Fix Version updated. |
+| Dev Complete | All linked stories, spikes, and tasks in Closed. Automation (E2E) may still be in progress. |
+| Release Pending | Release Notes fields updated (Release Notes Text + Release Notes Type). All work (stories, spikes, automation) done. |
+| Closed | Release (GA) has happened. |
+
+---
+
+## Story/Task Workflow (RHIDP)
+
+```
+New → Refinement → To Do → In Progress → Review → Closed
+```
+
+| Status | Required Fields Before Entry |
+|--------|----------------------------|
+| New | Description, Acceptance Criteria |
+| Refinement | Acceptance Criteria, Story Points, Team, Priority, Assignee |
+| To Do | Assignee set |
+| In Progress | Work has started |
+| Review | PR is up for review, has dev docs, and has been tested. Move to Closed once PR is merged. |
+| Closed | PR merged and verified |
+
+---
+
+## Bug Workflow (RHDHBUGS)
+
+```
+New → Refinement → Backlog → In Progress → Review → Release Pending → Closed
+```
+
+| Status | Required Fields Before Entry |
+|--------|----------------------------|
+| New | Description, Acceptance Criteria, Story Points |
+| Refinement | Acceptance Criteria, Story Points, Team, Priority |
+| Backlog | Assignee |
+| In Progress | Work has started |
+| Review | PR up for review and tested |
+| Release Pending | Release Notes fields updated (Release Notes Text + Release Notes Type). Work to be verified. |
+| Closed | PR merged and verified |
+
+---
+
+## Feature Request Workflow (RHDHPLAN)
+
+```
+Backlog → Under Review → Accepted | Deferred | Rejected
+```
+
+Create as `type = Feature Request` in RHDHPLAN. Kanban-style — no sprints.
+
+| Status | Meaning |
+|--------|---------|
+| Backlog | New request. Customer cases can be linked to show demand. |
+| Under Review | ENG/PM reviewing. Researching and following up. |
+| Accepted | Feature created and linked back to request. Will be prioritized into a future release. |
+| Deferred | Not being added to roadmap right now. Comment describes why. May be re-evaluated. |
+| Rejected | Won't be added to roadmap. Comment describes why. |
+
+---
+
+## RHDHSUPP Bug Workflow
+
+```
+New → In Progress → Review → Release Pending → Closed
+```
+
+Simplified workflow. Statuses Refinement, Backlog, and To Do exist in the workflow definition but are not used in practice.
+
+| Status | Required Fields Before Entry |
+|--------|----------------------------|
+| New | Description, linked to customer case |
+| In Progress | Engineering investigating |
+| Review | Fix identified, PR in review |
+| Release Pending | Fix ready, awaiting release |
+| Closed | Resolved. Story Points set to capture effort spent. |
+
+---
+
+## Automation Rules
+
+These automations run in the RHDH Jira instance:
+
+| Rule | Trigger | Action |
+|------|---------|--------|
+| Keep Fix Version in Sync | Epic fix version updated | Reflect to all child issues |
+| Move Epic to In Progress | Child issue moves to In Progress | Move parent Epic to In Progress |
+| Inherit Fix Version | Fix-version-less epic added to a feature with fix version | Epic inherits the fix version |
+| Move Feature to In Progress | Child epic moves to In Progress | Move parent Feature to In Progress |
+
+Be aware of these when setting fix versions or transitioning issues — changes may cascade automatically.

--- a/skills/rhdh-jira/scripts/parse_issues.py
+++ b/skills/rhdh-jira/scripts/parse_issues.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Flatten, enrich, and filter acli Jira JSON output.
+
+Core problem: acli search --json returns only basic fields. Custom fields
+(team, story points, size, sprint) are rejected by --fields. This script
+bridges the gap by enriching search results via acli view, then flattening
+deeply nested JSON into clean output.
+
+Usage:
+  # Flatten piped JSON (no enrichment — works with whatever fields are present)
+  acli jira workitem search --jql "project = RHIDP" --json | python parse_issues.py
+
+  # Enrich piped search results with full custom fields (calls acli view per issue)
+  acli jira workitem search --jql "project = RHIDP" --limit 20 --json | python parse_issues.py --enrich
+
+  # Flatten a single issue
+  acli jira workitem view RHIDP-123 --fields "*all" --json | python parse_issues.py
+
+  # Select specific fields
+  acli jira workitem search --jql "..." --json | python parse_issues.py --enrich -s key,summary,team,story_points
+
+  # Filter by team (the #1 use case — team is not JQL-filterable)
+  acli jira workitem search --jql "..." --json | python parse_issues.py --enrich -f team="RHDH Install"
+
+  # CSV export
+  acli jira workitem search --jql "..." --json | python parse_issues.py -s key,summary,status --csv
+"""
+
+import argparse
+import csv
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Field extractors: map friendly names → extraction logic
+# ---------------------------------------------------------------------------
+
+
+def _f(issue, field, default=None):
+    """Get field from issue.fields or top-level."""
+    return issue.get("fields", {}).get(field, issue.get(field, default))
+
+
+def _name(issue, field):
+    """Get .name from a nested object field."""
+    val = _f(issue, field)
+    if isinstance(val, dict):
+        return val.get("name", val.get("displayName", val.get("value", "")))
+    return val if val is not None else ""
+
+
+def _sprint_name(issue):
+    """Extract active/future sprint name from sprint array."""
+    sprints = _f(issue, "customfield_10020", [])
+    if not sprints:
+        return ""
+    for state in ("active", "future"):
+        for s in sprints:
+            if isinstance(s, dict) and s.get("state") == state:
+                return s.get("name", "")
+    if isinstance(sprints[-1], dict):
+        return sprints[-1].get("name", "")
+    return ""
+
+
+def _list_names(issue, field):
+    """Join .name values from a list of objects."""
+    items = _f(issue, field, [])
+    return ", ".join(i.get("name", "") for i in items if isinstance(i, dict)) if items else ""
+
+
+def _adf_to_text(issue):
+    """Extract plain text from ADF description."""
+    desc = _f(issue, "description")
+    if desc is None:
+        return ""
+    if isinstance(desc, str):
+        return desc
+    if isinstance(desc, dict):
+        parts = []
+        _walk_adf(desc, parts)
+        return " ".join(parts).strip()
+    return str(desc)
+
+
+def _walk_adf(node, parts):
+    if isinstance(node, dict):
+        if node.get("type") == "text":
+            text = node.get("text", "")
+            if text:
+                parts.append(text)
+        for child in node.get("content", []):
+            _walk_adf(child, parts)
+    elif isinstance(node, list):
+        for child in node:
+            _walk_adf(child, parts)
+
+
+FIELDS = {
+    # Core
+    "key": lambda i: i.get("key", ""),
+    "summary": lambda i: _f(i, "summary", ""),
+    "status": lambda i: _name(i, "status"),
+    "assignee": lambda i: _name(i, "assignee"),
+    "assignee_email": lambda i: (
+        _f(i, "assignee", {}).get("emailAddress", "") if isinstance(_f(i, "assignee"), dict) else ""
+    ),
+    "reporter": lambda i: _name(i, "reporter"),
+    "issuetype": lambda i: _name(i, "issuetype"),
+    "priority": lambda i: _name(i, "priority"),
+    "project": lambda i: (
+        _f(i, "project", {}).get("key", "")
+        if isinstance(_f(i, "project"), dict)
+        else str(_f(i, "project", ""))
+    ),
+    "created": lambda i: _f(i, "created", ""),
+    "updated": lambda i: _f(i, "updated", ""),
+    # Custom
+    "team": lambda i: _name(i, "customfield_10001"),
+    "story_points": lambda i: _f(i, "customfield_10028"),
+    "size": lambda i: _name(i, "customfield_10795"),
+    "sprint": _sprint_name,
+    "parent": lambda i: (
+        _f(i, "parent", {}).get("key", "") if isinstance(_f(i, "parent"), dict) else ""
+    ),
+    "rn_type": lambda i: _name(i, "customfield_10785"),
+    "fix_versions": lambda i: _list_names(i, "fixVersions"),
+    "components": lambda i: _list_names(i, "components"),
+    "labels": lambda i: ", ".join(_f(i, "labels", [])),
+    "description": _adf_to_text,
+    "security": lambda i: _name(i, "security"),
+    "feature_status": lambda i: _name(i, "customfield_10807"),
+    "link_count": lambda i: len(_f(i, "issuelinks", [])),
+}
+
+DEFAULT_SELECT = ["key", "issuetype", "status", "assignee", "priority", "summary"]
+ENRICHED_SELECT = [
+    "key",
+    "issuetype",
+    "status",
+    "assignee",
+    "team",
+    "story_points",
+    "sprint",
+    "summary",
+]
+
+
+# ---------------------------------------------------------------------------
+# Enrichment: fetch full fields via acli view
+# ---------------------------------------------------------------------------
+
+
+def find_acli():
+    """Find acli on PATH or common locations."""
+    path = shutil.which("acli")
+    if path:
+        return path
+    if sys.platform == "win32":
+        candidate = Path.home() / ".path" / "acli.exe"
+        if candidate.exists():
+            return str(candidate)
+    return None
+
+
+def enrich(issues, acli_path):
+    """Fetch full field data for each issue via acli view."""
+    enriched = []
+    total = len(issues)
+    for idx, issue in enumerate(issues, 1):
+        key = issue.get("key", "")
+        if not key:
+            continue
+        print(f"\r  Enriching {idx}/{total}: {key}...", end="", file=sys.stderr)
+        try:
+            result = subprocess.run(
+                [acli_path, "jira", "workitem", "view", key, "--fields", "*all", "--json"],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=15,
+            )
+            if result.returncode == 0 and result.stdout:
+                data = json.loads(result.stdout)
+                enriched.append(data[0] if isinstance(data, list) else data)
+            else:
+                enriched.append(issue)
+                print(" [failed]", file=sys.stderr)
+        except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError):
+            enriched.append(issue)
+    print(file=sys.stderr)  # newline after progress
+    return enriched
+
+
+# ---------------------------------------------------------------------------
+# Filtering
+# ---------------------------------------------------------------------------
+
+
+def apply_filters(issues, filters):
+    """Filter issues by field=value pairs. Case-insensitive matching."""
+    for filt in filters:
+        if "=" not in filt:
+            print(f"Warning: invalid filter '{filt}', use field=value", file=sys.stderr)
+            continue
+        field, value = filt.split("=", 1)
+        field, value = field.strip(), value.strip().strip('"').strip("'").lower()
+        extractor = FIELDS.get(field)
+        if extractor:
+            issues = [i for i in issues if str(extractor(i)).lower() == value]
+        else:
+            issues = [i for i in issues if str(_f(i, field, "")).lower() == value]
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+
+def flatten(issue, fields):
+    """Extract fields into a flat dict."""
+    row = {}
+    for f in fields:
+        ext = FIELDS.get(f)
+        val = ext(issue) if ext else _f(issue, f, "")
+        row[f] = val if val is not None else ""
+    return row
+
+
+def out_table(rows, fields):
+    if not rows:
+        print("No issues found.")
+        return
+    widths = {}
+    for f in fields:
+        col_vals = [str(r.get(f, "")) for r in rows]
+        widths[f] = min(max(len(f), max((len(v) for v in col_vals), default=0)), 60)
+    print(" | ".join(f.ljust(widths[f]) for f in fields))
+    print("-+-".join("-" * widths[f] for f in fields))
+    for row in rows:
+        print(" | ".join(str(row.get(f, ""))[: widths[f]].ljust(widths[f]) for f in fields))
+
+
+def out_csv(rows, fields):
+    writer = csv.DictWriter(sys.stdout, fieldnames=fields, extrasaction="ignore")
+    writer.writeheader()
+    writer.writerows(rows)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Flatten, enrich, and filter acli Jira JSON output.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="Fields: " + ", ".join(sorted(FIELDS.keys())),
+    )
+    parser.add_argument(
+        "--enrich",
+        action="store_true",
+        help="Fetch full custom fields via acli view per issue (slower, but gets team/points/sprint)",
+    )
+    parser.add_argument(
+        "-s",
+        "--select",
+        help="Comma-separated fields to output (default changes based on --enrich)",
+    )
+    parser.add_argument(
+        "-f",
+        "--filter",
+        action="append",
+        default=[],
+        help='Filter by field=value, e.g. -f team="RHDH Install". Repeatable.',
+    )
+    parser.add_argument("--json", action="store_true", help="JSON output")
+    parser.add_argument("--csv", action="store_true", help="CSV output")
+    parser.add_argument(
+        "--list-fields",
+        action="store_true",
+        help="List available field names",
+    )
+    args = parser.parse_args()
+
+    if args.list_fields:
+        for name in sorted(FIELDS.keys()):
+            print(f"  {name}")
+        sys.exit(0)
+
+    if sys.stdin.isatty():
+        print("Error: pipe JSON from acli to stdin.", file=sys.stderr)
+        print(
+            '  acli jira workitem search --jql "..." --json | python parse_issues.py',
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    issues = json.load(sys.stdin)
+    if not isinstance(issues, list):
+        issues = [issues]
+
+    if args.enrich:
+        acli_path = find_acli()
+        if not acli_path:
+            print("Error: acli not found (required for --enrich)", file=sys.stderr)
+            sys.exit(2)
+        issues = enrich(issues, acli_path)
+
+    if args.filter:
+        issues = apply_filters(issues, args.filter)
+
+    fields = (
+        [f.strip() for f in args.select.split(",")]
+        if args.select
+        else ENRICHED_SELECT
+        if args.enrich
+        else DEFAULT_SELECT
+    )
+
+    rows = [flatten(issue, fields) for issue in issues]
+
+    if args.json:
+        json.dump(rows, sys.stdout, indent=2, default=str)
+        print()
+    elif args.csv:
+        out_csv(rows, fields)
+    elif sys.stdout.isatty():
+        out_table(rows, fields)
+    else:
+        json.dump(rows, sys.stdout, indent=2, default=str)
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/rhdh-jira/scripts/setup.py
+++ b/skills/rhdh-jira/scripts/setup.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Verify acli installation and Jira authentication for RHDH projects."""
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+RHDH_PROJECTS = ["RHIDP", "RHDHPLAN", "RHDHBUGS", "RHDHSUPP"]
+JIRA_CONFIG_RELATIVE = Path(".config", "acli", "jira_config.yaml")
+
+
+def find_acli():
+    """Find acli binary on PATH."""
+    acli = shutil.which("acli")
+    if acli:
+        return acli
+
+    # Check common locations on Windows
+    if sys.platform == "win32":
+        home = Path.home()
+        candidates = [
+            home / ".path" / "acli.exe",
+            home / "AppData" / "Local" / "acli" / "acli.exe",
+        ]
+        for candidate in candidates:
+            if candidate.exists():
+                return str(candidate)
+
+    return None
+
+
+def check_config():
+    """Check if Jira API token config exists."""
+    config_path = Path.home() / JIRA_CONFIG_RELATIVE
+    if not config_path.exists():
+        return None, "not found"
+
+    try:
+        content = config_path.read_text(encoding="utf-8")
+        if "api_token" in content:
+            return str(config_path), "api_token"
+        elif "oauth" in content.lower():
+            return str(config_path), "oauth"
+        else:
+            return str(config_path), "unknown"
+    except OSError as e:
+        return None, f"read error: {e}"
+
+
+def smoke_test(acli_path):
+    """Run a smoke test to verify Jira connectivity."""
+    try:
+        result = subprocess.run(
+            [acli_path, "jira", "project", "list", "--recent", "1"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=30,
+        )
+        stdout = result.stdout or ""
+        stderr = result.stderr or ""
+        if result.returncode == 0 and stdout.strip():
+            return True, stdout.strip()
+        return False, stderr.strip() or "empty response"
+    except subprocess.TimeoutExpired:
+        return False, "timeout after 30s"
+    except OSError as e:
+        return False, str(e)
+
+
+def check_projects(acli_path):
+    """Check which RHDH projects are accessible."""
+    accessible = []
+    inaccessible = []
+
+    for project in RHDH_PROJECTS:
+        try:
+            result = subprocess.run(
+                [acli_path, "jira", "project", "view", "--key", project],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=15,
+            )
+            if result.returncode == 0:
+                accessible.append(project)
+            else:
+                stderr = result.stderr or ""
+                inaccessible.append((project, stderr.strip()))
+        except (subprocess.TimeoutExpired, OSError) as e:
+            inaccessible.append((project, str(e)))
+
+    return accessible, inaccessible
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Verify acli installation and Jira authentication for RHDH."
+    )
+    parser.add_argument("--json", action="store_true", help="Output results as JSON")
+    parser.add_argument("--quick", action="store_true", help="Skip project accessibility check")
+    args = parser.parse_args()
+
+    results = {
+        "acli_found": False,
+        "acli_path": None,
+        "config_found": False,
+        "config_path": None,
+        "auth_type": None,
+        "connectivity": False,
+        "connectivity_detail": None,
+        "projects_accessible": [],
+        "projects_inaccessible": [],
+        "overall": "fail",
+    }
+
+    # Step 1: Find acli
+    acli_path = find_acli()
+    if acli_path:
+        results["acli_found"] = True
+        results["acli_path"] = acli_path
+    else:
+        results["connectivity_detail"] = "acli not found on PATH"
+        _output(results, args.json)
+        sys.exit(1)
+
+    # Step 2: Check config
+    config_path, auth_type = check_config()
+    if config_path:
+        results["config_found"] = True
+        results["config_path"] = config_path
+        results["auth_type"] = auth_type
+
+    # Step 3: Smoke test (do NOT use 'acli auth status' — it lies with API tokens)
+    ok, detail = smoke_test(acli_path)
+    results["connectivity"] = ok
+    results["connectivity_detail"] = detail
+
+    if not ok:
+        _output(results, args.json)
+        sys.exit(1)
+
+    # Step 4: Check project access
+    if not args.quick:
+        accessible, inaccessible = check_projects(acli_path)
+        results["projects_accessible"] = accessible
+        results["projects_inaccessible"] = [{"project": p, "error": e} for p, e in inaccessible]
+
+    results["overall"] = "pass"
+    _output(results, args.json)
+    sys.exit(0)
+
+
+def _output(results, as_json):
+    """Print results in JSON or human-readable format."""
+    if as_json:
+        json.dump(results, sys.stdout, indent=2)
+        print()
+        return
+
+    print("=" * 50)
+    print("RHDH Jira Setup Check")
+    print("=" * 50)
+
+    # acli
+    if results["acli_found"]:
+        print(f"  [PASS] acli found: {results['acli_path']}")
+    else:
+        print("  [FAIL] acli not found on PATH")
+        print("         Install from: https://developer.atlassian.com/cloud/acli/")
+        return
+
+    # Config
+    if results["config_found"]:
+        print(f"  [PASS] Config found: {results['config_path']}")
+        print(f"         Auth type: {results['auth_type']}")
+    else:
+        print("  [WARN] No Jira config found at ~/.config/acli/jira_config.yaml")
+        print("         Run: acli auth login")
+
+    # Connectivity
+    if results["connectivity"]:
+        print("  [PASS] Jira connectivity verified")
+    else:
+        print(f"  [FAIL] Jira connectivity failed: {results['connectivity_detail']}")
+        return
+
+    # Projects
+    if results["projects_accessible"]:
+        print(f"  [PASS] Projects accessible: {', '.join(results['projects_accessible'])}")
+    if results["projects_inaccessible"]:
+        for item in results["projects_inaccessible"]:
+            print(f"  [WARN] {item['project']}: {item['error']}")
+
+    print()
+    print(f"Overall: {results['overall'].upper()}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Foundational agent skill for interacting with RHDH Jira projects (RHIDP, RHDHPLAN, RHDHBUGS, RHDHSUPP) using the Atlassian CLI (`acli`). Designed as the base layer that future specialized skills can build on.

## Structure

| File | Purpose |
|------|---------|
| `SKILL.md` | Setup, project table, gotchas, error handling, routing, common workflows |
| `references/acli-commands.md` | Command cheat sheet with flag gotchas and output format differences |
| `references/fields.md` | Custom fields, labels, link types, components, priorities |
| `references/workflows.md` | Issue type state machines + exit criteria for Feature, Epic, Story/Task, Bug, Feature Request |
| `references/templates.md` | Jira wiki markup templates for all 7 issue types |
| `references/support.md` | RHDHSupp/RHDHBUGS support case workflow + SLAs |
| `references/jql-patterns.md` | 23+ tested JQL queries + board/sprint reference tables |
| `scripts/setup.py` | Verify acli install + auth (smoke tests, not `acli auth status` which lies with API tokens) |
| `scripts/parse_issues.py` | Flatten, enrich, and filter acli JSON output — bridges the gap where `acli search --json` can't return custom fields |

## Validation

- All 23+ JQL queries tested live against `redhat.atlassian.net`
- All acli command flags verified against `--help`
- All 14 custom field IDs verified against real issue data
- Both scripts tested and passing
- Two rounds of expert review completed (skill-writing + Jira QA)
- All 245 project tests pass, ruff lint/format clean

## Key design decisions

- **One skill with references** (impeccable pattern) instead of a family of separate skills — reduces routing complexity
- **`acli-commands.md` is a cheat sheet**, not a full manual — trusts `acli --help` for details
- **`parse_issues.py` solves the #1 acli pain point**: search can't return custom fields (team, story points, sprint). The script enriches via `acli view` per issue, then flattens and filters.
- **Exit criteria framed as operational requirements**, not process knowledge
- **RHDHPAI documented as archived** — prevents agents from hitting JQL errors