### PR TITLE
Improve create-skill with architecture patterns

### DIFF
--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-skill
-description: Create new agent skills following the Agent Skills open standard (agentskills.io). Interviews the user relentlessly about intent, scope, and edge cases before drafting. Covers SKILL.md structure, frontmatter, progressive disclosure, description optimization, script bundling, and review. Use when the user wants to create a skill, write a skill, build a new skill, make a skill, draft a SKILL.md, or mentions "create-skill". Also use when asked to package expertise, workflows, or domain knowledge into a reusable skill.
+description: Create new agent skills following the Agent Skills open standard (agentskills.io). Interviews the user relentlessly about intent, scope, and edge cases before drafting. Covers SKILL.md structure, frontmatter, progressive disclosure, description optimization, script bundling, sub-command architecture, setup gates, context systems, and review. Use when the user wants to create a skill, write a skill, build a new skill, make a skill, draft a SKILL.md, or mentions "create-skill". Also use when asked to package expertise, workflows, or domain knowledge into a reusable skill.
 ---
 
 # Create Skill
@@ -9,21 +9,32 @@ Create agent skills following the [Agent Skills open standard](https://agentskil
 
 ## Phase 1: Interview
 
-Interview the user relentlessly about every aspect of this skill until reaching shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+Interview the user about every aspect of this skill until reaching shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
 
-Ask questions one at a time. If a question can be answered by exploring the codebase, explore the codebase instead.
+### Interview cadence
 
-Cover these areas before writing anything:
+Ask **one question at a time**. Wait for the answer before asking the next. Adapt follow-ups based on what you learn. Each question should provide clear benefit toward building a better skill — cut questions the codebase can answer for you.
 
-- **What task does this skill cover?** What specific problem does it solve? What does the user do today without it?
-- **Scope boundaries.** What should this skill NOT do? What adjacent tasks should be left to other skills or the agent's general capabilities?
-- **Input/output.** What does the user provide? What does the skill produce? Are there specific formats?
-- **Edge cases.** What goes wrong? What are the common mistakes? What gotchas would a new user hit?
-- **Success criteria.** How do you know the skill worked correctly?
-- **What can be scripted?** Actively look for operations that can be deterministic code rather than LLM instructions. Scripts are cheaper, faster, and more reliable. The more of a skill that runs as scripts, the less compute it burns. Only leave judgment calls and creative reasoning to instructions.
-- **References needed?** Is there domain knowledge too large for the main SKILL.md that should live in separate files?
-- **Existing patterns.** Are there similar skills or workflows to draw from? Check the codebase for conventions.
-- **Platform constraints.** Will this skill run on macOS, Windows, and Linux? Scripts must handle path separators, temp directories, and shell differences across platforms.
+If a question can be answered by exploring the codebase, explore the codebase instead of asking.
+
+Focus areas, roughly in order:
+
+1. **Purpose and audience.** What task does this skill cover? What specific problem does it solve? What does the user do today without it?
+2. **Scope boundaries.** What should this skill NOT do? What adjacent tasks belong to other skills?
+3. **Input/output.** What does the user provide? What does the skill produce? Specific formats?
+4. **Edge cases.** What goes wrong? Common mistakes? Gotchas for new users?
+5. **Success criteria.** How do you know the skill worked correctly?
+6. **What can be scripted?** Look for deterministic operations that should be code, not LLM instructions. Scripts are cheaper, faster, and more reliable.
+7. **References needed?** Domain knowledge too large for SKILL.md that should live in separate files?
+8. **Existing patterns.** Similar skills or workflows to draw from? Check the codebase.
+9. **Platform constraints.** macOS, Windows, and Linux? Scripts must handle path separators, temp directories, and shell differences.
+10. **Architecture.** Based on the answers above, decide whether the skill's scope warrants sub-commands, context systems, or setup gates. Most skills don't need this — skip to Phase 2 if the skill is straightforward. If it does, ask:
+    - **Should this be one skill with sub-commands or multiple skills?** One skill with a router table prevents menu pollution. Multiple skills are appropriate when the tasks have no shared context or setup.
+    - **Does the skill need project-level context?** If every command needs the same background (project config, conventions), design a context file pattern with a loader script.
+    - **Are there mandatory setup gates?** Steps that must pass before any work begins (context loaded, config valid, dependencies present). Gates prevent generic output.
+    - **Does behavior vary by task type?** If so, design a register/mode system that classifies the task first, then loads different references.
+
+Read `references/architecture-patterns.md` when the skill needs sub-commands, context systems, or setup gates.
 
 Do not proceed to Phase 2 until the user confirms the scope is complete.
 
@@ -56,12 +67,112 @@ Keep the SKILL.md body under 500 lines. If approaching this limit, split domain-
 
 ### Writing patterns
 
-- Use imperative form: "Run the command" not "You should run the command"
-- Define output formats with templates when the output structure matters
-- Include concrete examples showing input → output
-- Add gotchas sections for common mistakes
-- Use checklists for multi-step workflows
-- Tell the agent *when* to load each reference file: "Read `references/api-errors.md` if the API returns a non-200 status code" is better than "see references/ for details"
+- **Imperative form**: "Run the command" not "You should run the command"
+- **Output templates**: Define exact formats when the output structure matters
+- **Concrete examples**: Show input → output for non-obvious workflows
+- **Gotchas sections**: Common mistakes the agent should avoid
+- **Checklists**: Multi-step workflows with validation gates
+- **Conditional loading**: "Read `references/api-errors.md` if the API returns a non-200 status code" — not "see references/ for details"
+- **Absolute bans**: When certain patterns are always wrong, use match-and-refuse lists. "If you're about to write X, stop and do Y instead." More effective than vague "be careful" guidance.
+
+### Sub-command router (when applicable)
+
+For skills with multiple distinct operations, use a router table in SKILL.md:
+
+```markdown
+## Commands
+
+| Command | Description | Reference |
+|---|---|---|
+| `craft [feature]` | Build a feature end-to-end | [references/craft.md](references/craft.md) |
+| `audit [target]` | Technical quality checks | [references/audit.md](references/audit.md) |
+
+### Routing rules
+
+1. **No argument**: Show the command menu. Ask what to do.
+2. **First word matches a command**: Load its reference file and follow it.
+3. **First word doesn't match**: General invocation using the full argument as context.
+```
+
+Back the router with a `scripts/command-metadata.json` as the single source of truth:
+
+```json
+{
+  "craft": {
+    "description": "Full build flow. Use when building a new feature end-to-end.",
+    "argumentHint": "[feature description]"
+  }
+}
+```
+
+### Setup gates (when applicable)
+
+Non-negotiable checks before any file edits. Gates prevent generic output from missing context.
+
+```markdown
+## Setup (non-optional)
+
+| Gate | Required check | If fail |
+|---|---|---|
+| Context | Project config loaded via `python scripts/load_context.py` | Run the loader first |
+| Config | Config file exists and is valid | Run `skill-name setup` |
+| Command | Sub-command reference is loaded | Load the reference |
+| Mutation | All gates above pass | Do not edit project files |
+```
+
+### Register/mode system (when applicable)
+
+When behavior varies by task type, classify first, then load different references:
+
+```markdown
+## Register
+
+Every task is **library** (published, API-stable) or **application** (internal, can break).
+Identify before acting. Load the matching reference: [references/library.md] or [references/application.md].
+```
+
+### Capability-gating
+
+Steps that depend on optional environment capabilities (browser automation, specific CLI tools) must degrade gracefully:
+
+```markdown
+### Automated Scan (Capability-Gated)
+
+Run the automated scanner when ALL of these are true:
+- The target files exist and are readable
+- The required CLI tool is installed
+
+If unavailable, state in one line that the step is skipped and why. Do not ask the user to install tooling.
+```
+
+### Structured artifacts as handoffs
+
+When one command produces output that another consumes, define the artifact structure explicitly. The producing command's reference defines the format; the consuming command's reference says what it expects:
+
+```markdown
+### Plan Structure
+
+**1. Summary** (2-3 sentences)
+**2. Primary Goal**
+**3. Approach**
+...
+```
+
+### Self-critique loops
+
+For build/implementation commands, mandate inspect-and-fix passes with explicit exit bars:
+
+```markdown
+### Critique and fix loop
+
+After the first pass, write a short self-critique and patch. Repeat until no material issues remain:
+1. Does it match the requirements?
+2. Does it pass the [quality test]?
+3. Check every expected scenario.
+4. Check edge cases.
+
+The exit bar is not "it works." It is: [explicit quality threshold].
+```
 
 ## Phase 3: Description Optimization
 
@@ -75,44 +186,79 @@ Quick validation:
 4. Revise if needed — broaden for missed triggers, narrow for false triggers
 5. Verify under 1024 characters
 
+For skills with sub-commands, the main description covers the skill broadly. Each sub-command's description in `command-metadata.json` is optimized separately for auto-trigger keyword matching.
+
 ## Phase 4: Scripts
 
 Read `references/scripts-guide.md` for the full guide.
 
-**Bias toward scripts.** Every deterministic operation should be a script, not an instruction. Scripts are cheaper (no LLM tokens), faster (no reasoning), and more reliable (no hallucination). Instructions should only cover judgment calls, creative reasoning, and decision-making that genuinely requires LLM capability.
+**Bias toward scripts.** Every deterministic operation should be a script, not an instruction. Scripts are cheaper (no LLM tokens), faster (no reasoning), and more reliable (no hallucination).
 
 For each piece of the skill's workflow, ask: "Could a script do this?" If yes, write the script.
 
-Examples of what should be scripts:
+**Should be scripts:**
 - Validation (input format, required fields, schema compliance)
 - File generation from templates
 - Data extraction and transformation
 - API calls with structured responses
 - Setup and environment checks
 - Output formatting
+- Context loading (read project files, resolve paths, return JSON)
+- Pin/unpin shortcuts (create/remove command aliases)
+- Cleanup (remove deprecated files after skill updates)
 
-Examples of what should stay as instructions:
+**Should stay as instructions:**
 - Deciding between architectural approaches
 - Reviewing code for quality or style
 - Explaining tradeoffs to the user
 - Creative writing or design decisions
+- Interview/discovery conversations
 
 Key patterns:
 - **Python without dependencies**: stdlib only, `argparse` for CLI parsing
 - **Python with dependencies**: PEP 723 inline metadata with `uv run`
 - **All scripts**: Structured output (JSON when piped), clear exit codes, descriptive `--help`
 
+### Context loader pattern
+
+For skills that need project-level context, write a loader script:
+
+The script should follow all standard patterns: `argparse` with `--help`, structured JSON output (pretty when interactive, compact when piped), clear exit codes (0 = found, 1 = missing), `pathlib` for cross-platform paths, and stdlib-only imports. See the "Context File System" section in `references/architecture-patterns.md` for a skeleton.
+
+The SKILL.md references it: "Load context via `python scripts/load_context.py`. Consume the full JSON output. Never pipe through `head`, `tail`, or `grep`."
+
 ## Phase 5: Review
 
 Before presenting the final skill, verify against this checklist:
 
+### Basics
 - [ ] `name` is lowercase, hyphens only, max 64 chars
 - [ ] `description` is under 1024 chars and includes trigger phrases
 - [ ] `description` is slightly pushy — covers edge phrasings that should activate the skill
 - [ ] SKILL.md body is under 500 lines
 - [ ] Instructions use imperative form
-- [ ] References are split out with clear "when to read" pointers
+
+### Architecture (if applicable)
+- [ ] Sub-commands have a router table with clear routing rules
+- [ ] `command-metadata.json` is the single source of truth for command descriptions
+- [ ] Setup gates are defined with fail actions for each gate
+- [ ] Register/mode system classifies before loading references
+- [ ] Capability-gated steps degrade gracefully with one-line skip reasons
+
+### References
+- [ ] Domain knowledge split into `references/` with clear "when to read" pointers
+- [ ] Each reference is self-contained — an agent can load it without reading others
+- [ ] Reference loading is conditional, not eager ("Read X if Y happens")
+
+### Scripts
 - [ ] Scripts (if any) have shebangs, structured output, and `--help`
+- [ ] Context loader returns JSON, handles missing files, resolves fallback paths
+- [ ] Scripts are cross-platform (pathlib, tempfile, no hardcoded paths)
+- [ ] Scripts are idempotent — safe to re-run
+
+### Quality
 - [ ] No time-sensitive information (URLs to specific versions, dates that will go stale)
 - [ ] Consistent terminology throughout
 - [ ] Concrete examples included for non-obvious workflows
+- [ ] Absolute bans defined for patterns that are always wrong
+- [ ] Self-critique loops defined for build/implementation commands with explicit exit bars

--- a/skills/create-skill/references/architecture-patterns.md
+++ b/skills/create-skill/references/architecture-patterns.md
@@ -1,0 +1,343 @@
+# Architecture Patterns for Complex Skills
+
+Read this when the skill covers a broad domain with multiple distinct operations, needs project-level context, or has mandatory setup requirements.
+
+## Sub-Command Router
+
+### When to use
+
+Use when the skill has **multiple distinct operations** that share setup, context, or domain knowledge. One skill with a router table prevents menu pollution — users install one skill, not twenty.
+
+Do NOT use when the operations have no shared context. Separate skills are better when each task is fully independent.
+
+### Structure
+
+The SKILL.md contains:
+1. **Setup section** — shared gates that run before any command
+2. **Shared rules** — domain laws that apply to every command
+3. **Router table** — maps command names to reference files
+4. **Routing rules** — how to interpret user input
+
+Each command gets its own `references/<command>.md` file. The SKILL.md never contains command-specific instructions — it delegates.
+
+### Router table pattern
+
+```markdown
+## Commands
+
+| Command | Category | Description | Reference |
+|---|---|---|---|
+| `init [project]` | Setup | Initialize a new project | [references/init.md](references/init.md) |
+| `check [target]` | Evaluate | Run quality checks | [references/check.md](references/check.md) |
+| `fix [target]` | Repair | Auto-fix common issues | [references/fix.md](references/fix.md) |
+```
+
+Group commands by category (Setup, Evaluate, Repair, Generate, etc.) for the user-facing menu.
+
+### Routing rules
+
+```markdown
+### Routing rules
+
+1. **No argument**: Render the table as a user-facing command menu, grouped by category. Ask what to do.
+2. **First word matches a command**: Load its reference file and follow its instructions. Everything after the command name is the target.
+3. **First word doesn't match**: General invocation. Apply setup, shared rules, and the full argument as context.
+```
+
+Setup runs before routing. Sub-commands don't re-invoke the parent skill.
+
+### Command metadata as data
+
+Keep a `scripts/command-metadata.json` as the single source of truth for each command's description and argument hint. Both the SKILL.md router table and any tooling (pin scripts, build systems) read from this file.
+
+```json
+{
+  "init": {
+    "description": "Initialize a new project with scaffolding and config. Use when starting fresh.",
+    "argumentHint": "[project name or path]"
+  },
+  "check": {
+    "description": "Run quality checks across linting, tests, and conventions. Use when reviewing code.",
+    "argumentHint": "[file, directory, or area]"
+  }
+}
+```
+
+The `description` here is optimized for auto-trigger keyword matching. Pack it with trigger phrases and near-miss scenarios.
+
+### Pin/unpin shortcuts
+
+Allow users to create standalone shortcuts: `/check` → `/skill-name check`. Write a script that creates redirect shims in the harness directory.
+
+## Setup Gates
+
+### When to use
+
+Use when the skill produces noticeably worse output without certain preconditions. Gates turn "the output was mediocre" into "the agent tells you what's missing."
+
+### Gate table pattern
+
+Define gates as a table with required check and fail action:
+
+```markdown
+## Setup (non-optional)
+
+| Gate | Required check | If fail |
+|---|---|---|
+| Context | Project context loaded via `python scripts/load_context.py` | Run the loader |
+| Config | Config file exists and is not placeholder | Run `skill-name setup` |
+| Command | Sub-command reference is loaded | Load the reference |
+| Mutation | All gates above pass | Do not edit project files |
+```
+
+The **Mutation** gate is always last. No file edits until every other gate passes.
+
+### Preflight declaration
+
+For environments that support it, require the agent to state gate status before editing files:
+
+```text
+SKILL_PREFLIGHT: context=pass config=pass command_reference=pass mutation=open
+```
+
+This forces the agent to explicitly evaluate each gate rather than skipping silently.
+
+### Common gates
+
+| Gate type | Checks for | Example |
+|---|---|---|
+| Context | Project-level config loaded | Config file exists and is valid |
+| Config | Required configuration present | API keys, workspace settings |
+| Dependencies | Required tools installed | CLI tools, runtimes |
+| Command | Sub-command reference loaded | Reference file read into context |
+| Plan | User-confirmed plan exists | Plan approved before building |
+| Mutation | All above pass | Final gate before file edits |
+
+## Register/Mode System
+
+### When to use
+
+Use when the skill's behavior varies significantly by task type, but all types share the same commands and setup. The register classifies the task, then loads different reference material.
+
+### Pattern
+
+1. Define 2-4 registers with clear criteria:
+
+```markdown
+## Register
+
+Every task is **library** (published, API-stable) or **application** (internal, can break).
+
+Identify before acting. Priority: (1) cue in the task itself; (2) the target in focus; (3) explicit field in config. First match wins.
+
+Load the matching reference: [references/library.md](references/library.md) or [references/application.md](references/application.md).
+```
+
+2. Each register gets its own reference file with register-specific rules.
+3. Sub-command references add a short `## Register` section only where behavior diverges between registers. Don't restate the register file — link to it.
+
+### More examples
+
+- **Documentation**: `tutorial` (learning-focused, guided) vs `reference` (lookup-focused, exhaustive)
+- **Testing**: `unit` (isolated, fast, mock-heavy) vs `integration` (realistic, slow, infra-dependent)
+- **Deployment**: `development` (fast feedback, verbose) vs `production` (optimized, hardened)
+
+## Context File System
+
+### When to use
+
+Use when every command in the skill needs the same project background. Without it, the agent asks the same questions every session, or produces generic output.
+
+### Pattern
+
+Define 1-2 context files at the project root:
+
+| File | Purpose | Required? |
+|---|---|---|
+| `PROJECT.md` | Strategic context: users, goals, constraints, principles | Yes |
+| `CONVENTIONS.md` | Technical context: patterns, naming, structure | Recommended |
+
+The names should match the domain. A design skill uses `PRODUCT.md` and `DESIGN.md`. A deployment skill might use `INFRA.md`. Pick names that are obvious to the user.
+
+### Loader script
+
+Write a script that finds, reads, and returns context as JSON:
+
+```python
+#!/usr/bin/env python3
+"""Load project context files and return structured JSON."""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+CONFIG_NAMES = ["PROJECT.md", "Project.md", "project.md"]
+FALLBACK_DIRS = [".agents/context", "docs"]
+
+def load_context(cwd=None):
+    cwd = Path(cwd or os.getcwd())
+    # 1. Check env override (SKILL_CONTEXT_DIR)
+    # 2. Check cwd for context files
+    # 3. Fallback to subdirectories (.agents/context/, docs/)
+    # 4. Return structured JSON
+    config_path = ...  # resolve from cwd + fallbacks
+    config = config_path.read_text(encoding="utf-8") if config_path else None
+    return {
+        "hasConfig": config is not None,
+        "config": config,
+        "configPath": str(config_path.relative_to(cwd)) if config_path else None,
+        "contextDir": str(cwd),
+    }
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Load project context files and return structured JSON."
+    )
+    parser.add_argument("--dir", default=".", help="Project root directory")
+    args = parser.parse_args()
+
+    result = load_context(args.dir)
+    if sys.stdout.isatty():
+        print(json.dumps(result, indent=2))
+    else:
+        json.dump(result, sys.stdout)
+    sys.exit(0 if result["hasConfig"] else 1)
+
+if __name__ == "__main__":
+    main()
+```
+
+Key behaviors:
+- **Case-insensitive filename matching**: Accept `PROJECT.md`, `Project.md`, `project.md`
+- **Env override**: `SKILL_CONTEXT_DIR=path/to/dir` for non-standard layouts
+- **Fallback directories**: Check `.agents/context/` and `docs/` if root is clean
+- **Full JSON output**: Never pipe through `head`, `tail`, `grep`, or `jq`
+
+### Context validation
+
+Handle missing, empty, or placeholder files:
+
+```markdown
+If PROJECT.md is missing or placeholder (`[TODO]` markers, <200 chars):
+run `skill-name setup`, then resume the original task with fresh context.
+```
+
+### Session caching
+
+Don't re-run the loader if context is already in the conversation. Exceptions: the user just ran a setup command that rewrites the files, or manually edited them.
+
+## Capability-Gating
+
+### When to use
+
+Use when a step depends on optional environment capabilities (browser automation, specific CLI tools, API keys) that may not be present.
+
+### Pattern
+
+```markdown
+### Automated Scan (Capability-Gated)
+
+Run the scan when ALL of these are true:
+- The target files exist and are readable
+- The required CLI tool is installed
+
+When conditions are met, this step is mandatory. If unavailable, state in one line
+that the step is skipped and why. Do not ask the user to install tooling. Proceed.
+```
+
+Rules:
+- State the conditions explicitly (ALL must be true)
+- Make the step mandatory when conditions are met — don't let the agent skip out of laziness
+- Provide a one-line skip reason template
+- Never ask users to install tooling just to satisfy a gated step
+
+## Structured Artifacts as Handoffs
+
+### When to use
+
+Use when one command produces output that another command consumes. The artifact is the contract between them.
+
+### Pattern
+
+Define the artifact structure in the producing command's reference:
+
+```markdown
+### Plan Structure
+
+**1. Summary** (2-3 sentences)
+**2. Primary Goal**
+**3. Approach**
+**4. Scope** (breadth, depth, time intent)
+**5. Key Scenarios** (default, error, edge cases)
+**6. Open Questions**
+```
+
+The consuming command's reference defines what it expects:
+
+```markdown
+## Build Gate
+
+Build cannot start until:
+1. Context is valid and current.
+2. The plan is explicitly confirmed by the user.
+3. Relevant references from the plan are loaded.
+```
+
+Key: the plan must be **user-confirmed**, not self-authored by the agent. A separate user response approving the plan is required before proceeding.
+
+## Self-Critique Loops
+
+### When to use
+
+Use for any command that produces artifacts (code, documents, configs). The first pass is never the final pass.
+
+### Pattern
+
+```markdown
+### Critique and fix loop
+
+After the first pass, write a short self-critique and patch. Repeat until no material issues remain:
+
+1. Does it match the requirements?
+2. Does it pass the quality checks? (define explicitly)
+3. Check every expected scenario.
+4. Check against the absolute bans list.
+
+The exit bar is not "it works." It is: [specific, measurable quality threshold].
+```
+
+Define the exit bar explicitly. "Looks good" is not a bar. "All tests pass, all expected scenarios are handled, no placeholders remain, and the output would survive code review" is a bar.
+
+## Anti-Patterns in Skill Design
+
+### Monolithic SKILL.md
+
+**Problem**: Everything in one file. 800+ lines, mixing setup, rules, and command-specific logic.
+**Fix**: Router table + reference files. SKILL.md under 500 lines.
+
+### Eager reference loading
+
+**Problem**: "Before starting, read all reference files." Wastes context.
+**Fix**: Conditional loading. "Read `references/aws.md` if deploying to AWS."
+
+### Missing setup gates
+
+**Problem**: Agent produces generic output because it never checked for project context.
+**Fix**: Gate table with explicit fail actions. Mutation gate last.
+
+### Dumping all interview questions
+
+**Problem**: Agent asks 15 questions at once. User abandons.
+**Fix**: Ask one question at a time, wait for the answer, adapt. Every question should earn its place.
+
+### Self-authored plans
+
+**Problem**: Agent writes a plan, approves its own plan, and builds from it.
+**Fix**: Require a separate user response approving the plan before proceeding.
+
+### Vague quality bars
+
+**Problem**: "Make sure it's good quality" — unenforceable.
+**Fix**: Explicit checklists, scoring rubrics, or match-and-refuse ban lists.

--- a/skills/rhdh-jira/SKILL.md
+++ b/skills/rhdh-jira/SKILL.md
@@ -74,6 +74,8 @@ Load only what the current task requires.
 5. **Team field is NOT JQL-filterable.** `customfield_10001` cannot be used in JQL WHERE clauses. Fetch all issues, filter by `customfield_10001.name` in post-processing.
 6. **ADF vs plain text.** Reading descriptions via `--json` returns Atlassian Document Format (nested JSON). Creating/editing with `--description` accepts plain text. Don't try to round-trip ADF through `--description`.
 7. **Acceptance Criteria field is almost always null.** Scan the description for "Requirements", "Acceptance Criteria", or bullet-style criteria instead of checking `customfield_10718`.
+8. **`--enrich` is MANDATORY for custom fields.** Both `acli search --json` and `acli view KEY --json` (without `--fields "*all"`) return only basic fields (assignee, issuetype, priority, status, summary). Story points, team, sprint, and size will appear as empty/null — looking like the data isn't set when it actually is. Always use `scripts/parse_issues.py --enrich` to get custom field data. Skipping `--enrich` is the #1 cause of false "missing data" reports.
+9. **`acli sprint list-workitems --json` wraps results in `{"issues": [...]}`.** The output is NOT a flat array — it's an object with an `issues` key. Extract the array before piping to `parse_issues.py`. See `references/acli-commands.md` for the workaround command.
 
 ## Error Handling
 

--- a/skills/rhdh-jira/references/acli-commands.md
+++ b/skills/rhdh-jira/references/acli-commands.md
@@ -195,6 +195,14 @@ acli jira sprint list-workitems --sprint 65456 --board 11374
 acli jira sprint create --name "RHDH COPE 3292" --board 11374
 ```
 
+**Sprint JSON gotcha:** `list-workitems --json` returns `{"issues": [...], "maxResults": N, ...}` — NOT a flat array. Extract the `issues` array before piping to `parse_issues.py`:
+
+```bash
+acli jira sprint list-workitems --sprint 65456 --board 11374 --json | python -c "
+import json, sys; json.dump(json.load(sys.stdin)['issues'], sys.stdout)
+" | python scripts/parse_issues.py --enrich -s key,summary,status,story_points
+```
+
 ## Projects
 
 ```bash
@@ -231,3 +239,13 @@ acli jira filter get --id 10001
 | Fix versions | Not available via `--fields` | Array of version objects |
 
 When writing descriptions, use `--description "plain text"`. When reading, be aware `--json` returns ADF — don't try to round-trip it.
+
+## Custom Fields and `--enrich`
+
+**Critical:** Both `search --json` and `view KEY --json` (without `--fields "*all"`) return only basic fields: assignee, issuetype, priority, status, summary. Custom fields (story_points, team, sprint, size) are NOT included.
+
+To get custom fields, you MUST either:
+1. Use `view KEY --fields "*all" --json` (what `--enrich` does internally per issue), or
+2. Use `parse_issues.py --enrich` (recommended — handles batching and flattening)
+
+Without `--enrich`, custom fields appear as empty strings — making it look like data isn't set when it is. This is the #1 source of false "missing data" reports.


### PR DESCRIPTION
## What

Enhances the `create-skill` skill with architecture patterns learned from the [impeccable](https://github.com/pbakaus/impeccable) skill repo. Also fixes a duplication issue in `rhdh-jira`.

## Changes

### create-skill/SKILL.md
- Interview cadence: one question at a time, adapt based on answers
- Architecture decisions gated by reasoning, not hard thresholds
- New patterns taught inline: sub-command router, setup gates, register/mode system, capability-gating, structured handoffs, self-critique loops, absolute bans
- All examples use stdlib-only Python (argparse, pathlib, json)

### create-skill/references/architecture-patterns.md (NEW)
- Deep reference loaded only when the skill needs advanced patterns
- Sub-command router architecture (when, structure, metadata, pin/unpin)
- Setup gates (gate types, preflight declarations, common gates table)
- Register/mode system with domain-neutral examples
- Context file system (loader skeleton, validation, session caching)
- Capability-gating, structured handoffs, self-critique loops
- Anti-patterns in skill design (6 common mistakes with fixes)

### rhdh-jira/SKILL.md + references/acli-commands.md
- Deduplicate sprint JSON workaround — full command stays in `references/acli-commands.md`, gotcha in SKILL.md points to it
- Add `--enrich` mandatory gotcha and sprint JSON gotcha to references

## Review
Verified by a reviewer subagent. All findings addressed:
- `reference/` → `references/` consistency (9 spots fixed)
- `{{scripts_path}}` placeholder replaced with concrete path
- Hard "5+" threshold replaced with reasoning-based gating
- Node.js examples replaced with Python to match repo conventions