### PR TITLE
feat: add REST API/GraphQL fallback to rhdh-jira skill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       min-version: ${{ steps.resolve.outputs.min }}
-      max-version: ${{ steps.resolve.outputs.max }}
       matrix: ${{ steps.resolve.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
@@ -27,16 +26,8 @@ jobs:
               m = re.search(r'requires-python\s*=\s*\">=(\d+\.\d+)\"', f.read())
               print(m.group(1) if m else '3.9')
           ")
-          # Latest stable CPython minor version
-          MAX=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
-          if [ "$MIN" = "$MAX" ]; then
-            MATRIX="[\"$MIN\"]"
-          else
-            MATRIX="[\"$MIN\", \"$MAX\"]"
-          fi
           echo "min=$MIN" >> "$GITHUB_OUTPUT"
-          echo "max=$MAX" >> "$GITHUB_OUTPUT"
-          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          echo "matrix=[\"$MIN\", \"3.x\"]" >> "$GITHUB_OUTPUT"
 
   lint:
     needs: resolve-python
@@ -50,7 +41,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ needs.resolve-python.outputs.max-version }}
+          python-version: "3.x"
 
       - run: uv sync --frozen --extra dev
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,20 +14,27 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       min-version: ${{ steps.resolve.outputs.min }}
+      max-version: ${{ steps.resolve.outputs.max }}
       matrix: ${{ steps.resolve.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
 
       - id: resolve
         run: |
-          MIN=$(python3 -c "
-          import re
+          python3 << 'PYEOF' >> "$GITHUB_OUTPUT"
+          import re, json
           with open('pyproject.toml') as f:
-              m = re.search(r'requires-python\s*=\s*\">=(\d+\.\d+)\"', f.read())
-              print(m.group(1) if m else '3.9')
-          ")
-          echo "min=$MIN" >> "$GITHUB_OUTPUT"
-          echo "matrix=[\"$MIN\", \"3.x\"]" >> "$GITHUB_OUTPUT"
+              spec = re.search(r'requires-python\s*=\s*"([^"]+)"', f.read())
+          spec = spec.group(1) if spec else '>=3.9'
+          min_m = re.search(r'>=\s*([\d.]+)', spec)
+          max_m = re.search(r'<=?\s*([\d.]+)', spec)
+          min_v = min_m.group(1) if min_m else '3.9'
+          max_v = max_m.group(1) if max_m else '3.x'
+          matrix = [min_v, max_v] if min_v != max_v else [min_v]
+          print(f'min={min_v}')
+          print(f'max={max_v}')
+          print(f'matrix={json.dumps(matrix)}')
+          PYEOF
 
   lint:
     needs: resolve-python
@@ -41,7 +48,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: ${{ needs.resolve-python.outputs.max-version }}
 
       - run: uv sync --frozen --extra dev
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - run: uv run ruff format --check .
 
   test:
-    needs: [resolve-python, lint]
+    needs: resolve-python
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,36 @@ permissions:
   contents: read
 
 jobs:
+  resolve-python:
+    runs-on: ubuntu-latest
+    outputs:
+      min-version: ${{ steps.resolve.outputs.min }}
+      max-version: ${{ steps.resolve.outputs.max }}
+      matrix: ${{ steps.resolve.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: resolve
+        run: |
+          MIN=$(python3 -c "
+          import re
+          with open('pyproject.toml') as f:
+              m = re.search(r'requires-python\s*=\s*\">=(\d+\.\d+)\"', f.read())
+              print(m.group(1) if m else '3.9')
+          ")
+          # Latest stable CPython minor version
+          MAX=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+          if [ "$MIN" = "$MAX" ]; then
+            MATRIX="[\"$MIN\"]"
+          else
+            MATRIX="[\"$MIN\", \"$MAX\"]"
+          fi
+          echo "min=$MIN" >> "$GITHUB_OUTPUT"
+          echo "max=$MAX" >> "$GITHUB_OUTPUT"
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+
   lint:
+    needs: resolve-python
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -21,7 +50,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ needs.resolve-python.outputs.max-version }}
 
       - run: uv sync --frozen --extra dev
 
@@ -30,11 +59,11 @@ jobs:
       - run: uv run ruff format --check .
 
   test:
-    needs: lint
+    needs: [resolve-python, lint]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.11"]
+        python-version: ${{ fromJson(needs.resolve-python.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
 

--- a/skills/rhdh-jira/SKILL.md
+++ b/skills/rhdh-jira/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: rhdh-jira
 description: |
-  Interact with RHDH Jira projects (RHIDP, RHDHPLAN, RHDHBUGS, RHDHSUPP) using the Atlassian CLI (acli). Use when the user needs to search, create, view, edit, transition, comment on, or link Jira issues for Red Hat Developer Hub. Also use when the user asks about Jira workflows, exit criteria, issue templates, custom fields, boards, sprints, or JQL queries in the RHDH context. Trigger when the user mentions Jira issue keys like RHIDP-1234, RHDHPLAN-567, RHDHBUGS-890, or any RHDH project key. Also trigger for support case bug filing, feature request creation, or release planning in Jira. Covers acli setup, authentication, and troubleshooting.
+  Interacts with RHDH Jira projects (RHIDP, RHDHPLAN, RHDHBUGS, RHDHSUPP) using the Atlassian CLI (acli), with REST API and GraphQL fallback for custom field updates and complex queries. Use when the user needs to search, create, view, edit, transition, comment on, or link Jira issues for Red Hat Developer Hub. Also use when the user asks about Jira workflows, exit criteria, issue templates, custom fields, boards, sprints, JQL queries, or Jira API schema discovery. Trigger when the user mentions Jira issue keys like RHIDP-1234, RHDHPLAN-567, RHDHBUGS-890, or any RHDH project key. Also trigger for support case bug filing, feature request creation, release planning, or acli setup and installation.
 compatibility: "acli (Atlassian CLI) on PATH. Python 3 for scripts. Windows, macOS, Linux."
 ---
 
@@ -20,9 +20,17 @@ python scripts/setup.py
 The script checks:
 1. `acli` binary on PATH
 2. Jira API token auth configured (`~/.config/acli/jira_config.yaml`)
-3. Smoke test against `redhat.atlassian.net`
+3. `.jira-token` file next to `acli` executable (for REST API fallback)
+4. Smoke test against `redhat.atlassian.net`
 
-If `acli` is not installed, download from [Atlassian CLI](https://developer.atlassian.com/cloud/acli/). Authenticate with `acli auth login` or configure an API token.
+If `acli` is not installed, download from [Atlassian CLI](https://developer.atlassian.com/cloud/acli/) and follow the [Getting Started guide](https://developer.atlassian.com/cloud/acli/guides/how-to-get-started/) for installation and authentication setup. Use API token authentication, not OAuth — OAuth sessions expire and `acli auth status` gives false negatives with token auth (see Gotchas).
+
+### REST/GraphQL capability gate
+
+Before attempting any REST API or GraphQL call:
+1. Run `python scripts/setup.py --json` and check `token_file_found`
+2. If missing, state: "REST API/GraphQL fallback unavailable — `.jira-token` not configured. Run `setup.py` for instructions." Continue with acli-only workflow.
+3. If the user needs REST/GraphQL, load `references/auth.md` for setup instructions
 
 ## Scripts
 
@@ -64,6 +72,9 @@ Load only what the current task requires.
 | `references/templates.md` | Creating new issues. Also load `references/workflows.md` for required fields at entry status. |
 | `references/support.md` | Handling support cases, filing bugs from customer cases, or creating feature requests from support. |
 | `references/jql-patterns.md` | Building a JQL query, finding a board ID, or looking up sprint information. JQL cookbook with 23+ tested queries. |
+| `references/auth.md` | Setting up authentication for REST API or GraphQL calls. Token file format, path discovery, security, instance config, common auth errors. |
+| `references/rest-api-fallback.md` | `acli` failed to update a custom field (Team, Size, Story Points, Release Note Type). Curl examples, response handling, OpenAPI spec discovery. |
+| `references/graphql-queries.md` | Complex read queries needing multiple fields, relationships, or custom field data in one call. Schema introspection, JQL search via GraphQL, field type fragments. |
 
 ## Common Gotchas
 
@@ -75,19 +86,23 @@ Load only what the current task requires.
 6. **ADF vs plain text.** Reading descriptions via `--json` returns Atlassian Document Format (nested JSON). Creating/editing with `--description` accepts plain text. Don't try to round-trip ADF through `--description`.
 7. **Acceptance Criteria field is almost always null.** Scan the description for "Requirements", "Acceptance Criteria", or bullet-style criteria instead of checking `customfield_10718`.
 8. **`--enrich` is MANDATORY for custom fields.** Both `acli search --json` and `acli view KEY --json` (without `--fields "*all"`) return only basic fields (assignee, issuetype, priority, status, summary). Story points, team, sprint, and size will appear as empty/null — looking like the data isn't set when it actually is. Always use `scripts/parse_issues.py --enrich` to get custom field data. Skipping `--enrich` is the #1 cause of false "missing data" reports.
-9. **`acli sprint list-workitems --json` wraps results in `{"issues": [...]}`.** The output is NOT a flat array — it's an object with an `issues` key. Extract the array before piping to `parse_issues.py`. See `references/acli-commands.md` for the workaround command.
+9. **Custom fields may fail to update via `acli`.** `acli jira workitem edit` can silently fail or error when setting custom fields (Team, Size, Story Points). When an `acli edit` for a custom field fails, fall back to the Jira REST API. Find the token file at `.jira-token` next to the `acli` executable (discover the path with `readlink -f "$(which acli)"` or `where acli`). Read `references/rest-api-fallback.md` for curl examples and payload formats. Never read the token file into context.
+10. **`acli sprint list-workitems --json` wraps results in `{"issues": [...]}`.**  The output is NOT a flat array — it's an object with an `issues` key. Extract the array before piping to `parse_issues.py`. See `references/acli-commands.md` for the workaround command.
+11. **GraphQL search is beta.** `issueSearchStable` requires `X-ExperimentalApi: JiraIssueSearch` header. Load `references/graphql-queries.md` before attempting GraphQL queries.
+12. **`.jira-token` format is `email:token`, not bare token.** A file containing only the API token without the email prefix will cause 401 errors on REST/GraphQL calls. The `setup.py` script validates the format.
 
 ## Error Handling
 
 | Error | Action |
 |-------|--------|
-| `acli` not on PATH | Run `scripts/setup.py`. Install from Atlassian if missing. |
+| `acli` not on PATH | Run `scripts/setup.py`. Install from Atlassian if missing. See [Getting Started](https://developer.atlassian.com/cloud/acli/guides/how-to-get-started/). |
 | "unauthorized" from `auth status` | Ignore. Check `jira_config.yaml` exists. Run smoke test. |
 | "required flag(s) not set" | Command syntax wrong. Run `acli jira <subcommand> --help`. |
 | "field X is not allowed" | Use `--json` instead of `--fields` for that field. |
 | "the value X does not exist for the field 'project'" | Project key is wrong or project is archived (e.g., RHDHPAI). |
 | Rate limiting (429) | Wait 5 seconds, retry once. |
 | Interactive prompt hangs | Missing `--yes` flag on a mutating command. |
+| Custom field update fails via `acli` | Fall back to Jira REST API using `.jira-token` file. See Gotcha #9. |
 
 ## Common Workflows
 
@@ -106,7 +121,18 @@ Load only what the current task requires.
 2. Verify required fields are set before transitioning
 3. Run `acli jira workitem transition --key KEY --status "X" --yes`
 
+### Complex queries (many fields, relationships)
+1. Load `references/graphql-queries.md`
+2. Use `issueByKey` for single issues or `issueSearchStable` (beta) for JQL search
+3. Fall back to `acli` + `parse_issues.py --enrich` if GraphQL returns errors
+
+### Discovering unknown fields or endpoints
+1. For REST: load `references/rest-api-fallback.md` — use the OpenAPI spec or `/rest/api/3/field` endpoint
+2. For GraphQL: load `references/graphql-queries.md` — use `__type` introspection queries
+3. Do not guess field IDs or types — always verify against the live schema
+
 ## When NOT to Use
 
 - **Non-RHDH Jira projects** — this skill's field mappings, workflows, and JQL patterns are specific to RHIDP/RHDHPLAN/RHDHBUGS/RHDHSUPP
-- **Jira REST API directly** — this skill covers `acli` CLI only
+- **Jira REST API directly** — use `acli` first. REST API is a fallback for custom field updates and schema discovery when `acli` cannot handle the operation (see Gotcha #9)
+- **GraphQL for simple lookups** — use `acli` for single-issue views and simple searches. GraphQL is for complex queries needing relationships or many custom fields in one call, and for schema introspection

--- a/skills/rhdh-jira/references/auth.md
+++ b/skills/rhdh-jira/references/auth.md
@@ -1,0 +1,63 @@
+# Authentication and Token Setup
+
+Shared authentication for REST API and GraphQL calls. Both use the same `.jira-token` file with basic auth.
+
+**Never read the `.jira-token` file into context.** Pass it to `curl -u` via shell substitution.
+
+## Token File
+
+The `.jira-token` file lives next to the `acli` executable (same directory). Format is a single line:
+
+```
+email@example.com:your-api-token
+```
+
+Use the same API token you used to authenticate `acli`.
+
+## Token Discovery (Shell)
+
+```bash
+ACLI_DIR="$(dirname "$(readlink -f "$(which acli)" 2>/dev/null || which acli)")"
+TOKEN_FILE="$ACLI_DIR/.jira-token"
+if [ ! -f "$TOKEN_FILE" ]; then
+  echo "ERROR: .jira-token not found next to acli at $ACLI_DIR"
+  echo "Create it with: echo 'your-email@example.com:your-api-token' > $TOKEN_FILE"
+  echo "Then: chmod 600 $TOKEN_FILE"
+  exit 1
+fi
+AUTH=$(cat "$TOKEN_FILE")
+```
+
+The `AUTH` value is `email:api-token`, passed directly as basic auth credentials via `curl -u "$AUTH"`.
+
+## Security
+
+The `.jira-token` file contains plaintext credentials. Restrict permissions:
+- Unix/macOS: `chmod 600 .jira-token`
+- Windows: restrict access via file properties → Security tab
+
+The `setup.py` script warns when the file is group/world-readable.
+
+## Instance Config
+
+```bash
+CLOUD_ID="2b9e35e3-6bd3-4cec-b838-f4249ee02432"
+JIRA_BASE="https://redhat.atlassian.net"
+```
+
+### Discovering your cloudId
+
+The `cloudId` above is for `redhat.atlassian.net`. To discover it for any Jira Cloud instance:
+
+```bash
+curl -s -u "$AUTH" "$JIRA_BASE/_edge/tenant_info" | python -c "import json,sys; print(json.load(sys.stdin)['cloudId'])"
+```
+
+## Common Auth Errors
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| 401 on REST/GraphQL calls | `.jira-token` is bare token without email prefix | Format must be `email:token` |
+| 401 after token was working | API token expired or revoked | User must regenerate at Atlassian account settings |
+| `acli auth status` says unauthorized | False negative — `auth status` checks OAuth, not API tokens | Ignore. Use `acli jira project list --recent 1` as smoke test |
+| `.jira-token` not found | File is next to symlink, not the real binary | `setup.py` uses `resolve()` to follow symlinks — place file next to real binary |

--- a/skills/rhdh-jira/references/graphql-queries.md
+++ b/skills/rhdh-jira/references/graphql-queries.md
@@ -1,0 +1,174 @@
+# Jira GraphQL API
+
+Use the Atlassian GraphQL API for complex queries where you need multiple fields, relationships, or custom field data in a single call. For complex read queries and schema discovery via GraphQL. For REST API writes and OpenAPI schema discovery, see `references/rest-api-fallback.md`.
+
+**Do not read the `.jira-token` file into context.** Pass it to `curl -u` via shell substitution (see Authentication below).
+
+## Endpoint and Authentication
+
+See `references/auth.md` for token file setup, security, and instance config (`AUTH`, `CLOUD_ID`, `JIRA_BASE`).
+
+```bash
+# Set AUTH and CLOUD_ID per references/auth.md, then:
+GRAPHQL_URL="$JIRA_BASE/gateway/api/graphql"
+```
+
+## Schema Discovery
+
+GraphQL APIs are self-describing via introspection. There is no separate spec file to download (unlike REST's OpenAPI spec). Instead, query the schema directly.
+
+Use `__type` introspection queries to discover fields and types dynamically. Do this when encountering unknown types or before constructing a new query pattern.
+
+#### List all Jira query entry points
+
+```bash
+curl -s -u "$AUTH" -X POST -H 'Content-Type: application/json' \
+  -d '{"query": "query IntrospectJira { __type(name: \"JiraQuery\") { fields { name description type { name kind } } } }"}' \
+  "$GRAPHQL_URL"
+```
+
+#### Inspect a specific type
+
+```bash
+curl -s -u "$AUTH" -X POST -H 'Content-Type: application/json' \
+  -d '{"query": "query IntrospectType { __type(name: \"JiraIssue\") { fields { name type { name kind ofType { name } } } } }"}' \
+  "$GRAPHQL_URL"
+```
+
+Replace `JiraIssue` with any type name from the schema (e.g., `JiraSprintField`, `JiraTeamViewField`, `User`).
+
+#### Full schema introspection (large output)
+
+```bash
+curl -s -u "$AUTH" -X POST -H 'Content-Type: application/json' \
+  -d '{"query": "query FullSchema { __schema { types { name kind fields { name type { name kind ofType { name } } } } } }"}' \
+  "$GRAPHQL_URL" -o graphql-schema.json
+```
+
+The output is large (~1MB+). Do not load into context. Query it programmatically:
+
+```bash
+python -c "
+import json
+schema = json.load(open('graphql-schema.json'))
+for t in schema['data']['__schema']['types']:
+    if t['name'].startswith('Jira') and t.get('fields'):
+        print(f\"{t['name']:40} {len(t['fields'])} fields\")
+"
+```
+
+### Key types discovered
+
+| Type | Fields | Notes |
+|------|--------|-------|
+| `JiraIssue` | `key`, `summary`, `status`, `issueType`, `priority`, `assignee`, `parentIssue`, `storyPoints`, `labels`, `fixVersions`, `fields` (edges) | `storyPoints` is a first-class Float scalar |
+| `User` | `name`, `accountId`, `picture` | No `emailAddress` or `displayName` — more limited than REST |
+| `JiraSprintField` | `selectedSprintsConnection`, `sprints` | Access sprint data via connection edges |
+| `JiraTeamViewField` | Shows as `__typename` in field edges | Value extraction is limited — may need `@optIn` |
+| `JiraNumberField` | `number` | Used for Story Points and other numeric custom fields |
+| `JiraSingleSelectField` | `fieldOption { value }` | Used for Size, Ready, Blocked, Release Note Type |
+
+## Query Patterns
+
+### Fetch a single issue with all custom fields
+
+```bash
+curl -s -u "$AUTH" -X POST -H 'Content-Type: application/json' \
+  -d '{
+    "query": "query GetIssue { jira { issueByKey(key: \"RHIDP-1234\", cloudId: \"'"$CLOUD_ID"'\") { key summary status { name } issueType { name } priority { name } assignee { name } storyPoints parentIssue { key summary } fields { edges { node { __typename name ... on JiraNumberField { number } ... on JiraSingleSelectField { fieldOption { value } } ... on JiraSprintField { selectedSprintsConnection { edges { node { name state } } } } ... on JiraLabelsField { labels { edges { node { name } } } } } } } } } }"
+  }' \
+  "$GRAPHQL_URL"
+```
+
+This single call returns what would take `acli view` + `--enrich` + `parse_issues.py` in the acli workflow.
+
+### Search issues via JQL (beta)
+
+**Requires experimental header.** This endpoint can change without notice.
+
+```bash
+curl -s -u "$AUTH" -X POST \
+  -H 'Content-Type: application/json' \
+  -H 'X-ExperimentalApi: JiraIssueSearch' \
+  -d '{
+    "query": "query SearchIssues { jira { issueSearchStable(cloudId: \"'"$CLOUD_ID"'\", issueSearchInput: {jql: \"project = RHIDP AND status = \\\"In Progress\\\" ORDER BY created DESC\"}, first: 10) { totalCount pageInfo { endCursor hasNextPage } edges { node { key summary status { name } issueType { name } priority { name } assignee { name } storyPoints parentIssue { key summary } fields { edges { node { __typename name ... on JiraNumberField { number } ... on JiraSingleSelectField { fieldOption { value } } ... on JiraSprintField { selectedSprintsConnection { edges { node { name state } } } } } } } } } } } }"
+  }' \
+  "$GRAPHQL_URL"
+```
+
+- `first: N` controls page size (on the connection, not in `issueSearchInput`)
+- `totalCount` returns the total number of matching issues (useful to know if results are truncated)
+- JQL syntax is the same as REST/acli
+- Returns all custom fields in one call — no `--enrich` needed
+
+### Paginating search results
+
+Use `pageInfo.endCursor` to fetch the next page:
+
+```bash
+# First page
+# ... returns pageInfo: { endCursor: "abc123", hasNextPage: true }
+
+# Next page — add after: "abc123"
+curl -s -u "$AUTH" -X POST \
+  -H 'Content-Type: application/json' \
+  -H 'X-ExperimentalApi: JiraIssueSearch' \
+  -d '{
+    "query": "query SearchPage2 { jira { issueSearchStable(cloudId: \"'"$CLOUD_ID"'\", issueSearchInput: {jql: \"project = RHIDP AND status = \\\"In Progress\\\"\"}, first: 50, after: \"abc123\") { totalCount pageInfo { endCursor hasNextPage } edges { node { key summary } } } } }"
+  }' \
+  "$GRAPHQL_URL"
+```
+
+Loop until `hasNextPage` is `false`.
+
+## Field Type Reference
+
+Custom fields appear in `fields { edges { node { ... } } }` with typed fragments:
+
+| `__typename` | Fragment | Returns |
+|-------------|----------|---------|
+| `JiraNumberField` | `... on JiraNumberField { number }` | Story Points, DEV/QE/DOC Story Points |
+| `JiraSingleSelectField` | `... on JiraSingleSelectField { fieldOption { value } }` | Size (XS/S/M/L/XL), Ready, Blocked, Release Note Type |
+| `JiraSprintField` | `... on JiraSprintField { selectedSprintsConnection { edges { node { name state } } } }` | Sprint name and state (active/closed/future) |
+| `JiraLabelsField` | `... on JiraLabelsField { labels { edges { node { name } } } }` | All labels |
+| `JiraTeamViewField` | _(no value sub-fields currently extractable)_ | Team — visible as `__typename` but value needs REST fallback |
+| `JiraComponentsField` | _(introspect for sub-fields)_ | Components |
+| `JiraDatePickerField` | _(introspect for sub-fields)_ | Start date, Target start/end |
+| `JiraRichTextField` | _(introspect for sub-fields)_ | Description, Release Note Text, Acceptance Criteria |
+| `JiraParentIssueField` | _(introspect for sub-fields)_ | Parent Link (legacy) — prefer `parentIssue` on `JiraIssue` |
+
+When you encounter an unknown `__typename`, introspect it:
+
+```bash
+curl -s -u "$AUTH" -X POST -H 'Content-Type: application/json' \
+  -d '{"query": "query Introspect { __type(name: \"JiraTeamViewField\") { fields { name type { name kind ofType { name } } } } }"}' \
+  "$GRAPHQL_URL"
+```
+
+## Mutations (Experimental)
+
+GraphQL mutations for Jira issue updates exist but are experimental. They require `@optIn` directives and may break without notice. **Use REST API `PUT /rest/api/3/issue/{key}` for writes** — it is stable and well-documented.
+
+If you discover stable mutations in the future via introspection, verify they do not require experimental headers before relying on them.
+
+## Caveats
+
+1. **`issueSearchStable` is beta.** Requires `X-ExperimentalApi: JiraIssueSearch` header. May break without notice. If you get a `BetaHeaderOptInException` error, add this header.
+2. **Team field values are not directly extractable.** `JiraTeamViewField` appears in the schema but value sub-fields are limited. Use REST API to get team data.
+3. **`cloudId` is required on every query.** Use `2b9e35e3-6bd3-4cec-b838-f4249ee02432` for redhat.atlassian.net. Discover it via `/_edge/tenant_info` (see Authentication section).
+4. **Rate limiting is cost-based.** 10,000 points per user per minute. HTTP 429 with `RETRY-AFTER` header when exceeded. Do not retry on 5xx.
+5. **Operation names are mandatory.** Every query must have a name (e.g., `query GetIssue { ... }`). Unnamed queries will be rejected in the future.
+6. **No spec file to download.** Unlike REST (which has an OpenAPI spec), GraphQL schema is discovered via introspection queries only. Use `__type` or the full `__schema` query. See Schema Discovery section.
+
+## When to use GraphQL vs acli
+
+| Scenario | Use |
+|----------|-----|
+| Quick single-issue lookup | `acli` — faster, simpler |
+| Bulk search with custom fields | GraphQL `issueSearchStable` — one call vs `acli` + `--enrich` per issue |
+| Need parent/child relationships | GraphQL — `parentIssue { key summary }` inline |
+| Update a field | REST API — `PUT /rest/api/3/issue/{key}` (stable) |
+| Team field value | REST API — GraphQL can't extract it reliably |
+| Sprint data | Either — GraphQL returns it inline, acli needs `--enrich` |
+| Discover available fields/types | GraphQL introspection — `__type` queries |
+| Discover REST endpoints/payloads | REST OpenAPI spec — see `references/rest-api-fallback.md` |

--- a/skills/rhdh-jira/references/rest-api-fallback.md
+++ b/skills/rhdh-jira/references/rest-api-fallback.md
@@ -1,0 +1,161 @@
+# Jira REST API Fallback
+
+Use the Jira REST API when `acli` cannot update a custom field. This is a fallback only — always try `acli` first. For complex read queries, see `references/graphql-queries.md`.
+
+Authentication setup: see `references/auth.md`. All examples below assume `AUTH` is set per that file.
+
+## Schema Discovery
+
+The REST API v3 has a published OpenAPI spec. Use it to discover endpoints, field formats, and payload shapes.
+
+### Download the OpenAPI spec
+
+```bash
+curl -s -o jira-openapi.json \
+  'https://dac-static.atlassian.com/cloud/jira/platform/swagger-v3.v3.json'
+```
+
+The spec is ~4MB JSON. Do not load it into context. Query it programmatically:
+
+### Look up an endpoint
+
+```bash
+# Find the PUT issue endpoint schema
+python -c "
+import json, sys
+spec = json.load(open('jira-openapi.json'))
+put = spec['paths'].get('/rest/api/3/issue/{issueIdOrKey}', {}).get('put', {})
+print(json.dumps({'summary': put.get('summary'), 'parameters': [p['name'] for p in put.get('parameters', [])], 'requestBody': list(put.get('requestBody', {}).get('content', {}).keys())}, indent=2))
+"
+```
+
+### List all issue field endpoints
+
+```bash
+python -c "
+import json
+spec = json.load(open('jira-openapi.json'))
+for path, methods in spec['paths'].items():
+    if '/issue/' in path:
+        for method in methods:
+            if method in ('get','put','post','delete'):
+                print(f'{method.upper():6} {path}')
+" | head -30
+```
+
+### Discover field metadata from your instance
+
+```bash
+# List all fields (standard + custom) with IDs and types
+curl -s -u "$AUTH" \
+  'https://redhat.atlassian.net/rest/api/3/field' | \
+  python -c "
+import json, sys
+fields = json.load(sys.stdin)
+for f in sorted(fields, key=lambda x: x['id']):
+    print(f\"{f['id']:30} {f.get('schema',{}).get('type','?'):15} {f['name']}\")
+"
+```
+
+This returns the live field registry from the Jira instance — including custom field IDs, types, and display names. Use it when you encounter an unknown field or need to verify a custom field ID.
+
+### Check which fields are editable on a specific issue
+
+```bash
+curl -s -u "$AUTH" \
+  'https://redhat.atlassian.net/rest/api/3/issue/RHIDP-123/editmeta' | \
+  python -c "
+import json, sys
+meta = json.load(sys.stdin)
+for fid, info in meta.get('fields', {}).items():
+    ops = [o['id'] for o in info.get('operations', [])]
+    print(f\"{fid:30} {info['name']:25} ops={ops}\")
+"
+```
+
+Use this when a field update returns 400 — it shows which fields are editable and their allowed operations/values.
+
+### Schema discovery comparison
+
+| | REST API | GraphQL |
+|--|---------|---------|
+| **Spec format** | OpenAPI 3.0 JSON (~4MB downloadable file) | No spec file — self-describing via introspection queries |
+| **Download** | `curl -o jira-openapi.json 'https://dac-static.atlassian.com/cloud/jira/platform/swagger-v3.v3.json'` | `__schema` or `__type` introspection queries against the live endpoint |
+| **Live field registry** | `GET /rest/api/3/field` returns all field IDs, types, names | `__type(name: "JiraIssue")` returns typed fields on the issue object |
+| **Editability check** | `GET /rest/api/3/issue/{key}/editmeta` | Not available — use REST |
+
+## Updating Custom Fields
+
+### Story Points (customfield_10028) — number
+
+```bash
+curl -s -X PUT \
+  -u "$AUTH" \
+  -H "Content-Type: application/json" \
+  -d '{"fields": {"customfield_10028": 5}}' \
+  "https://redhat.atlassian.net/rest/api/3/issue/RHIDP-123"
+```
+
+### Size (customfield_10795) — dropdown
+
+```bash
+curl -s -X PUT \
+  -u "$AUTH" \
+  -H "Content-Type: application/json" \
+  -d '{"fields": {"customfield_10795": {"value": "M"}}}' \
+  "https://redhat.atlassian.net/rest/api/3/issue/RHIDP-123"
+```
+
+Valid values: XS, S, M, L, XL.
+
+### Team (customfield_10001) — atlassian-team
+
+```bash
+curl -s -X PUT \
+  -u "$AUTH" \
+  -H "Content-Type: application/json" \
+  -d '{"fields": {"customfield_10001": {"id": "TEAM_ID"}}}' \
+  "https://redhat.atlassian.net/rest/api/3/issue/RHIDP-123"
+```
+
+To find the team ID, fetch the issue first and inspect `customfield_10001.id` from an issue already assigned to that team.
+
+### Release Note Type (customfield_10785) — dropdown
+
+```bash
+curl -s -X PUT \
+  -u "$AUTH" \
+  -H "Content-Type: application/json" \
+  -d '{"fields": {"customfield_10785": {"value": "Enhancement"}}}' \
+  "https://redhat.atlassian.net/rest/api/3/issue/RHIDP-123"
+```
+
+Valid values: Feature, Enhancement, Developer Preview, Deprecated Functionality, Removed Functionality, Release Note Not Required.
+
+## Response Handling
+
+| HTTP Status | Meaning | Action |
+|-------------|---------|--------|
+| 204 | Success (no content) | Field updated. |
+| 400 | Bad request | Check field ID, value format, or allowed values. Use `editmeta` endpoint to check editability. |
+| 401 | Unauthorized | See `references/auth.md` → Common Auth Errors. |
+| 403 | Forbidden | User lacks edit permission on this issue. |
+| 404 | Not found | Issue key is wrong. |
+| 429 | Rate limited | Wait 5 seconds, retry once. |
+
+## Verifying the Update
+
+After a REST API update, verify the field was set:
+
+```bash
+curl -s -u "$AUTH" \
+  "https://redhat.atlassian.net/rest/api/3/issue/RHIDP-123?fields=customfield_10028,customfield_10795,customfield_10001"
+```
+
+## Common Mistakes
+
+- **Wrong value format for dropdowns.** Use `{"value": "M"}` not `"M"`. Number fields are bare numbers, not strings.
+- **PUT is a partial update.** Jira's `PUT /rest/api/3/issue/{key}` only updates the fields you include in the payload — you do not need to send the full issue body. There is no separate PATCH endpoint.
+- **Forgetting the `fields` wrapper.** The payload must be `{"fields": {"customfield_X": ...}}`, not `{"customfield_X": ...}`.
+- **Guessing field IDs.** Use the `/rest/api/3/field` endpoint or the OpenAPI spec to discover the correct field ID and type. Do not assume `customfield_XXXXX` mappings — verify them.
+- **Reading `.jira-token` into context.** See `references/auth.md` — never read credentials into the conversation.

--- a/skills/rhdh-jira/scripts/setup.py
+++ b/skills/rhdh-jira/scripts/setup.py
@@ -230,12 +230,12 @@ def _output(results, as_json):
             print(f"  [WARN] {w}")
     else:
         acli_dir = Path(results['acli_path']).resolve().parent
-        print(f"  [WARN] No .jira-token file found next to acli")
+        print("  [WARN] No .jira-token file found next to acli")
         print(f"         Expected at: {acli_dir / '.jira-token'}")
         print("         Create with: echo 'email:api-token' > .jira-token")
         print("         Then: chmod 600 .jira-token")
         print("         REST API/GraphQL fallback will not work without it.")
-        print(f"         See: https://developer.atlassian.com/cloud/acli/guides/how-to-get-started/")
+        print("         See: https://developer.atlassian.com/cloud/acli/guides/how-to-get-started/")
 
     # Connectivity
     if results["connectivity"]:

--- a/skills/rhdh-jira/scripts/setup.py
+++ b/skills/rhdh-jira/scripts/setup.py
@@ -114,9 +114,12 @@ def check_token_file(acli_path):
         # Check file permissions on Unix
         if sys.platform != "win32":
             import stat
+
             mode = token_path.stat().st_mode
             if mode & (stat.S_IRGRP | stat.S_IROTH):
-                warnings.append("file is readable by group/others — run: chmod 600 " + str(token_path))
+                warnings.append(
+                    "file is readable by group/others — run: chmod 600 " + str(token_path)
+                )
         return str(token_path), "valid", warnings
     except OSError as e:
         return None, f"read error: {e}", warnings
@@ -229,7 +232,7 @@ def _output(results, as_json):
         for w in results.get("token_file_warnings", []):
             print(f"  [WARN] {w}")
     else:
-        acli_dir = Path(results['acli_path']).resolve().parent
+        acli_dir = Path(results["acli_path"]).resolve().parent
         print("  [WARN] No .jira-token file found next to acli")
         print(f"         Expected at: {acli_dir / '.jira-token'}")
         print("         Create with: echo 'email:api-token' > .jira-token")

--- a/skills/rhdh-jira/scripts/setup.py
+++ b/skills/rhdh-jira/scripts/setup.py
@@ -98,6 +98,30 @@ def check_projects(acli_path):
     return accessible, inaccessible
 
 
+def check_token_file(acli_path):
+    """Check if .jira-token file exists next to the acli executable."""
+    acli_dir = Path(acli_path).resolve().parent
+    token_path = acli_dir / ".jira-token"
+    if not token_path.exists():
+        return None, "not found", []
+    warnings = []
+    try:
+        content = token_path.read_text(encoding="utf-8").strip()
+        if "\n" in content:
+            warnings.append("file contains multiple lines — should be a single line")
+        if ":" not in content:
+            return str(token_path), "missing email prefix (expected email:token format)", warnings
+        # Check file permissions on Unix
+        if sys.platform != "win32":
+            import stat
+            mode = token_path.stat().st_mode
+            if mode & (stat.S_IRGRP | stat.S_IROTH):
+                warnings.append("file is readable by group/others — run: chmod 600 " + str(token_path))
+        return str(token_path), "valid", warnings
+    except OSError as e:
+        return None, f"read error: {e}", warnings
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Verify acli installation and Jira authentication for RHDH."
@@ -112,6 +136,9 @@ def main():
         "config_found": False,
         "config_path": None,
         "auth_type": None,
+        "token_file_found": False,
+        "token_file_path": None,
+        "token_file_status": None,
         "connectivity": False,
         "connectivity_detail": None,
         "projects_accessible": [],
@@ -136,7 +163,15 @@ def main():
         results["config_path"] = config_path
         results["auth_type"] = auth_type
 
-    # Step 3: Smoke test (do NOT use 'acli auth status' — it lies with API tokens)
+    # Step 3: Check .jira-token file
+    token_path, token_status, token_warnings = check_token_file(acli_path)
+    if token_path:
+        results["token_file_found"] = True
+        results["token_file_path"] = token_path
+    results["token_file_status"] = token_status
+    results["token_file_warnings"] = token_warnings
+
+    # Step 4: Smoke test (do NOT use 'acli auth status' — it lies with API tokens)
     ok, detail = smoke_test(acli_path)
     results["connectivity"] = ok
     results["connectivity_detail"] = detail
@@ -145,7 +180,7 @@ def main():
         _output(results, args.json)
         sys.exit(1)
 
-    # Step 4: Check project access
+    # Step 5: Check project access
     if not args.quick:
         accessible, inaccessible = check_projects(acli_path)
         results["projects_accessible"] = accessible
@@ -182,6 +217,25 @@ def _output(results, as_json):
     else:
         print("  [WARN] No Jira config found at ~/.config/acli/jira_config.yaml")
         print("         Run: acli auth login")
+
+    # Token file
+    if results["token_file_found"]:
+        if results["token_file_status"] == "valid":
+            print(f"  [PASS] Token file found: {results['token_file_path']}")
+        else:
+            print(f"  [WARN] Token file found but {results['token_file_status']}")
+            print(f"         File: {results['token_file_path']}")
+            print("         Expected format: email@example.com:your-api-token")
+        for w in results.get("token_file_warnings", []):
+            print(f"  [WARN] {w}")
+    else:
+        acli_dir = Path(results['acli_path']).resolve().parent
+        print(f"  [WARN] No .jira-token file found next to acli")
+        print(f"         Expected at: {acli_dir / '.jira-token'}")
+        print("         Create with: echo 'email:api-token' > .jira-token")
+        print("         Then: chmod 600 .jira-token")
+        print("         REST API/GraphQL fallback will not work without it.")
+        print(f"         See: https://developer.atlassian.com/cloud/acli/guides/how-to-get-started/")
 
     # Connectivity
     if results["connectivity"]:

--- a/skills/skill-maker/SKILL.md
+++ b/skills/skill-maker/SKILL.md
@@ -28,7 +28,8 @@ Focus areas, roughly in order:
 7. **References needed?** Domain knowledge too large for SKILL.md that should live in separate files?
 8. **Existing patterns.** Similar skills or workflows to draw from? Check the codebase.
 9. **Platform constraints.** macOS, Windows, and Linux? Scripts must handle path separators, temp directories, and shell differences.
-10. **Architecture.** Based on the answers above, decide whether the skill's scope warrants sub-commands, context systems, or setup gates. Most skills don't need this — skip to Phase 2 if the skill is straightforward. If it does, ask:
+10. **External services and APIs.** Does the skill call external APIs or services? If yes, read `references/api-skill-patterns.md` — it covers credential handling, schema discovery, instance-specific values, and error placement.
+11. **Architecture.** Based on the answers above, decide whether the skill's scope warrants sub-commands, context systems, or setup gates. Most skills don't need this — skip to Phase 2 if the skill is straightforward. If it does, ask:
     - **Should this be one skill with sub-commands or multiple skills?** One skill with a router table prevents menu pollution. Multiple skills are appropriate when the tasks have no shared context or setup.
     - **Does the skill need project-level context?** If every command needs the same background (project config, conventions), design a context file pattern with a loader script.
     - **Are there mandatory setup gates?** Steps that must pass before any work begins (context loaded, config valid, dependencies present). Gates prevent generic output.
@@ -247,14 +248,26 @@ Before presenting the final skill, verify against this checklist:
 
 ### References
 - [ ] Domain knowledge split into `references/` with clear "when to read" pointers
-- [ ] Each reference is self-contained — an agent can load it without reading others
+- [ ] Each reference is self-contained — no transitive loading (see `spec-guide.md` → Reference Architecture)
 - [ ] Reference loading is conditional, not eager ("Read X if Y happens")
+- [ ] Shared concerns (auth, config) extracted into their own reference, not embedded in a consumer
+- [ ] Error handling lives in the reference for the tool that produces the error
+- [ ] Multi-approach skills include a decision table routing to the correct reference
+- [ ] No browser-only tools referenced (Postman, API consoles, OAuth login pages)
 
 ### Scripts
 - [ ] Scripts (if any) have shebangs, structured output, and `--help`
 - [ ] Context loader returns JSON, handles missing files, resolves fallback paths
 - [ ] Scripts are cross-platform (pathlib, tempfile, no hardcoded paths)
 - [ ] Scripts are idempotent — safe to re-run
+
+### API/Service Skills (if applicable)
+- [ ] Credential files are never read into context — passed via shell substitution only
+- [ ] Credential setup is single-sourced in its own reference file
+- [ ] Capability gate checks for credentials before attempting API calls
+- [ ] API schema discovery is documented (OpenAPI download, GraphQL introspection, or live endpoints)
+- [ ] API examples have been validated against the live endpoint
+- [ ] Instance-specific values include programmatic discovery methods
 
 ### Quality
 - [ ] No time-sensitive information (URLs to specific versions, dates that will go stale)

--- a/skills/skill-maker/SKILL.md
+++ b/skills/skill-maker/SKILL.md
@@ -271,6 +271,7 @@ Before presenting the final skill, verify against this checklist:
 
 ### Quality
 - [ ] No time-sensitive information (URLs to specific versions, dates that will go stale)
+- [ ] Examples use fake data where possible (emails, names, tokens) — see `spec-guide.md` → Fake Data in Examples
 - [ ] Consistent terminology throughout
 - [ ] Concrete examples included for non-obvious workflows
 - [ ] Absolute bans defined for patterns that are always wrong

--- a/skills/skill-maker/references/api-skill-patterns.md
+++ b/skills/skill-maker/references/api-skill-patterns.md
@@ -1,0 +1,85 @@
+# Patterns for Skills That Wrap APIs
+
+Lessons learned from building skills that wrap CLIs, REST APIs, and GraphQL APIs. Read this when the skill interacts with external services or APIs.
+
+For general reference architecture patterns (transitive loading, error placement, decision tables, agent-only audience), see `references/spec-guide.md` → Reference Architecture.
+
+## Credential handling
+
+Skills that authenticate against external services must handle credentials carefully.
+
+**Rules:**
+1. **Never read credential files into context.** The agent must not use `read` or `cat` to view token/password files. Credentials passed through the LLM context are logged, cached, and potentially leaked.
+2. **Pass credentials via shell substitution.** Use `curl -u "$(cat path/.token)"` — the secret stays in the shell, never enters the conversation.
+3. **Document the credential file format explicitly.** Show the exact format (e.g., `email:token`), not just "put your token here." Ambiguity causes auth errors.
+4. **Add a capability gate.** Before attempting any authenticated call, check if the credential file exists (preferably via a setup script, not by reading the file). If missing, state the fallback clearly and continue without the feature.
+5. **Warn about file permissions.** Credential files should be `chmod 600` on Unix. The setup script should warn when permissions are too open.
+6. **Single-source the credential setup.** Document token format, path discovery, and security in its own reference file. Other references point to it — don't embed it in a consumer (see `spec-guide.md` → transitive loading).
+
+Example capability gate in SKILL.md:
+```markdown
+Before attempting REST API calls:
+1. Run `python scripts/setup.py --json` and check `token_file_found`
+2. If missing, state: "REST API unavailable — token not configured." Continue with CLI-only workflow.
+3. Do not ask the user to create the token unless they explicitly need the feature.
+```
+
+## API schema discovery
+
+When a skill wraps an API, the agent should be able to discover available endpoints, fields, and types dynamically — not rely solely on hardcoded documentation.
+
+### REST APIs (OpenAPI)
+
+If the API publishes an OpenAPI spec:
+1. Document the download URL (without version pins that go stale)
+2. Show how to query it programmatically (Python `json.load` + dict traversal)
+3. Do not load the spec into context — it's typically 1-10MB
+4. Also document live discovery endpoints (e.g., `/rest/api/3/field` for Jira)
+
+### GraphQL APIs
+
+GraphQL APIs are self-describing via introspection. There is no spec file to download.
+1. Document `__type(name: "TypeName")` queries for targeted discovery
+2. Document full `__schema` dump for offline analysis (save to file, query programmatically)
+3. Note that introspection output is large — do not load into context
+
+### Schema discovery comparison table
+
+Include a table comparing how to discover the schema for each API the skill covers:
+
+```markdown
+| | REST API | GraphQL |
+|--|---------|---------|
+| **Spec format** | OpenAPI JSON (downloadable file) | No spec file — introspection queries |
+| **Download** | `curl -o spec.json 'https://...'` | `__schema` query against the live endpoint |
+| **Live field registry** | `GET /rest/api/3/field` | `__type(name: "...")` introspection |
+```
+
+## Validate examples against the live API
+
+Do not write API examples from memory or documentation alone. Run them against the real endpoint and verify the output before including them in the skill.
+
+**Why:** API schemas drift from documentation. Field names, payload formats, and required headers discovered through docs may not match the live API. A skill with broken examples is worse than no skill — the agent will retry the broken pattern repeatedly.
+
+**Process:**
+1. Draft the example from docs or training knowledge
+2. Run it against the real endpoint
+3. If it fails, use schema discovery (OpenAPI spec, GraphQL introspection) to find the correct field names and formats
+4. Include only verified examples in the skill
+
+This is especially important for GraphQL APIs where field names are typed and case-sensitive — `displayName` vs `name`, `parent` vs `parentIssue`, `sprint` vs `selectedSprintsConnection` can all differ from what you'd guess.
+
+## Instance-specific values
+
+Any value that is specific to a deployment (instance URL, tenant ID, cloud ID, org name) must include a programmatic discovery method.
+
+**Do not** just hardcode the value and move on. **Do** show how to obtain it:
+
+```markdown
+### Discovering your cloudId
+
+The `cloudId` below is for `example.atlassian.net`. To discover it for any instance:
+\`\`\`bash
+curl -s -u "$AUTH" 'https://example.atlassian.net/_edge/tenant_info' | python -c "import json,sys; print(json.load(sys.stdin)['cloudId'])"
+\`\`\`
+```

--- a/skills/skill-maker/references/spec-guide.md
+++ b/skills/skill-maker/references/spec-guide.md
@@ -79,6 +79,42 @@ Match the level of control to the task:
 
 Use explicit control for high-stakes, multi-step, or error-prone tasks. Use implicit guidance for creative or exploratory tasks.
 
+## Reference Architecture
+
+### The consumer is an agent
+
+Every feature in the skill must be usable by an agent with no browser, no GUI, and no interactive prompts.
+
+- Do not reference browser-only tools (Postman, Swagger UI, API consoles, OAuth login pages)
+- Do not include resources that require a human to visually browse or click
+- Ask: "Can the agent use this in a `bash` or `read` tool call?" If no, cut it.
+
+### Each reference must be independently loadable
+
+An agent should be able to load any single reference file and use it without being forced to load another.
+
+**Anti-pattern (transitive loading):** Shared setup (auth, config, constants) is embedded in one reference file. Other files depend on it, forcing the agent to load an unrelated file just to get the shared setup.
+
+**Correct pattern:** Extract shared setup into its own reference file. Consumer files point to it and assume its variables/context are set. The agent loads only what it needs.
+
+Signs of transitive loading:
+- Loading file A requires loading file B first
+- The same snippet appears in 2+ reference files
+- Updating a value requires editing multiple files
+- Two files explain the same concept with slightly different wording
+
+### Error handling belongs with the tool that produces the error
+
+Don't centralize all error handling in SKILL.md. Errors from the primary tool belong in SKILL.md. Errors from tools documented in reference files belong in those reference files — that's where the agent will be when it encounters them.
+
+### Decision tables for multi-approach skills
+
+When a skill offers multiple ways to accomplish similar tasks (CLI, API, library, etc.), include a decision table so the agent picks the right approach. Without one, the agent defaults to whatever it loaded most recently.
+
+- Put a routing table in SKILL.md that points to the correct reference
+- Each reference file explains when to use *it* vs alternatives
+- Default to the simplest approach — escalate only when it can't handle the task
+
 ## Best Practices
 
 Full guide: https://agentskills.io/skill-creation/best-practices

--- a/skills/skill-maker/references/spec-guide.md
+++ b/skills/skill-maker/references/spec-guide.md
@@ -115,6 +115,32 @@ When a skill offers multiple ways to accomplish similar tasks (CLI, API, library
 - Each reference file explains when to use *it* vs alternatives
 - Default to the simplest approach — escalate only when it can't handle the task
 
+## Fake Data in Examples
+
+Skill examples should use realistic but fake data wherever possible. Real credentials, real user emails, and real PII should never appear in skill files that may be committed to version control.
+
+Use [Faker](https://github.com/joke2k/faker) to generate realistic fake data when needed.
+
+### What to fake
+
+- **User data**: emails, display names, account IDs
+- **Credentials**: API tokens, passwords (use obviously fake placeholders like `your-api-token`)
+- **Issue/ticket keys in generic examples**: `PROJ-123` instead of real issue keys
+
+### What must stay real
+
+Some data must be real or the skill breaks:
+
+- **Instance URLs** that the skill connects to (e.g., `redhat.atlassian.net`)
+- **Project keys** when the skill is scoped to specific projects (e.g., `RHIDP`, `RHDHPLAN`)
+- **Cloud/tenant IDs** when required by API calls — but include a discovery method so others can find their own
+- **Custom field IDs** (`customfield_10028`) that are instance-specific
+- **API endpoint paths** (`/rest/api/3/issue/{key}`)
+
+### Rule of thumb
+
+If changing the value would cause a runtime error against the target system, it must be real. If it's just illustrative, fake it. When in doubt, use a placeholder format that's obviously not real: `your-email@example.com`, `YOUR_API_TOKEN`, `TEAM_ID`.
+
 ## Best Practices
 
 Full guide: https://agentskills.io/skill-creation/best-practices


### PR DESCRIPTION
## Summary

Adds REST API and GraphQL fallback capabilities to the rhdh-jira skill, plus API skill patterns to skill-maker.

## rhdh-jira changes

### New reference files
- **references/auth.md** — Single-sourced token/credential setup. Eliminates transitive loading between REST and GraphQL references.
- **references/rest-api-fallback.md** — REST API fallback for custom field updates with verified curl examples. Includes OpenAPI spec download and schema discovery.
- **references/graphql-queries.md** — GraphQL query patterns for complex reads. JQL search via issueSearchStable (beta), pagination, field type fragments, schema introspection.

### Updated files
- **SKILL.md** — Updated description, capability gate, 4 new gotchas (9–12), new workflows, Getting Started guide link.
- **scripts/setup.py** — Token file validation (existence, format, permissions).

## skill-maker changes

### New reference file
- **references/api-skill-patterns.md** — Patterns for API skills: credential handling, schema discovery, live validation, instance-specific values.

### Updated files
- **references/spec-guide.md** — New "Reference Architecture" section (agent-only audience, transitive loading, error placement, decision tables) and "Fake Data in Examples" section (use [Faker](https://github.com/joke2k/faker) for realistic test data, guidance on what to fake vs what must stay real).
- **SKILL.md** — New interview question (external services/APIs), updated Phase 5 checklist (reference architecture, API skill checks, fake data).

## Key design decisions
- acli remains primary — REST for writes, GraphQL for complex reads
- No transitive loading — auth is its own file
- Agent never reads credentials — shell substitution only
- Schema discovery over hardcoding — OpenAPI + GraphQL introspection
- Fake data in examples where possible — real data only when changing it would cause runtime errors
- All examples validated against live API
