### PR TITLE
feat: add sub-command router and sprint ceremony workflows to rhdh-jira

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,12 @@ Test plugins in a local RHDH instance before deploying.
 
 Track work across the four RHDH Jira projects.
 
-- **[rhdh-jira](./skills/rhdh-jira/SKILL.md)** — Search, create, view, edit, transition, and link issues across RHIDP, RHDHPLAN, RHDHBUGS, and RHDHSUPP. Uses `acli` with REST API and GraphQL fallback for custom fields.
+- **[rhdh-jira](./skills/rhdh-jira/SKILL.md)** — Search, create, view, edit, transition, link, assign, and refine issues across RHIDP, RHDHPLAN, RHDHBUGS, and RHDHSUPP. Uses `acli` for simple operations, GraphQL for bulk reads, and REST API as fallback. Sub-commands:
+  - **[assign](./skills/rhdh-jira/references/assign.md)** — Recommend assignees using team expertise profiling, sprint capacity analysis, and context proximity scoring. Supports deep mode (5-layer analysis via GraphQL) and quick mode (match from existing context). Assigns after user confirmation.
+  - **[refine](./skills/rhdh-jira/references/refine.md)** — Check issues against RHDH workflow exit criteria, detect duplicates, verify parent/child hierarchy, flag unaddressed comments, identify stale issues, and validate sprint readiness.
+  - **[plan](./skills/rhdh-jira/references/plan.md)** — Sprint planning prep: carryover report, velocity trend, per-member capacity, ready-for-planning queue, and sprint fill suggestions with expertise matching.
+  - **[sprint-report](./skills/rhdh-jira/references/sprint-report.md)** — Sprint review summary: committed vs completed, per-member breakdown, epic progress, demo checklist with naming conventions, and velocity trend.
+  - **[release](./skills/rhdh-jira/references/release.md)** — Release readiness: feature matrix, Program Increment funnel, epic roll-up, cross-team dependency map, blocker bugs, release notes readiness, and risk assessment. Replaces `rhdh-release-triage`.
 
 ### Orchestration
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Track work across the four RHDH Jira projects.
   - **[refine](./skills/rhdh-jira/references/refine.md)** — Check issues against RHDH workflow exit criteria, detect duplicates, verify parent/child hierarchy, flag unaddressed comments, identify stale issues, and validate sprint readiness.
   - **[plan](./skills/rhdh-jira/references/plan.md)** — Sprint planning prep: carryover report, velocity trend, per-member capacity, ready-for-planning queue, and sprint fill suggestions with expertise matching.
   - **[sprint-report](./skills/rhdh-jira/references/sprint-report.md)** — Sprint review summary: committed vs completed, per-member breakdown, epic progress, demo checklist with naming conventions, and velocity trend.
-  - **[release](./skills/rhdh-jira/references/release.md)** — Release readiness: feature matrix, Program Increment funnel, epic roll-up, cross-team dependency map, blocker bugs, release notes readiness, and risk assessment. Replaces `rhdh-release-triage`.
+  - **[release](./skills/rhdh-jira/references/release.md)** — Release readiness: feature matrix, Program Increment funnel, epic roll-up, cross-team dependency map, blocker bugs, release notes readiness, and risk assessment.
 
 ### Orchestration
 

--- a/skills/rhdh-jira/SKILL.md
+++ b/skills/rhdh-jira/SKILL.md
@@ -206,7 +206,7 @@ These apply across all sub-commands:
 2. Resolve sprint (active or previous)
 3. Partition completed vs carried over, compute completion rate
 4. Per-member breakdown, epic progress, demo checklist with naming conventions
-5. Optionally post to Slack
+5. Optionally save as markdown file
 
 ### Release readiness
 

--- a/skills/rhdh-jira/SKILL.md
+++ b/skills/rhdh-jira/SKILL.md
@@ -1,13 +1,31 @@
 ---
 name: rhdh-jira
 description: |
-  Interacts with RHDH Jira projects (RHIDP, RHDHPLAN, RHDHBUGS, RHDHSUPP) using the Atlassian CLI (acli), with REST API and GraphQL fallback for custom field updates and complex queries. Use when the user needs to search, create, view, edit, transition, comment on, or link Jira issues for Red Hat Developer Hub. Also use when the user asks about Jira workflows, exit criteria, issue templates, custom fields, boards, sprints, JQL queries, or Jira API schema discovery. Trigger when the user mentions Jira issue keys like RHIDP-1234, RHDHPLAN-567, RHDHBUGS-890, or any RHDH project key. Also trigger for support case bug filing, feature request creation, release planning, or acli setup and installation.
+  Interacts with RHDH Jira projects (RHIDP, RHDHPLAN, RHDHBUGS, RHDHSUPP) using acli, GraphQL, and REST API. Use when the user needs to search, create, view, edit, transition, assign, refine, or report on Jira issues for RHDH. Also use for sprint planning, sprint reviews, release readiness, assignee recommendations, or issue refinement. Trigger on Jira issue keys (RHIDP-1234, RHDHPLAN-567), sprint ceremony prep, "who should take this", "refine this", "plan the sprint", "sprint report", "how's the release looking", or "release status".
 compatibility: "acli (Atlassian CLI) on PATH. Python 3 for scripts. Windows, macOS, Linux."
 ---
 
 # RHDH Jira
 
 Foundational skill for interacting with RHDH's Jira instance via the Atlassian CLI (`acli`). Covers all four active projects, issue types, workflows, custom fields, and JQL patterns.
+
+## Commands
+
+| Command | Description | Reference |
+|---------|-------------|-----------|
+| `assign [issue key(s) or JQL]` | Recommend and assign team members using expertise, capacity, and context proximity analysis | [references/assign.md](references/assign.md) |
+| `refine [issue key(s), JQL, or 'sprint']` | Check issues against exit criteria, identify duplicates, missing fields, unaddressed comments, and readiness | [references/refine.md](references/refine.md) |
+| `plan [team]` | Sprint planning prep: carryover, velocity, capacity, ready queue, sprint fill suggestions | [references/plan.md](references/plan.md) |
+| `sprint-report [team]` | Sprint review summary: committed vs completed, per-member breakdown, demo checklist | [references/sprint-report.md](references/sprint-report.md) |
+| `release [version]` | Release readiness: feature matrix, PI funnel, dependency map, blocker bugs, risk assessment | [references/release.md](references/release.md) |
+
+Single source of truth for command descriptions: `scripts/command-metadata.json`
+
+### Routing rules
+
+1. **No argument**: Show the command menu. Ask what to do.
+2. **First word matches a command**: Load its reference file and follow it.
+3. **First word doesn't match**: General Jira invocation using the full argument as context — use the reference files table below to decide what to load.
 
 ## Prerequisites
 
@@ -26,6 +44,16 @@ The script checks:
 
 If `acli` is not installed, download from [Atlassian CLI](https://developer.atlassian.com/cloud/acli/) and follow the [Getting Started guide](https://developer.atlassian.com/cloud/acli/guides/how-to-get-started/) for installation and authentication setup. Use API token authentication, not OAuth — OAuth sessions expire and `acli auth status` gives false negatives with token auth (see Gotchas).
 
+### API preference order
+
+All operations follow this priority: **acli → GraphQL → REST API**.
+
+- **acli** — default for simple, single-issue operations (view, edit, assign, transition).
+- **GraphQL** — for bulk reads where acli would be too slow (expertise profiles, capacity, refinement checks). Skip acli entirely for bulk.
+- **REST API** — for writes when already in an authenticated API context (avoids shelling out to acli mid-workflow), or as fallback when acli fails for custom field updates.
+
+Sub-commands (`assign`, `refine`) document which API they use. When a sub-command's workflow already has `AUTH` set from GraphQL reads, prefer REST for writes.
+
 ### REST/GraphQL capability gate
 
 Before attempting any REST API or GraphQL call:
@@ -40,6 +68,7 @@ Before attempting any REST API or GraphQL call:
 |--------|---------|
 | `scripts/setup.py` | Verify acli install + auth. Run with `--json` for structured output. |
 | `scripts/parse_issues.py` | Flatten, enrich, and filter acli JSON output. Solves the core problem: `acli search --json` can't return custom fields (team, story points, sprint). Pipe search results in, get clean data out. Use `--enrich` to fetch full fields, `-f team="X"` to filter by team. |
+| `scripts/command-metadata.json` | Single source of truth for sub-command descriptions and argument hints. |
 
 ## Projects
 
@@ -76,7 +105,12 @@ Load only what the current task requires.
 | `references/jql-patterns.md` | Building a JQL query, finding a board ID, or looking up sprint information. JQL cookbook with 23+ tested queries. |
 | `references/auth.md` | Setting up authentication for REST API or GraphQL calls. Token file format, path discovery, security, instance config, common auth errors. |
 | `references/rest-api-fallback.md` | `acli` failed to update a custom field (Team, Size, Story Points, Release Note Type). Curl examples, response handling, OpenAPI spec discovery. |
-| `references/graphql-queries.md` | Complex read queries needing multiple fields, relationships, or custom field data in one call. Schema introspection, JQL search via GraphQL, field type fragments. |
+| `references/graphql-queries.md` | Complex read queries needing multiple fields, relationships, or custom field data in one call. Schema introspection, JQL search via GraphQL, field type fragments. Also for bulk operations where acli would be too slow. |
+| `references/assign.md` | Recommending assignees for unassigned issues. Team roster lookup, expertise profiling, sprint capacity analysis, context proximity scoring. Also for applying assignments after user confirmation. |
+| `references/refine.md` | Checking issues against exit criteria per status, identifying duplicates, missing fields, unaddressed comments, and readiness for the next workflow status. |
+| `references/plan.md` | Sprint planning prep: carryover report, velocity trend, per-member capacity, ready-for-planning queue, sprint fill suggestions. |
+| `references/sprint-report.md` | Sprint review summary: committed vs completed, per-member breakdown, epic progress, demo checklist with naming conventions, velocity trend. |
+| `references/release.md` | Release readiness report: feature matrix, PI funnel states, epic roll-up, cross-team dependency map, blocker bugs, RN readiness, risk assessment. Replaces `rhdh-release-triage`. |
 
 ## Common Gotchas
 
@@ -84,7 +118,7 @@ Load only what the current task requires.
 2. **`view` uses positional arg, everything else uses `--key`.** `acli jira workitem view RHIDP-123` but `acli jira workitem edit --key RHIDP-123 ...`.
 3. **`--yes` is mandatory for mutations.** All `edit`, `transition`, `assign`, and `link create` commands prompt interactively without it. Always pass `--yes`.
 4. **`--fields` is restrictive on search.** Only accepts `key`, `summary`, `status`, `assignee`, `issuetype`, `priority`, `description`, `labels`. For components, sprint, fixVersions, and all custom fields — use `--json` or `scripts/parse_issues.py --enrich`.
-5. **Team field is NOT JQL-filterable.** `customfield_10001` cannot be used in JQL WHERE clauses. Fetch all issues, filter by `customfield_10001.name` in post-processing.
+5. **Team field has two JQL syntaxes.** `customfield_10001` cannot be used in JQL WHERE clauses. However, `"Team[Team]" = {teamId}` (using the team UUID, not display name) works. Use the UUID syntax for JQL filtering; use `customfield_10001.name` in post-processing only when you need the display name from JSON output.
 6. **ADF vs plain text.** Reading descriptions via `--json` returns Atlassian Document Format (nested JSON). Creating/editing with `--description` accepts plain text. Don't try to round-trip ADF through `--description`.
 7. **Acceptance Criteria field is almost always null.** Scan the description for "Requirements", "Acceptance Criteria", or bullet-style criteria instead of checking `customfield_10718`.
 8. **`--enrich` is MANDATORY for custom fields.** Both `acli search --json` and `acli view KEY --json` (without `--fields "*all"`) return only basic fields (assignee, issuetype, priority, status, summary). Story points, team, sprint, and size will appear as empty/null — looking like the data isn't set when it actually is. Always use `scripts/parse_issues.py --enrich` to get custom field data. Skipping `--enrich` is the #1 cause of false "missing data" reports.
@@ -105,8 +139,18 @@ Load only what the current task requires.
 | Rate limiting (429) | Wait 5 seconds, retry once. |
 | Interactive prompt hangs | Missing `--yes` flag on a mutating command. |
 | Custom field update fails via `acli` | Fall back to Jira REST API using `.jira-token` file. See Gotcha #9. |
+| `issueSearchStable` returns errors | Fall back to REST API search (`/rest/api/3/search`) with the same JQL. Warn that the beta API failed. |
+
+## Team Conventions
+
+These apply across all sub-commands:
+
+- **Release Pending counts as completed.** Release Pending items remain in the sprint and count toward velocity and capacity. They represent done work awaiting release.
+- **Confirmation flow.** Sub-commands that modify Jira issues (assign, refine, release) use a standard prompt: `"Apply changes? [y/N/edit]"` — **y** applies all, **N** cancels, **edit** steps through each change individually.
 
 ## Common Workflows
+
+> Sub-commands share data. `plan` reuses roster/capacity/expertise from `assign`. `sprint-report` uses the same velocity query pattern as `plan`. `release` references exit criteria from `workflows.md` and can invoke `assign` for unassigned Features.
 
 ### Creating an issue
 
@@ -132,6 +176,46 @@ Load only what the current task requires.
 2. Use `issueByKey` for single issues or `issueSearchStable` (beta) for JQL search
 3. Fall back to `acli` + `parse_issues.py --enrich` if GraphQL returns errors
 
+### Recommending and assigning issues
+
+1. Load `references/assign.md`
+2. Identify unassigned issues (single key, JQL query, or passed-in list)
+3. Determine the team (from issue field, parent epic, or user input)
+4. Run deep or quick analysis per the reference
+5. Present recommendations, get user confirmation, then assign
+
+### Refining issues
+
+1. Load `references/refine.md`
+2. Identify issues to refine (specific keys, JQL, `sprint`, or `backlog`)
+3. Run all 6 checks: missing fields, duplicates, hierarchy, comments, staleness, sprint readiness
+4. Present refinement report with actionable recommendations
+5. Optionally apply auto-fixable changes and prompt for manual decisions
+
+### Sprint planning prep
+
+1. Load `references/plan.md`
+2. Resolve team, board, and sprint context
+3. Generate carryover report, velocity trend, capacity snapshot, and ready-for-planning queue
+4. Auto-generate sprint fill suggestions with expertise matching
+5. Surface critical customer bugs (exempt from capacity) and retro action items
+
+### Sprint review summary
+
+1. Load `references/sprint-report.md`
+2. Resolve sprint (active or previous)
+3. Partition completed vs carried over, compute completion rate
+4. Per-member breakdown, epic progress, demo checklist with naming conventions
+5. Optionally post to Slack
+
+### Release readiness
+
+1. Load `references/release.md`
+2. Fetch Features for the target version/label
+3. Quick mode: PI funnel, feature matrix, readiness score
+4. Deep mode: adds epic roll-up, dependency map, coherence analysis, RN readiness, risk assessment
+5. Optionally remediate (assign owners, create Epics, transition statuses)
+
 ### Discovering unknown fields or endpoints
 
 1. For REST: load `references/rest-api-fallback.md` — use the OpenAPI spec or `/rest/api/3/field` endpoint
@@ -141,5 +225,5 @@ Load only what the current task requires.
 ## When NOT to Use
 
 - **Non-RHDH Jira projects** — this skill's field mappings, workflows, and JQL patterns are specific to RHIDP/RHDHPLAN/RHDHBUGS/RHDHSUPP
-- **Jira REST API directly** — use `acli` first. REST API is a fallback for custom field updates and schema discovery when `acli` cannot handle the operation (see Gotcha #9)
-- **GraphQL for simple lookups** — use `acli` for single-issue views and simple searches. GraphQL is for complex queries needing relationships or many custom fields in one call, and for schema introspection
+- **Jira REST API directly** — use `acli` first, then GraphQL for bulk reads. REST API is the last resort for writes when acli fails and for schema discovery via OpenAPI spec (see Gotcha #9)
+- **GraphQL for simple lookups** — use `acli` for single-issue views and simple searches. GraphQL is for bulk operations, complex queries needing relationships or many custom fields in one call, team roster lookups, and schema introspection

--- a/skills/rhdh-jira/SKILL.md
+++ b/skills/rhdh-jira/SKILL.md
@@ -110,7 +110,7 @@ Load only what the current task requires.
 | `references/refine.md` | Checking issues against exit criteria per status, identifying duplicates, missing fields, unaddressed comments, and readiness for the next workflow status. |
 | `references/plan.md` | Sprint planning prep: carryover report, velocity trend, per-member capacity, ready-for-planning queue, sprint fill suggestions. |
 | `references/sprint-report.md` | Sprint review summary: committed vs completed, per-member breakdown, epic progress, demo checklist with naming conventions, velocity trend. |
-| `references/release.md` | Release readiness report: feature matrix, PI funnel states, epic roll-up, cross-team dependency map, blocker bugs, RN readiness, risk assessment. Replaces `rhdh-release-triage`. |
+| `references/release.md` | Release readiness report: feature matrix, PI funnel states, epic roll-up, cross-team dependency map, blocker bugs, RN readiness, risk assessment. |
 
 ## Common Gotchas
 

--- a/skills/rhdh-jira/references/assign.md
+++ b/skills/rhdh-jira/references/assign.md
@@ -161,17 +161,17 @@ Callers (hygiene dashboard, refinement workflow) consume this structure:
       "key": "RHIDP-1234",
       "summary": "Issue summary text",
       "priority": "Major",
-      "proposed_assignee": "Jon Koops",
-      "proposed_account_id": "712020:71f08212-...",
+      "proposed_assignee": "Allison Hill",
+      "proposed_account_id": "712020:9974d75b-...",
       "score": 14,
       "rationale": "Top expertise in plugins (12/50 issues). Capacity: 5 issues / 13 SP. Currently working on RHIDP-1200 (related component).",
-      "runner_up": "Hope Hadfield (score: 12)",
+      "runner_up": "Noah Rhodes (score: 12)",
       "signals": ["context_proximity: RHIDP-1200 shares 'plugins' component"]
     }
   ],
   "warnings": [
-    "Bus factor: Jon Koops owns 70% of 'plugins' issues. Consider spreading.",
-    "Nick Boldt overloaded (12 open sprint issues) — excluded from non-critical."
+    "Bus factor: Allison Hill owns 70% of 'plugins' issues. Consider spreading.",
+    "Daniel Wagner overloaded (12 open sprint issues) — excluded from non-critical."
   ]
 }
 ```
@@ -185,14 +185,14 @@ Mode: **{mode}** | Roster: {roster_size} members | Issues analyzed: {count}
 
 | # | Issue | P | Summary | Recommended | Score | Rationale |
 |---|-------|---|---------|-------------|-------|-----------|
-| 1 | [RHIDP-1234](url) | Major | Summary | Jon Koops | 14 | plugins (12/50), 5 issues/13 SP, proximity: RHIDP-1200 |
+| 1 | [RHIDP-1234](url) | Major | Summary | Allison Hill | 14 | plugins (12/50), 5 issues/13 SP, proximity: RHIDP-1200 |
 
 **Signals:**
-- Bus factor: Jon Koops owns 70% of 'plugins'. Consider Frank Kong (3/50, 5 issues/8 SP).
-- Growth opportunity for Kashish Mittal in 'catalog' — 2 prior issues.
+- Bus factor: Allison Hill owns 70% of 'plugins'. Consider Angie Henderson (3/50, 5 issues/8 SP).
+- Growth opportunity for Cristian Santos in 'catalog' — 2 prior issues.
 
 **Warnings:**
-- Nick Boldt excluded (12 open sprint issues, overloaded).
+- Daniel Wagner excluded (12 open sprint issues, overloaded).
 ```
 
 ## Assignment
@@ -241,9 +241,9 @@ After all assignments, summarize:
 
 ```markdown
 ## Assignment Results
-- ✅ RHIDP-1234 → Jon Koops
-- ✅ RHIDP-5678 → Hope Hadfield
-- ❌ RHIDP-9012 → Frank Kong (403: no edit permission)
+- ✅ RHIDP-1234 → Allison Hill
+- ✅ RHIDP-5678 → Noah Rhodes
+- ❌ RHIDP-9012 → Angie Henderson (403: no edit permission)
 ```
 
 ## Error Handling

--- a/skills/rhdh-jira/references/assign.md
+++ b/skills/rhdh-jira/references/assign.md
@@ -1,0 +1,266 @@
+# Assignee Recommendations
+
+Analyze team expertise, sprint capacity, and context proximity to recommend assignees for unassigned issues. Supports single issues, batch JQL queries, or a passed-in list of issue keys.
+
+Uses GraphQL for all reads (bulk operation). Writes follow the API preference order in SKILL.md — REST preferred here since deep mode already has `AUTH` set from GraphQL reads.
+
+Authentication setup: see `references/auth.md`. All examples below assume `AUTH`, `CLOUD_ID`, and `GRAPHQL_URL` are set per that file.
+
+## Input
+
+The caller provides:
+
+1. **Issue keys** — one or more unassigned issue keys (or a JQL query that produces them)
+2. **Team ID** — Jira team UUID (e.g., `ec74d716-af36-4b3c-950f-f79213d08f71-4403`). If not provided, infer from the issue's `customfield_10001` field or the parent epic's team. If neither is available, ask the user.
+
+## Mode Selection
+
+> "Unassigned issues found. **Deep** recommendations (team roster + expertise + capacity + context analysis, ~5-10 API calls) or **quick** (match from data already in context)? [deep/quick]"
+
+Default to **deep** if the user doesn't specify.
+
+## Quick Mode
+
+Match from data already in context — no extra API calls.
+
+1. Collect assignees visible in the current context (report data, search results, etc.) and note their components/domains.
+2. Match unassigned issues by component and keyword overlap.
+3. If no match, state "insufficient data for recommendation — use deep mode."
+4. If multiple matches, prefer the person with fewer open issues in context.
+5. Include short rationale.
+
+Skip the rest of this file. Format output per the Output section below.
+
+## Deep Mode
+
+Five analysis layers, executed in order.
+
+### Layer 1 — Team Roster
+
+Query the team directly via the Teams GraphQL API. No need to infer roster from issue assignees.
+
+```bash
+curl -s -u "$AUTH" "$GRAPHQL_URL" -X POST -H 'Content-Type: application/json' \
+  -d '{
+    "query": "query GetTeamRoster { team { teamV2(id: \"TEAM_ID\", siteId: \"'"$CLOUD_ID"'\") { displayName members(first: 50) { nodes { member { name accountId } state role } } } } }"
+  }'
+```
+
+Replace `TEAM_ID` with the team UUID.
+
+Extract distinct members: `name`, `accountId`. Filter to `state: FULL_MEMBER` only — exclude alumni and invited members.
+
+If the team has more than 50 members, paginate using `after` cursor. In practice, RHDH teams are <15 people.
+
+### Layer 2 — Expertise Profiles
+
+For each team member, query their recent issue history to build a domain profile.
+
+```bash
+curl -s -u "$AUTH" "$GRAPHQL_URL" -X POST \
+  -H 'Content-Type: application/json' \
+  -H 'X-ExperimentalApi: JiraIssueSearch' \
+  -d '{
+    "query": "query ExpertiseProfile { jira { issueSearchStable(cloudId: \"'"$CLOUD_ID"'\", issueSearchInput: {jql: \"project in (RHIDP, RHDHPLAN, RHDHSUPP, RHDHBUGS) AND assignee = ACCOUNT_ID AND updated >= -90d ORDER BY updated DESC\"}, first: 50) { edges { node { key summary status { name } issueType { name } fields { edges { node { __typename name ... on JiraComponentsField { components { edges { node { name } } } } } } } } } } } }"
+  }'
+```
+
+Replace `ACCOUNT_ID` with the member's `accountId`.
+
+Build profile per member:
+
+| Metric | How to compute |
+|--------|---------------|
+| **Components** | Rank by frequency across all 50 issues. Top 3 are primary domains. |
+| **Issue types** | Count by type (Story, Task, Epic, Bug). Shows work pattern. |
+| **Domain keywords** | Extract 2-3 word patterns from summaries (e.g., "catalog", "dynamic plugins", "RBAC", "CI/CD"). Rank by frequency. |
+| **Specialization %** | `(issues in top component / total issues) × 100`. High (>60%) = specialist. Low (<30%) = generalist. |
+
+### Layer 3 — Sprint Capacity
+
+For each team member, query their current sprint load.
+
+```bash
+curl -s -u "$AUTH" "$GRAPHQL_URL" -X POST \
+  -H 'Content-Type: application/json' \
+  -H 'X-ExperimentalApi: JiraIssueSearch' \
+  -d '{
+    "query": "query SprintCapacity { jira { issueSearchStable(cloudId: \"'"$CLOUD_ID"'\", issueSearchInput: {jql: \"project in (RHIDP, RHDHPLAN, RHDHSUPP, RHDHBUGS) AND assignee = ACCOUNT_ID AND sprint in (openSprints(), futureSprints()) AND status != Closed\"}, first: 50) { totalCount edges { node { key summary status { name } storyPoints fields { edges { node { __typename name ... on JiraSprintField { selectedSprintsConnection { edges { node { name state } } } } } } } } } } } }"
+  }'
+```
+
+Compute per member:
+
+| Metric | How to compute |
+|--------|---------------|
+| **Open issues (current sprint)** | Count issues where sprint state = `active` |
+| **Total SP committed** | Sum `storyPoints` across active sprint issues |
+| **Next sprint load** | Count issues where sprint state = `future` |
+| **Overloaded flag** | Set if open issues ≥ 10 or SP committed ≥ 21 |
+
+### Layer 4 — Soft Signals
+
+Derive from Layers 2 and 3 data. No additional API calls.
+
+| Signal | Condition | Output |
+|--------|-----------|--------|
+| **Growth opportunity** | For Major or lower priority issues: member has ≤ 2 issues in the matching component/domain | "Growth opportunity for {name} — {N} prior issues in this area." |
+| **Bus factor** | One member owns >60% of a component's issues across the team | "Consider spreading {component} knowledge — {name} owns {pct}%." |
+| **Concentration warning** | Same member recommended for 4+ issues in this batch | "{name} recommended for {N} issues — consider distributing." |
+| **Critical goes to experts** | Blocker/Critical priority issues | Always recommend the top domain contributor. Do not suggest growth opportunities for Blocker/Critical. |
+
+### Layer 5 — Context Proximity
+
+Compare each unassigned issue against each member's *current* open work (already fetched in Layer 3).
+
+For each `(unassigned issue, team member)` pair:
+
+1. **Component overlap** — does the unassigned issue share a component with any of the member's open issues? Score: +3 per shared component.
+2. **Keyword overlap** — extract 2-3 word tokens from the unassigned issue summary. Compare against the member's open issue summaries. Score: +1 per shared keyword (case-insensitive, ignoring stop words).
+3. **Parent overlap** — does the unassigned issue share a parent epic with any of the member's open issues? Score: +5 (strongest signal — same deliverable).
+
+Higher proximity score = lower context-switching cost.
+
+## Scoring
+
+For each `(unassigned issue, team member)` pair, compute a composite score:
+
+```
+score = (expertise_match × 3) + (proximity_score × 2) - (capacity_penalty × 1)
+```
+
+Where:
+
+| Factor | Computation |
+|--------|-------------|
+| `expertise_match` | Number of matching components + domain keywords between the issue and the member's profile (Layer 2) |
+| `proximity_score` | Context proximity score from Layer 5 |
+| `capacity_penalty` | `open_issues_current_sprint × 1`. If overloaded flag is set, add +10 penalty. |
+
+**Rank members by score (descending).** Recommend the top scorer. Include the runner-up if scores are within 20%.
+
+**Override rules:**
+
+- Blocker/Critical: always recommend the highest `expertise_match` regardless of capacity (note the load concern in rationale).
+- Overloaded members (≥10 open sprint issues): exclude unless they are the only expert for a Blocker/Critical.
+
+## Output
+
+### Data Contract
+
+Callers (hygiene dashboard, refinement workflow) consume this structure:
+
+```json
+{
+  "team": "RHDH Cope",
+  "team_id": "ec74d716-af36-4b3c-950f-f79213d08f71-4403",
+  "mode": "deep",
+  "roster_size": 9,
+  "recommendations": [
+    {
+      "key": "RHIDP-1234",
+      "summary": "Issue summary text",
+      "priority": "Major",
+      "proposed_assignee": "Jon Koops",
+      "proposed_account_id": "712020:71f08212-...",
+      "score": 14,
+      "rationale": "Top expertise in plugins (12/50 issues). Capacity: 5 issues / 13 SP. Currently working on RHIDP-1200 (related component).",
+      "runner_up": "Hope Hadfield (score: 12)",
+      "signals": ["context_proximity: RHIDP-1200 shares 'plugins' component"]
+    }
+  ],
+  "warnings": [
+    "Bus factor: Jon Koops owns 70% of 'plugins' issues. Consider spreading.",
+    "Nick Boldt overloaded (12 open sprint issues) — excluded from non-critical."
+  ]
+}
+```
+
+### Markdown Template
+
+```markdown
+## Assignee Recommendations ({team})
+
+Mode: **{mode}** | Roster: {roster_size} members | Issues analyzed: {count}
+
+| # | Issue | P | Summary | Recommended | Score | Rationale |
+|---|-------|---|---------|-------------|-------|-----------|
+| 1 | [RHIDP-1234](url) | Major | Summary | Jon Koops | 14 | plugins (12/50), 5 issues/13 SP, proximity: RHIDP-1200 |
+
+**Signals:**
+- Bus factor: Jon Koops owns 70% of 'plugins'. Consider Frank Kong (3/50, 5 issues/8 SP).
+- Growth opportunity for Kashish Mittal in 'catalog' — 2 prior issues.
+
+**Warnings:**
+- Nick Boldt excluded (12 open sprint issues, overloaded).
+```
+
+## Assignment
+
+After the user reviews recommendations:
+
+Use the standard confirmation flow from SKILL.md (`y/N/edit`).
+
+Follow the API preference order from SKILL.md. In deep mode (GraphQL reads already set up `AUTH`), prefer REST. In quick mode (no prior API calls), prefer acli.
+
+### REST API assignment
+
+```bash
+curl -s -X PUT \
+  -u "$AUTH" \
+  -H "Content-Type: application/json" \
+  -d '{"fields": {"assignee": {"accountId": "ACCOUNT_ID"}}}' \
+  "https://redhat.atlassian.net/rest/api/3/issue/RHIDP-1234"
+```
+
+| HTTP Status | Action |
+|-------------|--------|
+| 204 | Assigned. Report success. |
+| 400 | User cannot be assigned (permissions). Report and skip. |
+| 403 | No edit permission. Report and skip. |
+| 429 | Wait 5 seconds, retry once. |
+
+### acli assignment
+
+```bash
+acli jira workitem assign --key RHIDP-1234 --assignee "ACCOUNT_ID" --yes
+```
+
+`--assignee` accepts an account ID or email address. `--yes` is mandatory to avoid interactive prompts.
+
+For bulk assignment from a file:
+
+```bash
+# Create a file with key,accountId pairs
+acli jira workitem assign --from-file assignments.txt --yes
+```
+
+If acli fails, fall back to REST API.
+
+After all assignments, summarize:
+
+```markdown
+## Assignment Results
+- ✅ RHIDP-1234 → Jon Koops
+- ✅ RHIDP-5678 → Hope Hadfield
+- ❌ RHIDP-9012 → Frank Kong (403: no edit permission)
+```
+
+## Error Handling
+
+| Error | Action |
+|-------|--------|
+| Team ID not found / `teamV2` returns null | "Team not found. Verify the team UUID." |
+| `issueSearchStable` returns errors | See SKILL.md Error Handling. |
+| Member has 0 issues in 90 days | Include in roster but mark as "no recent activity — cannot build expertise profile." |
+| GraphQL rate limit (429) | Wait 5 seconds, retry once. If still fails, skip that member and note "partial profile." |
+| All members overloaded | Warn: "All team members have ≥10 open sprint issues. Recommending least-loaded member with caveat." |
+| Unassigned issue has no components | Score on keyword and parent overlap only. Note: "No components set — recommendation based on summary keywords only." |
+
+## Caveats
+
+1. **Expertise profiles are backward-looking.** 90-day window may miss someone who recently joined the team or changed focus areas.
+2. **Story points are inconsistently set.** Capacity scoring falls back to issue count when SP data is sparse.
+3. **`issueSearchStable` is beta.** Requires `X-ExperimentalApi: JiraIssueSearch` header. If it breaks, fall back to REST `/rest/api/3/search` with the same JQL.
+4. **Team field values cannot be read via GraphQL on issues.** Use `team.teamV2` for roster (works). For filtering issues by team, use JQL `"Team[Team]" = {teamId}` in the search query.
+5. **Context proximity is only as good as issue metadata.** Issues without components or with vague summaries produce weak proximity scores.

--- a/skills/rhdh-jira/references/assign.md
+++ b/skills/rhdh-jira/references/assign.md
@@ -148,7 +148,7 @@ Where:
 
 ### Data Contract
 
-Callers (hygiene dashboard, refinement workflow) consume this structure:
+Callers (refinement, release, or other workflows) consume this structure:
 
 ```json
 {

--- a/skills/rhdh-jira/references/auth.md
+++ b/skills/rhdh-jira/references/auth.md
@@ -44,7 +44,13 @@ The `setup.py` script warns when the file is group/world-readable.
 ```bash
 CLOUD_ID="2b9e35e3-6bd3-4cec-b838-f4249ee02432"
 JIRA_BASE="https://redhat.atlassian.net"
+GRAPHQL_URL="$JIRA_BASE/gateway/api/graphql"
+ORG_ID="4k7c08c0-9kb0-1aca-k606-d1417cc24104"
 ```
+
+- `CLOUD_ID` — required for all Jira GraphQL queries (`issueSearchStable`, `issueByKey`).
+- `GRAPHQL_URL` — the GraphQL endpoint. Derived from `JIRA_BASE`.
+- `ORG_ID` — the Atlassian organization ID. Required for the Teams GraphQL API (`team.teamSearchV2` for searching teams by name). Not needed for `team.teamV2` (direct lookup by team ID, which uses `CLOUD_ID` as `siteId`).
 
 ### Discovering your cloudId
 
@@ -53,6 +59,10 @@ The `cloudId` above is for `redhat.atlassian.net`. To discover it for any Jira C
 ```bash
 curl -s -u "$AUTH" "$JIRA_BASE/_edge/tenant_info" | python -c "import json,sys; print(json.load(sys.stdin)['cloudId'])"
 ```
+
+### Discovering your orgId
+
+The `ORG_ID` is visible in the Atlassian admin URL: `https://admin.atlassian.com/o/{ORG_ID}/...`. It can also be found via the Teams API — any team entity returned by `team.teamSearchV2` includes `organizationId` in its response. The value `4k7c08c0-9kb0-1aca-k606-d1417cc24104` is the Red Hat organization.
 
 ## Common Auth Errors
 

--- a/skills/rhdh-jira/references/graphql-queries.md
+++ b/skills/rhdh-jira/references/graphql-queries.md
@@ -131,8 +131,8 @@ Custom fields appear in `fields { edges { node { ... } } }` with typed fragments
 | `JiraSingleSelectField` | `... on JiraSingleSelectField { fieldOption { value } }` | Size (XS/S/M/L/XL), Ready, Blocked, Release Note Type |
 | `JiraSprintField` | `... on JiraSprintField { selectedSprintsConnection { edges { node { name state } } } }` | Sprint name and state (active/closed/future) |
 | `JiraLabelsField` | `... on JiraLabelsField { labels { edges { node { name } } } }` | All labels |
-| `JiraTeamViewField` | _(no value sub-fields currently extractable)_ | Team — visible as `__typename` but value needs REST fallback |
-| `JiraComponentsField` | _(introspect for sub-fields)_ | Components |
+| `JiraTeamViewField` | `... on JiraTeamViewField { selectedTeam { jiraSuppliedName jiraMemberCount fullTeam { displayName members(first: 50) { nodes { member { name accountId } state role } } } } }` | Team — name, member count, and full roster via `fullTeam.members`. For direct roster lookup without an issue, use `team.teamV2` (see Team Roster Query). |
+| `JiraComponentsField` | `... on JiraComponentsField { components { edges { node { name } } } }` | Components |
 | `JiraDatePickerField` | _(introspect for sub-fields)_ | Start date, Target start/end |
 | `JiraRichTextField` | _(introspect for sub-fields)_ | Description, Release Note Text, Acceptance Criteria |
 | `JiraParentIssueField` | _(introspect for sub-fields)_ | Parent Link (legacy) — prefer `parentIssue` on `JiraIssue` |
@@ -147,28 +147,50 @@ curl -s -u "$AUTH" -X POST -H 'Content-Type: application/json' \
 
 ## Mutations (Experimental)
 
-GraphQL mutations for Jira issue updates exist but are experimental. They require `@optIn` directives and may break without notice. **Use REST API `PUT /rest/api/3/issue/{key}` for writes** — it is stable and well-documented.
+GraphQL mutations for Jira issue updates exist but are experimental. They require `@optIn` directives and may break without notice. There is **no GraphQL mutation for assigning issues**. For writes, use `acli` (simple single-issue operations) or REST API `PUT /rest/api/3/issue/{key}` (when already in a REST context or acli fails).
 
 If you discover stable mutations in the future via introspection, verify they do not require experimental headers before relying on them.
 
 ## Caveats
 
 1. **`issueSearchStable` is beta.** Requires `X-ExperimentalApi: JiraIssueSearch` header. May break without notice. If you get a `BetaHeaderOptInException` error, add this header.
-2. **Team field values are not directly extractable.** `JiraTeamViewField` appears in the schema but value sub-fields are limited. Use REST API to get team data.
+2. **Team field values on issues are limited.** `JiraTeamViewField` on issues exposes `selectedTeam.jiraSuppliedName` and `fullTeam.members` but not all sub-fields. For direct team roster lookup (without going through an issue), use `team.teamV2(id, siteId)` — see the Team Roster Query pattern below.
 3. **`cloudId` is required on every query.** Use `2b9e35e3-6bd3-4cec-b838-f4249ee02432` for redhat.atlassian.net. Discover it via `/_edge/tenant_info` (see Authentication section).
 4. **Rate limiting is cost-based.** 10,000 points per user per minute. HTTP 429 with `RETRY-AFTER` header when exceeded. Do not retry on 5xx.
 5. **Operation names are mandatory.** Every query must have a name (e.g., `query GetIssue { ... }`). Unnamed queries will be rejected in the future.
 6. **No spec file to download.** Unlike REST (which has an OpenAPI spec), GraphQL schema is discovered via introspection queries only. Use `__type` or the full `__schema` query. See Schema Discovery section.
 
-## When to use GraphQL vs acli
+## Team Roster Query
+
+Query team membership directly via the Teams GraphQL API — no need to infer roster from issue assignees.
+
+```bash
+curl -s -u "$AUTH" "$GRAPHQL_URL" -X POST -H 'Content-Type: application/json' \
+  -d '{
+    "query": "query GetTeamRoster { team { teamV2(id: \"TEAM_ID\", siteId: \"'"$CLOUD_ID"'\") { displayName members(first: 50) { nodes { member { name accountId } state role } } } } }"
+  }'
+```
+
+Replace `TEAM_ID` with the Jira team UUID (e.g., `ec74d716-af36-4b3c-950f-f79213d08f71-4403`).
+
+Returns `name`, `accountId`, `state` (FULL_MEMBER, INVITED, ALUMNI), and `role` (REGULAR, ADMIN). Filter to `FULL_MEMBER` for active team members.
+
+For assignee analysis using this data, see `references/assign.md`.
+
+## When to use GraphQL vs acli vs REST
+
+Preference order: **acli → GraphQL → REST API**. Skip acli for bulk operations.
 
 | Scenario | Use |
 |----------|-----|
 | Quick single-issue lookup | `acli` — faster, simpler |
-| Bulk search with custom fields | GraphQL `issueSearchStable` — one call vs `acli` + `--enrich` per issue |
+| Bulk search with custom fields | GraphQL `issueSearchStable` — skip acli, one call vs `--enrich` per issue |
+| Bulk operations (expertise profiles, capacity) | GraphQL — skip acli entirely |
 | Need parent/child relationships | GraphQL — `parentIssue { key summary }` inline |
-| Update a field | REST API — `PUT /rest/api/3/issue/{key}` (stable) |
-| Team field value | REST API — GraphQL can't extract it reliably |
+| Team roster lookup | GraphQL — `team.teamV2(id, siteId)` returns members directly |
 | Sprint data | Either — GraphQL returns it inline, acli needs `--enrich` |
+| Update a field (standalone) | `acli` — simple, reliable |
+| Update a field (already in REST context) | REST API — avoid shelling out to acli when already authenticated |
+| Update a field (acli fails) | REST API — fallback for custom field writes |
 | Discover available fields/types | GraphQL introspection — `__type` queries |
 | Discover REST endpoints/payloads | REST OpenAPI spec — see `references/rest-api-fallback.md` |

--- a/skills/rhdh-jira/references/plan.md
+++ b/skills/rhdh-jira/references/plan.md
@@ -146,14 +146,14 @@ Note: "Retro action items to consider for this sprint."
     "trend": "accelerating"
   },
   "capacity": [
-    {"name": "Jon Koops", "carryover_items": 2, "carryover_sp": 8, "open": 5, "sp_load": 13, "overloaded": false}
+    {"name": "Allison Hill", "carryover_items": 2, "carryover_sp": 8, "open": 5, "sp_load": 13, "overloaded": false}
   ],
   "available_sp": 5,
   "ready_queue": [
     {"key": "...", "summary": "...", "priority": "Critical", "sp": 3, "parent_epic": "RHIDP-100"}
   ],
   "fill_suggestions": [
-    {"key": "RHIDP-5678", "proposed_assignee": "Hope Hadfield", "score": 12, "rationale": "..."}
+    {"key": "RHIDP-5678", "proposed_assignee": "Noah Rhodes", "score": 12, "rationale": "..."}
   ],
   "critical_customer_bugs": [],
   "ci_items": []

--- a/skills/rhdh-jira/references/plan.md
+++ b/skills/rhdh-jira/references/plan.md
@@ -1,0 +1,220 @@
+# Sprint Planning Prep
+
+Generate a sprint planning package: carryover report, velocity trend, per-member capacity, ready-for-planning queue, and sprint fill suggestions. Run before each bi-weekly sprint planning call.
+
+Uses GraphQL for bulk reads (skip acli). Writes follow the API preference order in SKILL.md.
+
+Authentication setup: see `references/auth.md`. All examples below assume `AUTH`, `CLOUD_ID`, and `GRAPHQL_URL` are set per that file.
+
+## Input
+
+The caller provides:
+
+1. **Team ID** — Jira team UUID. If not provided, ask the user.
+2. **Board ID** — optional. If not provided, discover from `references/jql-patterns.md` board table or ask.
+3. **Sprint** — optional. Defaults to "plan the next sprint" (uses active sprint for carryover, next sprint as target).
+
+## Workflow
+
+### Step 1 — Resolve Sprint Context
+
+Find the team's board and identify sprints. Use acli for sprint lookup (simple, single call):
+
+```bash
+acli jira board list-sprints --board BOARD_ID --state active --json
+acli jira board list-sprints --board BOARD_ID --state closed --json --recent 3
+acli jira board list-sprints --board BOARD_ID --state future --json --recent 1
+```
+
+Identify:
+
+- **Active sprint** (ending soon) — source for carryover
+- **Next sprint** (future) — target for planning
+- **Last 3 closed sprints** — source for velocity
+
+### Step 2 — Carryover Report
+
+Issues in the active sprint that are NOT Closed or Release Pending. These carry into the next sprint.
+
+```bash
+curl -s -u "$AUTH" "$GRAPHQL_URL" -X POST \
+  -H 'Content-Type: application/json' \
+  -H 'X-ExperimentalApi: JiraIssueSearch' \
+  -d '{
+    "query": "query Carryover { jira { issueSearchStable(cloudId: \"'"$CLOUD_ID"'\", issueSearchInput: {jql: \"project in (RHIDP, RHDHPLAN, RHDHSUPP, RHDHBUGS) AND sprint = SPRINT_ID AND status not in (Closed, \\\"Release Pending\\\") AND \\\"Team[Team]\\\" = TEAM_ID\"}, first: 50) { totalCount edges { node { key summary status { name } assignee { name } storyPoints issueType { name } } } } } }"
+  }'
+```
+
+**Validation:** Flag any Epics in the sprint — only Bug, Task, or Story should be in sprints. "⚠ RHIDP-1234 is an Epic — Epics should be broken down into Stories/Tasks, not added to sprints."
+
+Sum carryover SP. If carryover > avg velocity, flag: "Carryover ({N} SP) exceeds avg velocity ({M} SP) — sprint is overcommitted before adding new work."
+
+### Step 3 — Velocity Calculation
+
+For each of the last 3 closed sprints, count completed SP:
+
+```bash
+curl -s -u "$AUTH" "$GRAPHQL_URL" -X POST \
+  -H 'Content-Type: application/json' \
+  -H 'X-ExperimentalApi: JiraIssueSearch' \
+  -d '{
+    "query": "query Velocity { jira { issueSearchStable(cloudId: \"'"$CLOUD_ID"'\", issueSearchInput: {jql: \"project in (RHIDP, RHDHPLAN, RHDHSUPP, RHDHBUGS) AND sprint = SPRINT_ID AND status in (Closed, \\\"Release Pending\\\") AND \\\"Team[Team]\\\" = TEAM_ID\"}, first: 100) { totalCount edges { node { storyPoints } } } } }"
+  }'
+```
+
+Compute: SP per sprint, 3-sprint average, trend (↑ accelerating / → stable / ↓ decelerating).
+
+### Step 4 — Per-Member Capacity
+
+Reuse the capacity query from `references/assign.md` Layer 3. For each team member (roster from `assign.md` Layer 1):
+
+- Open issues in active sprint (carryover per person)
+- SP committed in active sprint
+- Issues in next sprint (already planned)
+- Overloaded flag (≥10 open issues or ≥21 SP)
+
+### Step 5 — Ready-for-Planning Queue
+
+Backlog issues that are refined and ready to pull into the sprint:
+
+```bash
+jql: "project in (RHIDP, RHDHPLAN, RHDHSUPP, RHDHBUGS)
+  AND \"Team[Team]\" = TEAM_ID
+  AND status in (Backlog, \"To Do\")
+  AND sprint not in (openSprints(), futureSprints())
+  AND (cf[10028] is not EMPTY OR issuetype = Bug)
+  AND issuetype in (Bug, Task, Story)
+  ORDER BY priority ASC, created ASC"
+```
+
+Rank by priority, then by parent epic priority. Include: key, summary, priority, SP, parent epic key, assignee (if set).
+
+### Step 6 — Available Capacity
+
+```
+available_SP = avg_velocity - carryover_SP
+```
+
+If negative, warn: "No room for new work — carryover alone exceeds velocity."
+
+### Step 7 — Sprint Fill Suggestions
+
+Automatically generate issue-to-person recommendations from the ready queue. Uses expertise matching from `references/assign.md` Layer 2 (if not already fetched, run it now).
+
+For each ready-for-planning issue, score against each team member using the same formula from `assign.md` (expertise × 3 + proximity × 2 - capacity × 1). Suggest assignments up to `available_SP`.
+
+**Framing:** "These are suggestions — team members self-select during planning."
+
+### Step 8 — Critical Customer Bugs
+
+Separately surface any critical/blocker bugs with `rhdh-customer` label:
+
+```bash
+jql: "project in (RHIDP, RHDHBUGS) AND priority in (Blocker, Critical) AND labels = rhdh-customer AND \"Team[Team]\" = TEAM_ID AND status != Closed"
+```
+
+Note: "Critical customer bugs are exempt from capacity constraints — work immediately regardless of sprint load."
+
+### Step 9 — Continuous Improvement Items
+
+Surface open issues with `Component: Continuous Improvement` (retro action items):
+
+```bash
+jql: "project = RHIDP AND component = 'Continuous Improvement' AND \"Team[Team]\" = TEAM_ID AND status != Closed ORDER BY priority ASC"
+```
+
+Note: "Retro action items to consider for this sprint."
+
+## Output
+
+### Data Contract
+
+```json
+{
+  "team": "RHDH Cope",
+  "active_sprint": "Sprint 47",
+  "target_sprint": "Sprint 48",
+  "carryover": {
+    "count": 5,
+    "sp": 13,
+    "items": [{"key": "...", "summary": "...", "assignee": "...", "status": "...", "sp": 5}],
+    "epic_violations": ["RHIDP-1234"]
+  },
+  "velocity": {
+    "sprints": [{"name": "Sprint 46", "sp": 21}, {"name": "Sprint 45", "sp": 18}],
+    "average": 18,
+    "trend": "accelerating"
+  },
+  "capacity": [
+    {"name": "Jon Koops", "carryover_items": 2, "carryover_sp": 8, "open": 5, "sp_load": 13, "overloaded": false}
+  ],
+  "available_sp": 5,
+  "ready_queue": [
+    {"key": "...", "summary": "...", "priority": "Critical", "sp": 3, "parent_epic": "RHIDP-100"}
+  ],
+  "fill_suggestions": [
+    {"key": "RHIDP-5678", "proposed_assignee": "Hope Hadfield", "score": 12, "rationale": "..."}
+  ],
+  "critical_customer_bugs": [],
+  "ci_items": []
+}
+```
+
+### Markdown Template
+
+```markdown
+## Sprint Planning — {team}
+
+{active_sprint} → Planning {target_sprint}
+
+### Carryover ({count} items, {sp} SP)
+| # | Issue | Summary | Assignee | Status | SP | Days |
+|---|-------|---------|----------|--------|----|------|
+
+⚠ Carryover ({sp} SP) vs avg velocity ({avg} SP): {assessment}
+
+### Velocity (last 3 sprints)
+| Sprint | Completed SP | Trend |
+|--------|-------------|-------|
+Avg: {avg} SP | Trend: {trend}
+
+### Capacity
+| Member | Carryover | Open | SP Load | Status |
+|--------|-----------|------|---------|--------|
+
+### Available Capacity
+Avg velocity: {avg} SP − Carryover: {carry_sp} SP = **{available} SP available**
+
+### Ready for Planning ({count} items, {total_sp} SP in queue)
+| # | Issue | P | Summary | SP | Parent Epic |
+|---|-------|---|---------|----|----||
+
+### Sprint Fill Suggestions
+| # | Issue | Summary | Suggested Assignee | Score | Rationale |
+|---|-------|---------|-------------------|-------|-----------|
+
+*Suggestions are recommendations — team members self-select during planning.*
+
+### 🚨 Critical Customer Bugs (exempt from capacity)
+| Issue | Summary | Priority | Assignee |
+
+### 🔧 Retro Action Items (Continuous Improvement)
+| Issue | Summary | Status |
+```
+
+## Error Handling
+
+| Error | Action |
+|-------|--------|
+| Board ID not found | Ask user. List available boards via `acli jira board list`. |
+| No active sprint | "No active sprint found. Is the team between sprints?" |
+| No closed sprints (new team) | Skip velocity. Note: "No historical data — velocity unavailable." |
+| `issueSearchStable` fails | Fall back to REST `/rest/api/3/search`. |
+| Carryover query returns 0 | "Clean sprint — no carryover. Full velocity available." |
+
+## Caveats
+
+1. **Velocity is SP-based.** Teams with inconsistent SP estimation will see noisy trends. Fall back to issue count if SP coverage < 50%.
+2. **Sprint fill suggestions reuse assign.md scoring.** If expertise profiles aren't cached, this step adds ~5-10 API calls.
+3. **Bug SP exemption.** The doc says "every item needs story points or needs to be time-boxed." Bugs in the ready queue without SP are still shown but flagged.
+4. **Release Pending items stay in sprint.** Per team convention, Release Pending items remain in the sprint and count toward capacity.

--- a/skills/rhdh-jira/references/refine.md
+++ b/skills/rhdh-jira/references/refine.md
@@ -272,7 +272,8 @@ These are non-controversial changes applied without individual prompts:
 - Setting Story Points — needs estimation
 - Linking to parent Feature/Epic — needs selection from candidates
 - Marking as duplicate — destructive, needs confirmation
-- Closing stale issues — needs relevance confirmation
+- Closing stale issues — needs relevance confirmation. When closing, **always** add a comment documenting the rationale (e.g., "Closing as stale — no activity for 90 days, no longer on the roadmap") and set the resolution field (e.g., `Won't Do`, `Duplicate`, `Done`). This preserves the decision trail for future reference.
+- Marking as duplicate — same rule: add a comment linking to the original issue and set resolution to `Duplicate`
 
 For writes, follow the API preference order from SKILL.md. Since refinement uses GraphQL reads (AUTH is already set), prefer REST for writes.
 

--- a/skills/rhdh-jira/references/refine.md
+++ b/skills/rhdh-jira/references/refine.md
@@ -227,7 +227,7 @@ Checked: {issues_checked} issues | Findings: {issues_with_findings} issues
 
 | # | Issue | Last comment | By | Days ago |
 |---|-------|--------------|----|----------|
-| 1 | [RHIDP-5678](url) | "Can we use the new API?" | Jon Koops | 7 |
+| 1 | [RHIDP-5678](url) | "Can we use the new API?" | Allison Hill | 7 |
 
 ### ⏰ Stale Issues ({count})
 

--- a/skills/rhdh-jira/references/refine.md
+++ b/skills/rhdh-jira/references/refine.md
@@ -1,0 +1,295 @@
+# Issue Refinement
+
+Analyze issues for readiness, missing fields, duplicates, stale comments, and relevance. Produces a refinement report with actionable recommendations and optional auto-fixes.
+
+Uses GraphQL for bulk reads (skip acli). Writes follow the API preference order in SKILL.md.
+
+Authentication setup: see `references/auth.md`. All examples below assume `AUTH`, `CLOUD_ID`, and `GRAPHQL_URL` are set per that file.
+
+## Input
+
+The caller provides one of:
+
+1. **Issue key(s)** — one or more specific issues to refine
+2. **JQL query** — e.g., `"project = RHIDP AND sprint in openSprints() AND status = New"`
+3. **`sprint`** — shorthand for "all issues in the current sprint that need refinement"
+4. **`backlog`** — shorthand for "unrefined backlog issues for my team"
+
+If `sprint` or `backlog` is used, ask for the team ID (or infer from context).
+
+## Exit Criteria Reference
+
+Load `references/workflows.md` for the full exit criteria tables per issue type and status. That file is the single source of truth for required fields at each workflow stage.
+
+Key definitions used by the checks below:
+
+- **Unrefined** = Story Points empty AND not in a sprint AND status is New or Refinement.
+- **Ready for Planning** = Story Points set AND not in a sprint AND status is Backlog or To Do.
+- **Planned** = Story Points set AND in an open/future sprint AND status is To Do, In Progress, or Review AND assignee set.
+- **DoR** (Definition of Ready) = all exit criteria from entry statuses complete before moving to In Progress.
+- **DoD** (Definition of Done) = all exit criteria for all statuses complete before moving to Closed.
+
+## Refinement Checks
+
+Run all applicable checks for each issue. Use GraphQL `issueSearchStable` for bulk reads.
+
+### Check 1 — Missing Fields (Exit Criteria)
+
+For each issue, determine its type and current status. Look up the required fields from the exit criteria tables in `references/workflows.md`. Report any missing fields.
+
+GraphQL query to fetch issue data:
+
+```bash
+curl -s -u "$AUTH" "$GRAPHQL_URL" -X POST \
+  -H 'Content-Type: application/json' \
+  -H 'X-ExperimentalApi: JiraIssueSearch' \
+  -d '{
+    "query": "query RefineCheck { jira { issueSearchStable(cloudId: \"'"$CLOUD_ID"'\", issueSearchInput: {jql: \"JQL_HERE\"}, first: 50) { totalCount edges { node { key summary status { name } issueType { name } priority { name } assignee { name accountId } storyPoints parentIssue { key summary status { name } } fields { edges { node { __typename name ... on JiraComponentsField { components { edges { node { name } } } } ... on JiraSingleSelectField { fieldOption { value } } ... on JiraSprintField { selectedSprintsConnection { edges { node { name state } } } } ... on JiraLabelsField { labels { edges { node { name } } } } ... on JiraRichTextField { richText { adfValue { json } } } } } } } } } } }"
+  }'
+```
+
+For each issue, check:
+
+| Issue Type | Field | How to verify |
+|------------|-------|---------------|
+| All | Assignee | `assignee` is not null |
+| All | Priority | `priority.name` is not "Undefined" |
+| All | Component | At least one component in `JiraComponentsField` |
+| Feature/Epic | Team | Cannot be read via GraphQL — use REST fallback: `GET /rest/api/3/issue/{key}?fields=customfield_10001` |
+| Feature/Epic | Size | `JiraSingleSelectField` named "Size" has a value |
+| Story/Task/Bug | Story Points | `storyPoints` is not null |
+| Epic | Description | `JiraRichTextField` named "Description" is not empty |
+| Feature (Refinement+) | Candidate label | Labels include `rhdh-X.Y-candidate` pattern |
+| Feature (Backlog+) | Child Epics | Query `parent = {key}` to verify at least one Epic child exists |
+| Epic (To Do+) | Child Stories/Tasks | Query `parent = {key}` to verify children exist |
+
+### Check 2 — Duplicate Detection
+
+For each issue, search for potential duplicates:
+
+```bash
+# Search by similar summary keywords
+curl -s -u "$AUTH" "$GRAPHQL_URL" -X POST \
+  -H 'Content-Type: application/json' \
+  -H 'X-ExperimentalApi: JiraIssueSearch' \
+  -d '{
+    "query": "query FindDuplicates { jira { issueSearchStable(cloudId: \"'"$CLOUD_ID"'\", issueSearchInput: {jql: \"project in (RHIDP, RHDHPLAN, RHDHSUPP, RHDHBUGS) AND summary ~ \\\"KEYWORD1 KEYWORD2\\\" AND key != \\\"CURRENT_KEY\\\" AND status != Closed ORDER BY updated DESC\"}, first: 10) { edges { node { key summary status { name } assignee { name } } } } } }"
+  }'
+```
+
+Extract 2-3 distinctive keywords from the issue summary (skip stop words, project names, and generic terms like "update", "fix", "add"). If the search returns issues with high summary similarity:
+
+- **Exact match** (>80% word overlap): Flag as "likely duplicate — review before proceeding."
+- **Partial match** (40-80%): Flag as "possibly related — check for overlap."
+- **Low match** (<40%): Skip.
+
+Also check existing issue links for `Duplicate` link type — if already linked, note it and skip.
+
+### Check 3 — Parent/Hierarchy Integrity
+
+Verify the issue's position in the hierarchy:
+
+| Issue Type | Check | Action if missing |
+|------------|-------|-------------------|
+| Epic | Has a parent Feature in RHDHPLAN | "Epic has no parent Feature. Link to an existing Feature or create one." |
+| Story/Task | Has a parent Epic | "Story/Task has no parent Epic. Link to an existing Epic or create one." |
+| Feature | Has at least one child Epic (if status ≥ Backlog) | "Feature in Backlog+ has no child Epics. Create delivery Epics." |
+| Epic | Has at least one child Story/Task (if status ≥ To Do) | "Epic in To Do+ has no children. Break down into Stories/Tasks." |
+
+Query parent:
+
+```graphql
+parentIssue { key summary status { name } issueType { name } }
+```
+
+Query children:
+
+```bash
+jql: "parent = {key} AND status != Closed"
+```
+
+### Check 4 — Unaddressed Comments
+
+Fetch recent comments on each issue and check for unanswered questions or action items.
+
+```bash
+curl -s -u "$AUTH" \
+  "https://redhat.atlassian.net/rest/api/3/issue/ISSUE_KEY/comment?orderBy=-created&maxResults=5" \
+  -H "Accept: application/json"
+```
+
+Flag if:
+
+- The most recent comment is a **question** (contains `?`) and was not posted by the current assignee — "Unaddressed question from {author}, {N} days ago."
+- The most recent comment mentions **action items** (contains "TODO", "action item", "follow up", "next step") — "Unaddressed action item from {author}."
+- The last comment is older than 14 days on an In Progress issue — "Stale — no activity for {N} days."
+
+### Check 5 — Relevance and Staleness
+
+Flag issues that may no longer be relevant:
+
+| Condition | Flag |
+|-----------|------|
+| Status is New or Refinement AND `updated` > 90 days ago | "Stale in {status} for {N} days. Still relevant?" |
+| Status is In Progress AND `updated` > 30 days ago | "In Progress but no updates for {N} days. Blocked?" |
+| Fix Version is set to a released version AND status != Closed | "Fix version {version} is released but issue is still open." |
+| Linked upstream issue is closed but this issue is still open | "Upstream {link} is closed. Can this be closed too?" |
+
+For upstream checks, look at issue links with `outwardIssue` or `inwardIssue` containing GitHub URLs in comments or external links.
+
+### Check 6 — Sprint Readiness (when input is `sprint`)
+
+For issues in the current sprint, verify they meet the "Planned" criteria:
+
+- Story Points set
+- Assignee set
+- Status is To Do, In Progress, or Review
+- Component set
+
+Flag any sprint issue missing these as "not sprint-ready."
+
+## Output
+
+### Data Contract
+
+```json
+{
+  "issues_checked": 15,
+  "issues_with_findings": 8,
+  "findings": [
+    {
+      "key": "RHIDP-1234",
+      "summary": "Issue summary",
+      "status": "New",
+      "type": "Epic",
+      "checks": [
+        {
+          "check": "missing_fields",
+          "severity": "error",
+          "details": "Missing: Component, Size",
+          "auto_fixable": false
+        },
+        {
+          "check": "no_parent",
+          "severity": "warning",
+          "details": "Epic has no parent Feature in RHDHPLAN",
+          "auto_fixable": false
+        },
+        {
+          "check": "duplicate",
+          "severity": "info",
+          "details": "Possibly related to RHIDP-1100 (72% summary overlap)",
+          "auto_fixable": false
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "missing_fields": 5,
+    "duplicates": 2,
+    "hierarchy_gaps": 3,
+    "unaddressed_comments": 1,
+    "stale_issues": 2,
+    "sprint_not_ready": 4
+  },
+  "auto_fixable": [
+    {"key": "RHIDP-5678", "action": "set_priority", "value": "Major", "reason": "Parent epic is Major, child inherits"}
+  ]
+}
+```
+
+### Markdown Template
+
+```markdown
+## Refinement Report
+
+Checked: {issues_checked} issues | Findings: {issues_with_findings} issues
+
+### ❌ Missing Fields ({count})
+
+| # | Issue | Type | Status | Missing |
+|---|-------|------|--------|---------|
+| 1 | [RHIDP-1234](url) | Epic | New | Component, Size |
+
+### 🔄 Possible Duplicates ({count})
+
+| # | Issue | Possibly duplicates | Overlap |
+|---|-------|--------------------|---------|
+| 1 | [RHIDP-1234](url) | [RHIDP-1100](url) | 72% |
+
+### 🔗 Hierarchy Gaps ({count})
+
+| # | Issue | Type | Gap |
+|---|-------|------|-----|
+| 1 | [RHIDP-1234](url) | Epic | No parent Feature |
+
+### 💬 Unaddressed Comments ({count})
+
+| # | Issue | Last comment | By | Days ago |
+|---|-------|--------------|----|----------|
+| 1 | [RHIDP-5678](url) | "Can we use the new API?" | Jon Koops | 7 |
+
+### ⏰ Stale Issues ({count})
+
+| # | Issue | Status | Last updated | Flag |
+|---|-------|--------|-------------|------|
+| 1 | [RHIDP-9012](url) | New | 95 days ago | Still relevant? |
+
+### 🏃 Sprint Not Ready ({count})
+
+| # | Issue | Missing for sprint |
+|---|-------|--------------------|
+| 1 | [RHIDP-3456](url) | Story Points, Assignee |
+
+### Summary
+
+| Check | Count |
+|-------|-------|
+| Missing fields | {n} |
+| Possible duplicates | {n} |
+| Hierarchy gaps | {n} |
+| Unaddressed comments | {n} |
+| Stale issues | {n} |
+| Sprint not ready | {n} |
+```
+
+## Remediation
+
+After presenting the report:
+
+Use the standard confirmation flow from SKILL.md (`y/N/edit`). **y** applies auto-fixable changes and prompts for non-auto-fixable. **N** is report only.
+
+### Auto-fixable actions
+
+These are non-controversial changes applied without individual prompts:
+
+- Setting Priority to parent's priority when child has "Undefined"
+- Adding missing Component when parent Epic has exactly one component
+
+### Always requires user input
+
+- Setting Size (T-shirt) — needs estimation
+- Setting Story Points — needs estimation
+- Linking to parent Feature/Epic — needs selection from candidates
+- Marking as duplicate — destructive, needs confirmation
+- Closing stale issues — needs relevance confirmation
+
+For writes, follow the API preference order from SKILL.md. Since refinement uses GraphQL reads (AUTH is already set), prefer REST for writes.
+
+## Error Handling
+
+| Error | Action |
+|-------|--------|
+| `issueSearchStable` returns errors | See SKILL.md Error Handling. |
+| Comment fetch fails (REST 403) | Skip Check 4 for that issue. Note "comments not accessible." |
+| GraphQL rate limit (429) | Wait 5 seconds, retry once. If still fails, report partial results. |
+| JQL returns 0 results | "No issues match the query. Check the JQL or team/sprint filters." |
+| Issue type not recognized | Skip exit criteria check. Note "unknown issue type — skipped field validation." |
+
+## Caveats
+
+1. **Duplicate detection is keyword-based.** It catches obvious duplicates but misses semantically similar issues with different wording. When in doubt, flag as "possibly related" not "duplicate."
+2. **Comment analysis is heuristic.** Question detection (looking for `?`) has false positives (rhetorical questions, URLs with query params). Use as a signal, not a verdict.
+3. **Team field requires REST fallback.** GraphQL cannot reliably read team values from issues. When checking the Team field, make a REST call per issue: `GET /rest/api/3/issue/{key}?fields=customfield_10001`.
+4. **Exit criteria may evolve.** The field requirements are maintained in `references/workflows.md`. If the process changes, update that file.
+5. **Triage is automated separately.** The RHDH Triage Maintainer role is handled by an AI CronJob (`jira_triager_agent.py`) that sets Component, Team, and Priority on new issues. This refinement check complements triage — it validates deeper readiness, not initial routing.

--- a/skills/rhdh-jira/references/release.md
+++ b/skills/rhdh-jira/references/release.md
@@ -209,7 +209,7 @@ Synthesize a 1-paragraph risk assessment:
       "key": "RHDHPLAN-400",
       "summary": "...",
       "status": "In Progress",
-      "owner": "Hope Hadfield",
+      "owner": "Noah Rhodes",
       "team": "COPE",
       "size": "M",
       "stretch": false,
@@ -223,7 +223,7 @@ Synthesize a 1-paragraph risk assessment:
     {"source": "RHIDP-200", "source_team": "COPE", "target": "RHIDP-300", "target_team": "Install Method", "target_status": "New", "risk": "high"}
   ],
   "blocker_bugs": [
-    {"key": "RHDHBUGS-3100", "summary": "...", "assignee": "Martin Polasko", "days_stale": 5}
+    {"key": "RHDHBUGS-3100", "summary": "...", "assignee": "Connie Lawrence", "days_stale": 5}
   ],
   "stretch_features": ["RHDHPLAN-410"],
   "pm_blockers": ["RHDHPLAN-402"],

--- a/skills/rhdh-jira/references/release.md
+++ b/skills/rhdh-jira/references/release.md
@@ -1,0 +1,302 @@
+# Release Status
+
+Generate a release readiness report: feature status matrix, Program Increment funnel, epic roll-up, dependency map, blocker bugs, release notes readiness, and risk assessment. Replaces the standalone `rhdh-release-triage` skill — consolidates all release triage functionality into this sub-command.
+
+Supports quick mode (ceremony prep, ~5 API calls) and deep mode (full coherence analysis with per-feature assessment, ~20+ calls).
+
+Uses GraphQL for bulk reads (skip acli). Writes follow the API preference order in SKILL.md.
+
+Authentication setup: see `references/auth.md`. All examples below assume `AUTH`, `CLOUD_ID`, and `GRAPHQL_URL` are set per that file.
+
+## Input
+
+The caller provides:
+
+1. **Release version** — e.g., `2.1`, `1.10`. Matches against candidate labels (`rhdh-2.1-candidate`) and fix versions.
+2. **Team** — optional. If provided, filter to that team's Features/Epics only. If omitted, show all teams (program-level view).
+
+## Mode Selection
+
+> "Release status for {version}. **Quick** (ceremony prep, feature matrix + funnel) or **deep** (full coherence analysis, per-feature assessment)? [quick/deep]"
+
+Default to **quick** if not specified.
+
+## Quick Mode
+
+### Step 1 — Fetch Features
+
+Query RHDHPLAN Features with the candidate label or fix version. Replace `VERSION` with the target release version (e.g., `2.1`):
+
+```bash
+curl -s -u "$AUTH" "$GRAPHQL_URL" -X POST \
+  -H 'Content-Type: application/json' \
+  -H 'X-ExperimentalApi: JiraIssueSearch' \
+  -d '{
+    "query": "query ReleaseFeatures { jira { issueSearchStable(cloudId: \"'"$CLOUD_ID"'\", issueSearchInput: {jql: \"project = RHDHPLAN AND issuetype = Feature AND (labels = \\\"rhdh-VERSION-candidate\\\" OR fixVersion = \\\"VERSION\\\") ORDER BY priority ASC\"}, first: 50) { totalCount edges { node { key summary status { name } priority { name } assignee { name } storyPoints fields { edges { node { __typename name ... on JiraSingleSelectField { fieldOption { value } } ... on JiraLabelsField { labels { edges { node { name } } } } } } } } } } } }"
+  }'
+```
+
+For team field, use REST fallback per issue: `GET /rest/api/3/issue/{key}?fields=customfield_10001`
+
+### Step 2 — Program Increment Funnel
+
+Classify each Feature into PI release planning states based on its field values:
+
+| PI State | Condition |
+|----------|-----------|
+| **Candidate Definition** | Labels include `needs-pm` or `needs-info` |
+| **Defined but No Team** | Team field is empty |
+| **Exploration** | Size is empty OR assignee is empty |
+| **Ready for Commitment** | Size set, assignee set, has child Epics, fix version is empty |
+| **Fixversion Set** | Fix version is set (committed to release) |
+
+Show the funnel as a count breakdown:
+
+```markdown
+### Program Increment Funnel
+| Stage | Count | Features |
+|-------|-------|----------|
+| ⚠ Candidate Definition (blocked on PM) | 2 | RHDHPLAN-402, RHDHPLAN-410 |
+| ⚠ Defined but No Team | 1 | RHDHPLAN-415 |
+| 🔍 Exploration | 3 | ... |
+| ✅ Ready for Commitment | 2 | ... |
+| ✅ Fixversion Set | 4 | ... |
+```
+
+### Step 3 — Feature Status Matrix
+
+Map each Feature to its Jira workflow status with color coding:
+
+| Icon | Status range |
+|------|-------------|
+| 🔴 | New, Refinement |
+| 🟡 | Backlog |
+| 🟢 | In Progress |
+| ✅ | Release Pending, Closed |
+
+Include: key, summary, status, owner, team, size, stretch flag.
+
+### Step 4 — Stretch Features
+
+Features with `stretch` label listed separately as descope candidates. These are first to cut if the release is at risk.
+
+### Step 4b — Label Checks
+
+For each Feature, verify expected labels:
+
+| Label | Required when | Flag if missing |
+|-------|--------------|----------------|
+| `demo` | Customer-facing Feature | "Customer-facing Feature missing `demo` label — needs Feature Demo." |
+| `test-day` | Test Day candidate | Informational only — note if present. |
+| Documentation component | Feature requires docs | "No Documentation component — will Docs team create an Epic?" |
+
+### Step 5 — Readiness Score
+
+```
+readiness = (Features in In Progress or later) / total Features × 100
+```
+
+Breakdown by status bucket.
+
+### Step 6 — PM Blockers
+
+Features with `needs-pm` or `needs-info` labels surfaced prominently:
+
+```markdown
+### ⏳ Waiting on PM ({count})
+| Feature | Summary | Label | Days since label added |
+```
+
+## Deep Mode
+
+Includes everything from quick mode, plus:
+
+### Step 7 — Epic Roll-up
+
+For each Feature, query child Epics:
+
+```bash
+jql: "issuetype = Epic AND parent = {feature_key}"
+```
+
+If 0 results, retry with legacy Epic Link: `"Epic Link" = {feature_key}` (older data may use this instead of `parent`).
+
+Count Epics by status. Compute percent complete. Flag mismatches:
+
+- Feature is "In Progress" but no child Epics are in progress → "Stale Feature status"
+- Feature is "Backlog" but child Epics are "In Progress" → "Feature status behind Epics"
+
+Load `references/workflows.md` for the exit criteria validation on each Feature and Epic.
+
+### Step 8 — Dependency Map
+
+Scan `Blocks` and `Depend` issue links on Features and Epics. Filter to **cross-team and cross-project** dependencies only (same-team internal deps are noise).
+
+For each dependency:
+
+- Source issue (key, team, status)
+- Target issue (key, team, status)
+- Risk: is the blocker not started? Is it in a different team? Is it in a different project?
+
+```markdown
+### Dependencies (cross-team)
+| Source | Depends on | Target Team | Target Status | Risk |
+|--------|-----------|-------------|---------------|------|
+| RHIDP-200 (COPE) | RHIDP-300 | Install Method | New | 🔴 not started |
+```
+
+### Step 9 — Blocker/Critical Bugs
+
+Bugs in RHDHBUGS with the release fix version and priority Blocker or Critical:
+
+```bash
+jql: "project = RHDHBUGS AND priority in (Blocker, Critical) AND fixVersion = VERSION AND status != Closed"
+```
+
+Include: key, summary, status, assignee, days since last update.
+
+### Step 10 — Release Notes Readiness
+
+For Features and Epics in Release Pending or Closed, check:
+
+- Release Note Type (`customfield_10785`) is set
+- Release Note Text (`customfield_10783`) is set
+
+Flag missing: "RN fields not set — required before closing."
+
+### Step 11 — Per-Feature Coherence Analysis
+
+For each Feature, assess:
+
+1. Are exit criteria met for current status? (reference `workflows.md`)
+2. Are all child Epics sized?
+3. Are child Epics assigned to teams?
+4. Are there child Epics without Stories/Tasks (if Epic is in To Do+)?
+5. Is there a Design Doc or RFE link (if Feature is in Refinement+)?
+
+Produce a coherence score per Feature: `checks_passed / total_checks × 100`.
+
+### Step 12 — Risk Assessment
+
+Synthesize a 1-paragraph risk assessment:
+
+- How many Features are blocked (on PM, on dependencies, on bugs)?
+- What's the readiness score?
+- Are there stale Features (New status, no activity)?
+- Stretch feature count vs committed count
+- Recommend: specific actions (assign, descope, escalate)
+
+## Output
+
+### Data Contract
+
+```json
+{
+  "version": "2.1",
+  "team": null,
+  "mode": "deep",
+  "feature_count": 12,
+  "readiness_score": 67,
+  "pi_funnel": {
+    "candidate_definition": ["RHDHPLAN-402"],
+    "no_team": ["RHDHPLAN-415"],
+    "exploration": ["RHDHPLAN-420", "RHDHPLAN-421"],
+    "ready_for_commitment": ["RHDHPLAN-430"],
+    "fixversion_set": ["RHDHPLAN-400", "RHDHPLAN-401"]
+  },
+  "features": [
+    {
+      "key": "RHDHPLAN-400",
+      "summary": "...",
+      "status": "In Progress",
+      "owner": "Hope Hadfield",
+      "team": "COPE",
+      "size": "M",
+      "stretch": false,
+      "epic_count": 4,
+      "epics_complete": 3,
+      "coherence_score": 85,
+      "rn_ready": true
+    }
+  ],
+  "dependencies": [
+    {"source": "RHIDP-200", "source_team": "COPE", "target": "RHIDP-300", "target_team": "Install Method", "target_status": "New", "risk": "high"}
+  ],
+  "blocker_bugs": [
+    {"key": "RHDHBUGS-3100", "summary": "...", "assignee": "Martin Polasko", "days_stale": 5}
+  ],
+  "stretch_features": ["RHDHPLAN-410"],
+  "pm_blockers": ["RHDHPLAN-402"],
+  "rn_missing": ["RHIDP-500"],
+  "risk_assessment": "67% readiness. 1 Feature in New with no owner. 2 Blocker bugs. Recommend: assign RHDHPLAN-402 or descope."
+}
+```
+
+### Markdown Template
+
+```markdown
+## Release Status — RHDH {version}
+
+Features: {count} | Readiness: {score}% | Mode: {mode}
+
+### Program Increment Funnel
+| Stage | Count | Features |
+|-------|-------|----------|
+
+### Feature Matrix
+| # | Feature | Status | Owner | Team | Size | Epics | Stretch |
+|---|---------|--------|-------|------|------|-------|---------|
+
+### ⏳ Waiting on PM ({count})
+| Feature | Summary | Label | Days |
+
+### 🔗 Dependencies — cross-team (deep only)
+| Source | Depends on | Target Team | Status | Risk |
+
+### 🐛 Blocker Bugs ({count})
+| Bug | Summary | Assignee | Days stale |
+
+### 📝 Release Notes Missing ({count}) (deep only)
+| Issue | Type | Missing |
+
+### 📊 Stretch Features (descope candidates)
+| Feature | Summary | Owner | Status |
+
+### Risk Assessment
+{risk_paragraph}
+```
+
+## Remediation
+
+After presenting the report:
+
+> "Fix issues? [y/N/edit]"
+
+**⚠ Automation warning:** Setting fix version on a Feature cascades to all child Epics automatically (Jira automation rule). Setting Epic status also cascades to parent Feature. See `references/workflows.md` Automation Rules. Warn the user before applying fix version changes.
+
+Available actions (all require user confirmation):
+
+- **Set fix version** on Features in "Ready for Commitment" (cascades to child Epics)
+- **Create missing Epics** (Eng, QE, Doc) for Features in Backlog+
+- **Transition Feature status** when exit criteria are met
+- **Assign owner** to unassigned Features (invokes `assign` sub-command)
+- **Add missing RN fields** — prompt user for Release Note Type and Text
+
+## Error Handling
+
+| Error | Action |
+|-------|--------|
+| No Features match version/label | "No Features found. Check version name or label." |
+| RHDHPLAN inaccessible | Stop. User lacks project access. |
+| RHIDP inaccessible | Warn. Continue without Epic data. |
+| Team field REST call fails | Skip team filtering. Show all Features. |
+| Epic query returns 0 children | Note "no child Epics" — this is a finding, not an error. |
+| `issueSearchStable` fails | Fall back to REST. |
+
+## Caveats
+
+1. **Intended to replace `rhdh-release-triage`.** This sub-command covers ceremony prep (PI funnel, feature matrix, readiness score) and most deep analysis. For detailed per-feature checklists (15+ checks), Mermaid diagrams, and run history trending, the standalone `rhdh-release-triage` skill remains more thorough until feature parity is reached.
+2. **Team field requires REST fallback.** One REST call per Feature for team data. For 12 Features, this is 12 extra calls in quick mode.
+3. **Coherence analysis is deep-mode only.** Quick mode skips per-feature exit criteria validation and epic child checks.
+4. **PI funnel states are computed, not stored.** Jira doesn't have a "PI State" field — the funnel is derived from field values (labels, size, assignee, fix version).
+5. **Cross-team dependency detection requires issue links.** Features/Epics without `Blocks`/`Depend` links won't show in the dependency map even if real dependencies exist.

--- a/skills/rhdh-jira/references/release.md
+++ b/skills/rhdh-jira/references/release.md
@@ -1,6 +1,6 @@
 # Release Status
 
-Generate a release readiness report: feature status matrix, Program Increment funnel, epic roll-up, dependency map, blocker bugs, release notes readiness, and risk assessment. Replaces the standalone `rhdh-release-triage` skill — consolidates all release triage functionality into this sub-command.
+Generate a release readiness report: feature status matrix, Program Increment funnel, epic roll-up, dependency map, blocker bugs, release notes readiness, and risk assessment.
 
 Supports quick mode (ceremony prep, ~5 API calls) and deep mode (full coherence analysis with per-feature assessment, ~20+ calls).
 
@@ -295,7 +295,7 @@ Available actions (all require user confirmation):
 
 ## Caveats
 
-1. **Intended to replace `rhdh-release-triage`.** This sub-command covers ceremony prep (PI funnel, feature matrix, readiness score) and most deep analysis. For detailed per-feature checklists (15+ checks), Mermaid diagrams, and run history trending, the standalone `rhdh-release-triage` skill remains more thorough until feature parity is reached.
+1. **Deep mode coverage.** This sub-command covers ceremony prep (PI funnel, feature matrix, readiness score) and most deep analysis. For more detailed per-feature checklists, Mermaid diagram generation, and run history trending, consider extending this sub-command.
 2. **Team field requires REST fallback.** One REST call per Feature for team data. For 12 Features, this is 12 extra calls in quick mode.
 3. **Coherence analysis is deep-mode only.** Quick mode skips per-feature exit criteria validation and epic child checks.
 4. **PI funnel states are computed, not stored.** Jira doesn't have a "PI State" field — the funnel is derived from field values (labels, size, assignee, fix version).

--- a/skills/rhdh-jira/references/sprint-report.md
+++ b/skills/rhdh-jira/references/sprint-report.md
@@ -137,7 +137,7 @@ Format as Slack mrkdwn and offer to post to the team channel. Use `slack_convers
   "scope_creep": {"count": 2, "sp": 4},
   "completion_rate": 86,
   "per_member": [
-    {"name": "Jon Koops", "closed": 4, "sp_done": 8, "carried": 1, "sp_carry": 3}
+    {"name": "Allison Hill", "closed": 4, "sp_done": 8, "carried": 1, "sp_carry": 3}
   ],
   "epic_progress": [
     {"key": "RHIDP-100", "summary": "Dynamic plugins v2", "closed_this_sprint": 3, "total": 8, "pct_before": 37, "pct_after": 75}

--- a/skills/rhdh-jira/references/sprint-report.md
+++ b/skills/rhdh-jira/references/sprint-report.md
@@ -1,0 +1,207 @@
+# Sprint Report
+
+Generate a sprint review summary: committed vs completed, per-member breakdown, epic progress, demo checklist with naming conventions, and velocity trend. Run at the end of each sprint before the review/demo meeting.
+
+Uses GraphQL for bulk reads (skip acli). Writes follow the API preference order in SKILL.md.
+
+Authentication setup: see `references/auth.md`. All examples below assume `AUTH`, `CLOUD_ID`, and `GRAPHQL_URL` are set per that file.
+
+## Input
+
+The caller provides:
+
+1. **Team ID** — Jira team UUID. If not provided, ask.
+2. **Sprint** — defaults to active sprint. Accept `previous` for last closed sprint, or a sprint name/ID.
+3. **Board ID** — optional. If not provided, discover or ask.
+
+## Workflow
+
+### Step 1 — Resolve Sprint
+
+Find the target sprint:
+
+```bash
+# Active sprint (default)
+acli jira board list-sprints --board BOARD_ID --state active --json
+
+# Previous sprint
+acli jira board list-sprints --board BOARD_ID --state closed --json --recent 1
+```
+
+Extract: sprint ID, name, start date, end date.
+
+### Step 2 — Fetch All Sprint Issues
+
+Get every issue that was in the sprint:
+
+```bash
+curl -s -u "$AUTH" "$GRAPHQL_URL" -X POST \
+  -H 'Content-Type: application/json' \
+  -H 'X-ExperimentalApi: JiraIssueSearch' \
+  -d '{
+    "query": "query SprintIssues { jira { issueSearchStable(cloudId: \"'"$CLOUD_ID"'\", issueSearchInput: {jql: \"project in (RHIDP, RHDHPLAN, RHDHSUPP, RHDHBUGS) AND sprint = SPRINT_ID AND \\\"Team[Team]\\\" = TEAM_ID\"}, first: 100) { totalCount edges { node { key summary status { name } issueType { name } priority { name } assignee { name accountId } storyPoints parentIssue { key summary } fields { edges { node { __typename name ... on JiraLabelsField { labels { edges { node { name } } } } ... on JiraSprintField { selectedSprintsConnection { edges { node { name state startDate } } } } } } } } } } } }"
+  }'
+```
+
+### Step 3 — Partition Issues
+
+Split into categories:
+
+| Category | Condition |
+|----------|-----------|
+| **Completed** | Status is Closed or Release Pending |
+| **Carried over** | Status is anything else (In Progress, To Do, Review, etc.) |
+| **Added mid-sprint** | Issue's sprint start date is after the sprint's start date (scope creep) |
+
+### Step 4 — Committed vs Completed
+
+| Metric | Computation |
+|--------|-------------|
+| Committed SP | Sum SP of all sprint issues (completed + carried) |
+| Completed SP | Sum SP of completed issues only |
+| Completion rate | `completed_sp / committed_sp × 100` |
+| Scope creep | Count and SP of mid-sprint additions |
+
+Flag if completion rate < 70%: "⚠ Below 70% completion — review sprint commitments."
+Note if > 100%: "Team completed more than committed — pulled in extra work."
+
+### Step 5 — Per-Member Breakdown
+
+Group issues by assignee. For each team member:
+
+- Issues closed (count)
+- SP completed
+- Issues carried over (count)
+- SP carried over
+
+Highlight: top contributor (most SP completed), anyone with 0 completions (may be blocked, on PTO, or doing non-Jira work — don't assume negatively).
+
+### Step 6 — Epic Progress
+
+Group completed work by parent Epic (`parentIssue`). For each Epic with at least one completed child:
+
+1. Count total children (query: `parent = {epic_key}` — include ALL statuses for the denominator)
+2. Count closed children (filter to `status in (Closed, "Release Pending")`)
+3. Compute: "X/Y stories closed this sprint ({before}% → {after}% complete)"
+
+### Step 7 — Demo Checklist
+
+Find issues with `demo` label. For each:
+
+1. Check if the parent Feature (in RHDHPLAN) has a Feature Demo link set
+2. Generate the expected naming conventions:
+   - **Demo file:** `${SPRINT_NUMBER} ${JIRA_Project}-${JIRA_NUMBER} ${DEMO_TITLE}`
+   - **Slide:** `${SPRINT_NUMBER} ${Team name} Review`
+3. Suggest demo venue:
+   - **Sprint Review** — customer-facing features
+   - **Team Forum** — team-related demos
+   - **Architecture Call** — deep technical topics
+
+Flag missing demo links: "❌ Demo required but no Feature Demo link set on parent Feature."
+
+### Step 8 — Velocity Trend
+
+Fetch last 3 closed sprints. For each, sum SP of Closed/Release Pending issues (same query pattern as plan.md Step 3 — duplicated here to avoid transitive loading):
+
+```bash
+acli jira board list-sprints --board BOARD_ID --state closed --json --recent 3
+```
+
+Then for each closed sprint:
+
+```bash
+jql: "project in (RHIDP, RHDHPLAN, RHDHSUPP, RHDHBUGS)
+  AND sprint = SPRINT_ID
+  AND status in (Closed, \"Release Pending\")
+  AND \"Team[Team]\" = TEAM_ID"
+```
+
+Compute this sprint's velocity vs 3-sprint average. Show trend (↑ accelerating / → stable / ↓ decelerating).
+
+### Step 9 — Optional: Post to Slack
+
+Format as Slack mrkdwn and offer to post to the team channel. Use `slack_conversations_add_message` if Slack MCP is connected. Follow Slack formatting rules from the hygiene dashboard (no markdown bold, use `<url|text>` for links, `<@USERID>` for mentions).
+
+## Output
+
+### Data Contract
+
+```json
+{
+  "team": "RHDH Cope",
+  "sprint": "Sprint 47",
+  "period": "May 7–20, 2026",
+  "committed": {"count": 14, "sp": 21},
+  "completed": {"count": 11, "sp": 18},
+  "carried_over": {"count": 3, "sp": 5},
+  "scope_creep": {"count": 2, "sp": 4},
+  "completion_rate": 86,
+  "per_member": [
+    {"name": "Jon Koops", "closed": 4, "sp_done": 8, "carried": 1, "sp_carry": 3}
+  ],
+  "epic_progress": [
+    {"key": "RHIDP-100", "summary": "Dynamic plugins v2", "closed_this_sprint": 3, "total": 8, "pct_before": 37, "pct_after": 75}
+  ],
+  "demos": [
+    {"key": "RHIDP-1234", "summary": "...", "demo_link_set": true, "file_name": "3247 RHIDP-1234 Demo title", "venue": "Sprint Review"}
+  ],
+  "velocity": {
+    "this_sprint": 18,
+    "average": 18,
+    "trend": "stable"
+  }
+}
+```
+
+### Markdown Template
+
+```markdown
+## Sprint Report — {team} {sprint}
+
+Period: {start} – {end}
+
+### Summary
+| Metric | Value |
+|--------|-------|
+| Committed | {committed_sp} SP ({committed_count} items) |
+| Completed | {completed_sp} SP ({completed_count} items) |
+| Carried over | {carried_sp} SP ({carried_count} items) |
+| Added mid-sprint | {scope_count} items ({scope_sp} SP) |
+| Completion rate | {rate}% {icon} |
+
+### Per-Member
+| Member | Closed | SP Done | Carried | SP Carry |
+|--------|--------|---------|---------|----------|
+
+### Epic Progress
+| Epic | Summary | This Sprint | Overall |
+|------|---------|-------------|---------|
+
+### Demo Items
+| # | Issue | Summary | Demo Link | File Name | Venue |
+|---|-------|---------|-----------|-----------|-------|
+
+**Slide name:** `{sprint_number} {team} Review`
+
+### Velocity Trend
+| Sprint | SP | vs Avg |
+|--------|----|--------|
+{sprint}: {sp} SP | 3-sprint avg: {avg} SP | Trend: {trend}
+```
+
+## Error Handling
+
+| Error | Action |
+|-------|--------|
+| No active/closed sprint found | "No sprint found for this board. Check board ID." |
+| Sprint has 0 issues | "Empty sprint. Was work tracked elsewhere?" |
+| Parent Epic query fails | Skip epic progress for that issue. Note "parent unavailable." |
+| Demo label but no parent Feature | Note "Demo item has no parent Feature — cannot check demo link." |
+| Slack MCP not connected | Skip Slack posting. Suggest copy-paste. |
+
+## Caveats
+
+1. **Scope creep detection is approximate.** It checks if the issue's sprint assignment date is after the sprint start. Issues moved between sprints may show false positives.
+2. **Per-member breakdown only shows Jira-tracked work.** Code reviews, documentation, support, and meetings don't appear. Note this in the report.
+3. **Demo venue routing is a suggestion.** Based on the issue type and labels, not a hard rule.
+4. **Release Pending counts as completed.** Per team convention, Release Pending items remain in sprint and are counted as "done" for velocity.

--- a/skills/rhdh-jira/references/sprint-report.md
+++ b/skills/rhdh-jira/references/sprint-report.md
@@ -118,9 +118,13 @@ jql: "project in (RHIDP, RHDHPLAN, RHDHSUPP, RHDHBUGS)
 
 Compute this sprint's velocity vs 3-sprint average. Show trend (↑ accelerating / → stable / ↓ decelerating).
 
-### Step 9 — Optional: Post to Slack
+### Step 9 — Save Report
 
-Format as Slack mrkdwn and offer to post to the team channel. Use `slack_conversations_add_message` if Slack MCP is connected. Follow Slack mrkdwn formatting rules: use `*bold*` not `**bold**`, `<url|text>` for links, `<@USERID>` for mentions, and `content_type: text/plain`.
+Offer to save the report as a markdown file:
+
+> "Save report as markdown? [y/N]"
+
+If yes, save to `sprint-report-{team}-{sprint}-{YYYY-MM-DD}.md` in the current working directory. Accept a custom path if the user provides one.
 
 ## Output
 
@@ -197,7 +201,7 @@ Period: {start} – {end}
 | Sprint has 0 issues | "Empty sprint. Was work tracked elsewhere?" |
 | Parent Epic query fails | Skip epic progress for that issue. Note "parent unavailable." |
 | Demo label but no parent Feature | Note "Demo item has no parent Feature — cannot check demo link." |
-| Slack MCP not connected | Skip Slack posting. Suggest copy-paste. |
+| File save fails | Warn. Report was already displayed in terminal. |
 
 ## Caveats
 

--- a/skills/rhdh-jira/references/sprint-report.md
+++ b/skills/rhdh-jira/references/sprint-report.md
@@ -120,7 +120,7 @@ Compute this sprint's velocity vs 3-sprint average. Show trend (↑ accelerating
 
 ### Step 9 — Optional: Post to Slack
 
-Format as Slack mrkdwn and offer to post to the team channel. Use `slack_conversations_add_message` if Slack MCP is connected. Follow Slack formatting rules from the hygiene dashboard (no markdown bold, use `<url|text>` for links, `<@USERID>` for mentions).
+Format as Slack mrkdwn and offer to post to the team channel. Use `slack_conversations_add_message` if Slack MCP is connected. Follow Slack mrkdwn formatting rules: use `*bold*` not `**bold**`, `<url|text>` for links, `<@USERID>` for mentions, and `content_type: text/plain`.
 
 ## Output
 

--- a/skills/rhdh-jira/scripts/command-metadata.json
+++ b/skills/rhdh-jira/scripts/command-metadata.json
@@ -1,0 +1,27 @@
+{
+  "assign": {
+    "description": "Recommend and assign team members to unassigned issues using expertise, capacity, and context proximity analysis.",
+    "argumentHint": "[issue key(s) or JQL query]",
+    "reference": "references/assign.md"
+  },
+  "refine": {
+    "description": "Check issues against exit criteria, identify duplicates, missing fields, unaddressed comments, and readiness for the next status.",
+    "argumentHint": "[issue key(s), JQL query, or 'sprint' for current sprint]",
+    "reference": "references/refine.md"
+  },
+  "plan": {
+    "description": "Sprint planning prep: carryover, velocity, capacity, ready-for-planning queue, and sprint fill suggestions. Run before each planning call.",
+    "argumentHint": "[team name or ID]",
+    "reference": "references/plan.md"
+  },
+  "sprint-report": {
+    "description": "Sprint review summary: committed vs completed, per-member breakdown, epic progress, demo checklist with naming conventions, velocity trend.",
+    "argumentHint": "[team] or [team previous]",
+    "reference": "references/sprint-report.md"
+  },
+  "release": {
+    "description": "Release readiness: feature matrix, PI funnel, epic roll-up, dependency map, blocker bugs, RN readiness, risk assessment. Replaces rhdh-release-triage.",
+    "argumentHint": "[version] or [version team]",
+    "reference": "references/release.md"
+  }
+}

--- a/skills/rhdh-jira/scripts/command-metadata.json
+++ b/skills/rhdh-jira/scripts/command-metadata.json
@@ -20,7 +20,7 @@
     "reference": "references/sprint-report.md"
   },
   "release": {
-    "description": "Release readiness: feature matrix, PI funnel, epic roll-up, dependency map, blocker bugs, RN readiness, risk assessment. Replaces rhdh-release-triage.",
+    "description": "Release readiness: feature matrix, PI funnel, epic roll-up, dependency map, blocker bugs, RN readiness, risk assessment.",
     "argumentHint": "[version] or [version team]",
     "reference": "references/release.md"
   }

--- a/skills/skill-maker/SKILL.md
+++ b/skills/skill-maker/SKILL.md
@@ -70,6 +70,14 @@ Follow progressive disclosure — three loading levels:
 
 Keep the SKILL.md body under 500 lines. If approaching this limit, split domain-specific content into `references/` files with clear pointers about when to read them.
 
+### Deduplication check
+
+Before writing domain knowledge into a new reference file, check if it already exists in another reference. Shared data (exit criteria, field mappings, workflow rules) must live in exactly one file. New references should point to the existing source — not embed a copy.
+
+Common trap: a new sub-command reference duplicates tables from an existing reference because it "needs them for context." Instead, add a one-line pointer: "Load `references/workflows.md` for exit criteria per status."
+
+**Exception: intentional duplication.** When two sub-commands need the same query pattern but referencing each other would create a transitive loading chain (A → B → C), duplicate the pattern and add a note: "Same query pattern as X.md Step N — duplicated here to avoid transitive loading." This is cheaper than forcing the agent to load an unrelated file.
+
 ### Writing patterns
 
 - **Imperative form**: "Run the command" not "You should run the command"
@@ -79,6 +87,7 @@ Keep the SKILL.md body under 500 lines. If approaching this limit, split domain-
 - **Checklists**: Multi-step workflows with validation gates
 - **Conditional loading**: "Read `references/api-errors.md` if the API returns a non-200 status code" — not "see references/ for details"
 - **Absolute bans**: When certain patterns are always wrong, use match-and-refuse lists. "If you're about to write X, stop and do Y instead." More effective than vague "be careful" guidance.
+- **Avoid hardcoded thresholds**: Don't write arbitrary numbers as rules (e.g., "when you have 3+ sub-commands" or "if more than 5 issues") unless the threshold comes from a real constraint (API limit, spec requirement). Instead, describe the signal that triggers the behavior (e.g., "when you're copying the same text into another sub-command"). Hardcoded numbers feel authoritative but are usually guesses that don't generalize.
 
 ### Sub-command router (when applicable)
 

--- a/skills/skill-maker/references/api-skill-patterns.md
+++ b/skills/skill-maker/references/api-skill-patterns.md
@@ -74,6 +74,30 @@ Do not write API examples from memory or documentation alone. Run them against t
 
 This is especially important for GraphQL APIs where field names are typed and case-sensitive — `displayName` vs `name`, `parent` vs `parentIssue`, `sprint` vs `selectedSprintsConnection` can all differ from what you'd guess.
 
+## Multi-API preference order
+
+When a skill wraps multiple APIs (e.g., CLI + GraphQL + REST), define the preference order once in SKILL.md. Sub-commands reference it instead of each explaining when to use which API.
+
+**Pattern:**
+
+```markdown
+### API preference order
+
+All operations follow this priority: **CLI → GraphQL → REST API**.
+
+- **CLI** — default for simple, single-issue operations.
+- **GraphQL** — for bulk reads where CLI would be too slow. Skip CLI entirely for bulk.
+- **REST API** — for writes when already in an authenticated API context (avoid shelling out to CLI mid-workflow), or as fallback when CLI fails.
+
+Sub-commands document which API they use. When a sub-command's workflow already has auth set from GraphQL reads, prefer REST for writes.
+```
+
+Sub-commands then say: "Writes follow the API preference order in SKILL.md" instead of repeating the decision logic.
+
+**Key heuristic: skip the CLI for bulk operations.** If a workflow needs 10+ API calls (e.g., building expertise profiles across a team), go straight to GraphQL or REST. The CLI's per-call overhead (process spawn, auth handshake) makes it impractical for bulk.
+
+**Context-aware write selection.** When reads already established an authenticated API session (e.g., GraphQL set up `AUTH` from a token file), prefer the same auth mechanism for writes rather than shelling out to the CLI.
+
 ## Instance-specific values
 
 Any value that is specific to a deployment (instance URL, tenant ID, cloud ID, org name) must include a programmatic discovery method.

--- a/skills/skill-maker/references/architecture-patterns.md
+++ b/skills/skill-maker/references/architecture-patterns.md
@@ -10,6 +10,23 @@ Use when the skill has **multiple distinct operations** that share setup, contex
 
 Do NOT use when the operations have no shared context. Separate skills are better when each task is fully independent.
 
+### Evolving from reference files to a router
+
+Skills often start with standalone reference files (e.g., `references/assign.md`) loaded on demand. Upgrade to a router table when:
+
+- You have multiple distinct operations and expect to add more
+- Operations share setup gates, auth, or domain context
+- Users need a discoverable menu of what the skill can do
+
+Migration path:
+
+1. Keep existing reference files as-is — they become command references
+2. Add the router table and routing rules to SKILL.md
+3. Create `scripts/command-metadata.json` as the single source of truth
+4. Add a "Common Workflows" section that maps user intents to commands
+
+Do not delay the migration until the skill is "complete" — add the router as soon as the pattern is clear. Retrofitting is cheap.
+
 ### Structure
 
 The SKILL.md contains:
@@ -20,6 +37,30 @@ The SKILL.md contains:
 4. **Routing rules** — how to interpret user input
 
 Each command gets its own `references/<command>.md` file. The SKILL.md never contains command-specific instructions — it delegates.
+
+### Cross-cutting conventions
+
+When multiple sub-commands share interaction patterns, error handling rows, or domain rules, centralize them in SKILL.md under a dedicated section (e.g., "Conventions" or "Shared Rules"). Sub-commands reference them instead of repeating.
+
+The signal to centralize: you're copying the same text into another sub-command and realizing a change would require updating multiple files.
+
+Common candidates for centralization:
+
+- **Confirmation flow**: `"Apply changes? [y/N/edit]"` — define once, sub-commands say "use the standard confirmation flow from SKILL.md."
+- **Error rows**: If the same error/action row appears across sub-commands' error tables, move it to SKILL.md's Error Handling table. Sub-commands say "See SKILL.md Error Handling."
+- **Domain conventions**: Team-specific rules that apply everywhere (e.g., "Release Pending counts as completed for velocity"). State once in SKILL.md.
+
+### Data flow between sub-commands
+
+When sub-commands reuse each other's analysis (e.g., sprint planning reuses assignee expertise profiles), document the data flow in SKILL.md's Common Workflows section:
+
+```markdown
+> Sub-commands share data. `plan` reuses roster/capacity from `assign`.
+> `sprint-report` uses the same velocity pattern as `plan`.
+> `release` references exit criteria from `workflows.md` and can invoke `assign`.
+```
+
+This tells the agent which references to load together and prevents redundant API calls when running sub-commands in sequence.
 
 ### Router table pattern
 


### PR DESCRIPTION
## Summary

Adds a sub-command router and 5 workflow references to the rhdh-jira skill, covering all applicable Scrum ceremonies for the RHDH team. Also updates the skill-maker skill with patterns learned during development.

## rhdh-jira: New sub-commands

| Command | Ceremony | Description |
|---------|----------|-------------|
| `assign` | Any time | 5-layer deep assignee analysis: team roster (GraphQL `team.teamV2`), expertise profiling, sprint capacity, soft signals (bus factor, growth), context proximity |
| `refine` | Backlog Refinement | 6-check refinement: missing fields per exit criteria, duplicates, hierarchy integrity, unaddressed comments, staleness, sprint readiness |
| `plan` | Sprint Planning | Carryover report, velocity trend, per-member capacity, ready-for-planning queue, sprint fill suggestions, critical customer bugs, retro action items |
| `sprint-report` | Sprint Review/Demo | Committed vs completed, per-member breakdown, epic progress, demo checklist with naming conventions and venue routing |
| `release` | Feature Refinement + SOS | PI funnel states, feature matrix, epic roll-up, cross-team dependency map, blocker bugs, RN readiness, risk assessment. Intended to replace `rhdh-release-triage` |

## Architecture

- **Sub-command router** with `scripts/command-metadata.json` as single source of truth
- **API preference order**: acli → GraphQL → REST API (skip acli for bulk operations)
- **Cross-cutting conventions** centralized in SKILL.md (confirmation flow, error handling, team conventions)
- **Data flow documentation** between sub-commands (plan reuses assign capacity, sprint-report shares velocity pattern, release invokes assign)
- **Exit criteria single-sourced** in `references/workflows.md` — refine and release point to it

## Key GraphQL discoveries

- `team.teamV2(id, siteId)` returns full team roster directly — no REST Teams API needed
- `JiraComponentsField` fragment works: `components { edges { node { name } } }`
- `JiraTeamViewField.selectedTeam.fullTeam.members` returns roster via issue context
- No GraphQL mutation exists for issue assignment — acli/REST for writes
- `"Team[Team]" = {teamId}` works in JQL (corrected Gotcha 5)

## skill-maker updates

- **Deduplication check** with intentional duplication exception (avoid transitive loading)
- **Avoid hardcoded thresholds** writing pattern — describe the signal, not an arbitrary number
- **Multi-API preference order** pattern for skills wrapping CLI + GraphQL + REST
- **Router evolution** guidance — when and how to upgrade from reference files
- **Cross-cutting conventions** and **data flow documentation** patterns

## Reviewed by

Two specialized reviewer agents (2 rounds each):
- **Skills expert** — spec compliance, architecture, reference independence, description optimization
- **Agile/Scrum expert** — ceremony coverage, workflow alignment with RHDH Agile process, output practicality

## Files changed

**New (6):**
- `references/assign.md` (269 lines)
- `references/refine.md` (298 lines)
- `references/plan.md` (219 lines)
- `references/sprint-report.md` (207 lines)
- `references/release.md` (296 lines)
- `scripts/command-metadata.json`

**Modified (7):**
- `SKILL.md` — router, API preference, conventions, workflows, description
- `references/auth.md` — GRAPHQL_URL, ORG_ID with discovery
- `references/graphql-queries.md` — team roster query, field types, 3-way API table
- `skills/skill-maker/SKILL.md` — dedup exception, hardcoded thresholds
- `skills/skill-maker/references/api-skill-patterns.md` — multi-API pattern
- `skills/skill-maker/references/architecture-patterns.md` — router evolution, conventions, data flow
- `README.md` — all 5 sub-commands documented