### PR TITLE
feat(skill-maker): add audit workflow, anti-patterns, templates, and writing improvements

### DIFF
--- a/skills/skill-maker/SKILL.md
+++ b/skills/skill-maker/SKILL.md
@@ -1,13 +1,79 @@
 ---
 name: skill-maker
-description: Create new agent skills or consolidate existing skills following the Agent Skills open standard (agentskills.io). Interviews the user relentlessly about intent, scope, and edge cases before drafting. Covers SKILL.md structure, frontmatter, progressive disclosure, description optimization, script bundling, sub-command architecture, setup gates, context systems, and review. Use when the user wants to create a skill, write a skill, build a new skill, make a skill, draft a SKILL.md, or mentions "skill-maker". Also use when asked to package expertise, workflows, or domain knowledge into a reusable skill. Also use when asked to consolidate skills, merge skills, combine skills, reduce skill count, or refactor multiple skills into one.
+description: Create, audit, or consolidate agent skills following the Agent Skills open standard (agentskills.io). Interviews the user relentlessly about intent, scope, and edge cases before drafting. Covers SKILL.md structure, frontmatter, progressive disclosure, description optimization, script bundling, sub-command architecture, setup gates, context systems, and review. Use when the user wants to create a skill, write a skill, build a new skill, make a skill, draft a SKILL.md, or mentions "skill-maker". Also use when asked to review a skill, audit a SKILL.md, check why a skill never triggers, improve an existing skill, or fix a skill. Also use when asked to package expertise, workflows, or domain knowledge into a reusable skill. Also use when asked to consolidate skills, merge skills, combine skills, reduce skill count, or refactor multiple skills into one.
 ---
 
-# Create or Consolidate Skills
+# Create, Audit, or Consolidate Skills
 
 Create agent skills following the [Agent Skills open standard](https://agentskills.io/specification).
 
+**If auditing an existing skill**, follow the Audit Workflow below instead of the creation phases.
+
 **If consolidating existing skills** (merging multiple skills into fewer), read `references/consolidation-guide.md` and follow its workflow instead of the phases below. Return to Phase 5 (Review) for the final checklist.
+
+## Audit Workflow
+
+Use this workflow when reviewing, improving, or debugging an existing skill.
+
+### Step 1: Locate and read the skill
+
+Read the full SKILL.md and list all files in the skill directory (`references/`, `scripts/`, `templates/`, `assets/`).
+
+### Step 2: Run the audit checklist
+
+Check each category. Note issues as you go.
+
+**Frontmatter:**
+
+- [ ] `name` matches the directory name, lowercase+hyphens, max 64 chars
+- [ ] `description` is under 1024 chars, non-empty, third person
+- [ ] `description` includes trigger phrases (not just a summary of what the skill does)
+- [ ] `description` covers edge phrasings users would actually say
+
+**Structure:**
+
+- [ ] SKILL.md body is under 500 lines
+- [ ] Essential principles are inline in SKILL.md (not only in a reference file)
+- [ ] All referenced files exist (check every path in the SKILL.md)
+- [ ] References are one level deep (no nested chains: A → B → C)
+
+**Content quality:**
+
+- [ ] No rigid ALWAYS/NEVER rules without reasoning (explain WHY)
+- [ ] No explanations of things the agent already knows from training
+- [ ] Steps are specific and verifiable (not "handle errors appropriately")
+- [ ] Success criteria are observable and testable
+- [ ] Examples use fake data where appropriate
+
+**Router pattern** (if applicable):
+
+- [ ] Intake question asks what the user wants before routing
+- [ ] Router table maps commands to reference files
+- [ ] All referenced workflow/reference files exist
+- [ ] Essential principles are in SKILL.md, not only in sub-command references
+
+**Scripts** (if present):
+
+- [ ] Scripts have shebangs, `--help`, and structured output
+- [ ] No interactive prompts (all input via flags/env/stdin)
+- [ ] Cross-platform paths (pathlib, no hardcoded separators)
+- [ ] Error messages explain what went wrong and what to do
+
+Read `references/anti-patterns.md` for the full catalog of common failures.
+
+### Step 3: Generate the report
+
+Present findings grouped by severity:
+
+1. **Critical** — skill won't trigger or produces wrong output
+2. **Important** — structural issues, missing files, spec violations
+3. **Minor** — style, conciseness, optimization opportunities
+
+For each finding, state the issue, cite the specific line or section, and recommend a fix.
+
+### Step 4: Offer fixes
+
+Ask the user which findings to fix. Apply changes surgically — don't rewrite sections that aren't broken. Run the Phase 5 review checklist on the modified skill before finishing.
 
 ## Phase 1: Interview
 
@@ -31,13 +97,40 @@ Focus areas, roughly in order:
 8. **Existing patterns.** Similar skills or workflows to draw from? Check the codebase.
 9. **Platform constraints.** macOS, Windows, and Linux? Scripts must handle path separators, temp directories, and shell differences.
 10. **External services and APIs.** Does the skill call external APIs or services? If yes, read `references/api-skill-patterns.md` — it covers credential handling, schema discovery, instance-specific values, and error placement.
-11. **Architecture.** Based on the answers above, decide whether the skill's scope warrants sub-commands, context systems, or setup gates. Most skills don't need this — skip to Phase 2 if the skill is straightforward. If it does, ask:
-    - **Should this be one skill with sub-commands or multiple skills?** One skill with a router table prevents menu pollution. Multiple skills are appropriate when the tasks have no shared context or setup.
-    - **Does the skill need project-level context?** If every command needs the same background (project config, conventions), design a context file pattern with a loader script.
-    - **Are there mandatory setup gates?** Steps that must pass before any work begins (context loaded, config valid, dependencies present). Gates prevent generic output.
-    - **Does behavior vary by task type?** If so, design a register/mode system that classifies the task first, then loads different references.
 
-Read `references/architecture-patterns.md` when the skill needs sub-commands, context systems, or setup gates.
+### Architecture decision tree
+
+After the interview questions above, decide the architecture. Most skills are simple — only escalate when the answers demand it.
+
+**Question 1: How many distinct things can a user want to do?**
+
+- One specific thing → **Simple skill** (single SKILL.md, under 200 lines)
+- Multiple things with shared principles → continue to Q2
+
+**Question 2: Is there shared domain knowledge across those operations?**
+
+- No, each operation is self-contained → **Simple skill** (or multiple separate simple skills)
+- Yes, multiple operations share knowledge → **Router skill** (SKILL.md + `references/`)
+
+**Question 3: Does it cover a full lifecycle (build, debug, test, ship)?**
+
+- No → **Router skill** is sufficient
+- Yes → **Domain expertise skill** (exhaustive references, full lifecycle workflows)
+
+| What you're building | Pattern |
+|---|---|
+| "A skill that commits with a conventional message" | Simple |
+| "A skill that manages PRs — create, review, merge, close" | Router |
+| "A skill for building and shipping macOS apps" | Domain expertise |
+| "A skill that audits other skills" | Simple (upgrade to Router if it grows) |
+
+For Router and Domain expertise patterns, also ask:
+
+- **Does the skill need project-level context?** If every command needs the same background, design a context file pattern with a loader script.
+- **Are there mandatory setup gates?** Steps that must pass before any work begins. Gates prevent generic output.
+- **Does behavior vary by task type?** If so, design a register/mode system that classifies the task first, then loads different references.
+
+Read `references/architecture-patterns.md` for implementation details of each pattern.
 
 **Consolidation signal check:** If the interview reveals the new skill overlaps significantly with existing skills (shared scripts, cross-references, linear pipeline), consider consolidating instead of creating. Read `references/consolidation-guide.md` for the signals and workflow.
 
@@ -46,6 +139,8 @@ Do not proceed to Phase 2 until the user confirms the scope is complete.
 ## Phase 2: Draft the SKILL.md
 
 Write the skill following the spec. Read `references/spec-guide.md` for the full format reference before drafting.
+
+**Starter templates:** Use `templates/simple-skill.md` for single-purpose skills or `templates/router-skill.md` for multi-command skills. Copy the template as a starting point, then customize.
 
 ### Frontmatter
 
@@ -81,6 +176,8 @@ Common trap: a new sub-command reference duplicates tables from an existing refe
 ### Writing patterns
 
 - **Imperative form**: "Run the command" not "You should run the command"
+- **Explain WHY, not just what**: Avoid rigid ALWAYS/NEVER rules without reasoning. Agents generalize from principles better than from rigid rules. Instead of "ALWAYS use pdfplumber. NEVER use PyPDF2," write "Use pdfplumber over PyPDF2 — it handles malformed PDFs more gracefully and preserves layout metadata needed for table extraction." Principles adapt to edge cases; rigid rules break.
+- **Don't explain what the agent already knows**: Skip basic programming concepts, standard library usage, and well-known tool behavior. Only add context the agent doesn't have — project-specific conventions, non-obvious behavior, domain-specific gotchas. A 30-token code example beats a 150-token explanation of what a library is.
 - **Output templates**: Define exact formats when the output structure matters
 - **Concrete examples**: Show input → output for non-obvious workflows
 - **Gotchas sections**: Common mistakes the agent should avoid
@@ -89,9 +186,13 @@ Common trap: a new sub-command reference duplicates tables from an existing refe
 - **Absolute bans**: When certain patterns are always wrong, use match-and-refuse lists. "If you're about to write X, stop and do Y instead." More effective than vague "be careful" guidance.
 - **Avoid hardcoded thresholds**: Don't write arbitrary numbers as rules (e.g., "when you have 3+ sub-commands" or "if more than 5 issues") unless the threshold comes from a real constraint (API limit, spec requirement). Instead, describe the signal that triggers the behavior (e.g., "when you're copying the same text into another sub-command"). Hardcoded numbers feel authoritative but are usually guesses that don't generalize.
 
+Read `references/anti-patterns.md` during drafting to avoid known pitfalls.
+
 ### Sub-command router (when applicable)
 
-For skills with multiple distinct operations, use a router table in SKILL.md:
+For skills with multiple distinct operations, use a router table in SKILL.md.
+
+**Format choice:** Markdown headings work for most skills. For complex multi-agent orchestration or skills needing machine-parseable sections, XML tags (`<intake>`, `<routing>`, `<essential_principles>`) are also valid. You can mix them — XML tags for structural sections, markdown within content. Use whichever makes the skill easier to follow.
 
 ```markdown
 ## Commands

--- a/skills/skill-maker/references/anti-patterns.md
+++ b/skills/skill-maker/references/anti-patterns.md
@@ -1,0 +1,180 @@
+# Skill Anti-Patterns
+
+Common failures and how to fix them. Read this during Phase 2 (drafting) to avoid known pitfalls.
+
+## Discovery Failures
+
+### Context Selection Omission (CSO)
+
+The description matches how the *author* thinks about the skill, not how *users* phrase requests.
+
+**Symptom:** Skill exists but never triggers. Users rephrase until they give up.
+
+**Example:**
+
+```yaml
+# BAD — author's mental model
+description: Manages Kubernetes pod lifecycle annotations
+
+# GOOD — how users actually ask
+description: |
+  Manage Kubernetes pod annotations and labels. Use when deploying,
+  updating pod metadata, debugging pod scheduling, or when the user
+  mentions annotations, labels, taints, tolerations, or pod spec changes.
+```
+
+**Fix:** Write should-trigger queries first (Phase 3), then write the description to match them.
+
+### Description Summarizes the Workflow
+
+The description explains *how* the skill works instead of *when* to use it.
+
+**Symptom:** Description is accurate but doesn't contain the words users would say.
+
+**Example:**
+
+```yaml
+# BAD — describes internals
+description: |
+  Loads project config, runs validation checks, generates a report
+  with findings, and offers auto-fixes.
+
+# GOOD — describes when to use it
+description: |
+  Audit agent skills for spec violations, structural issues, and
+  content quality. Use when reviewing a SKILL.md, checking why a
+  skill never triggers, or improving an existing skill.
+```
+
+**Fix:** Lead with the task the user wants done, not the steps the skill takes.
+
+## Structure Failures
+
+### Monolithic Skill
+
+**Symptom:** Single SKILL.md over 500 lines covering multiple distinct workflows.
+
+**Fix:** Extract workflows into `references/` files. Add a router table to SKILL.md. Each reference should be self-contained.
+
+### Mixed Concerns
+
+**Symptom:** Procedures and domain knowledge interleaved in the same file.
+
+**Fix:** Procedures (step-by-step workflows) stay in SKILL.md or `references/` command files. Domain knowledge (patterns, rules, examples) goes in separate `references/` files with conditional loading.
+
+### Nested Reference Chains
+
+**Symptom:** Reference A says "read reference B", which says "read reference C." The agent loads three files to answer one question.
+
+**Fix:** Each reference should be self-contained. If two references need the same data, either duplicate it with a note ("Same pattern as X.md — duplicated to avoid transitive loading") or extract the shared data into a third file that both reference directly.
+
+## Content Failures
+
+### Explaining What the Agent Already Knows
+
+**Symptom:** Skill explains basic programming concepts, standard library usage, or well-known tools.
+
+**Fix:** Trust the agent's training data. Only add context the agent doesn't already have — project-specific conventions, non-obvious tool behavior, domain-specific gotchas.
+
+```markdown
+# BAD (~150 tokens wasted)
+PDF files are a common document format. To extract text from PDFs,
+we use pdfplumber, a Python library. First, import it at the top
+of your file. Then open the file using a context manager...
+
+# GOOD (~30 tokens)
+Extract text with pdfplumber:
+  with pdfplumber.open("file.pdf") as pdf:
+      text = pdf.pages[0].extract_text()
+```
+
+### Rigid Rules Without Reasoning
+
+**Symptom:** ALWAYS/NEVER rules in all caps with no explanation of why.
+
+**Fix:** Explain the reasoning. Agents generalize from principles better than from rigid rules. Rigid rules also break at edge cases; principles adapt.
+
+```markdown
+# BAD
+ALWAYS use pdfplumber. NEVER use PyPDF2.
+
+# GOOD
+Use pdfplumber over PyPDF2 — it handles malformed PDFs more gracefully
+and preserves layout metadata needed for table extraction.
+```
+
+### Vague Steps
+
+**Symptom:** Instructions like "handle errors appropriately" or "ensure quality."
+
+**Fix:** Be specific. Name the errors. Define the quality bar. Show the expected output.
+
+```markdown
+# BAD
+Handle API errors appropriately.
+
+# GOOD
+If the API returns 401, re-check credentials. If 429, wait 60 seconds
+and retry once. If 5xx, report the status code and body to the user.
+```
+
+### Untestable Success Criteria
+
+**Symptom:** "The skill works correctly" or "output is high quality."
+
+**Fix:** Define observable, verifiable outcomes.
+
+```markdown
+# BAD
+The migration is successful.
+
+# GOOD
+Migration is complete when: all tests pass, no deprecated imports remain
+(grep -rn 'old_module'), and the changelog entry exists.
+```
+
+### Offering Too Many Options
+
+**Symptom:** Skill presents 5+ approaches and asks the user to choose.
+
+**Fix:** Recommend the best default. Present alternatives only when the tradeoffs genuinely depend on the user's situation. Two options is usually the right number — a default and an escape hatch.
+
+## Script Failures
+
+### Interactive Prompts
+
+**Symptom:** Script blocks waiting for user input; agent hangs.
+
+**Fix:** Accept all input via flags, env vars, or stdin. Scripts must be fully non-interactive.
+
+### Opaque Error Messages
+
+**Symptom:** Script prints "Error" or exits silently on failure.
+
+**Fix:** Print what went wrong, what was expected, and what the user can do about it. Use structured output (JSON with an `error` field) when the consumer is an agent.
+
+### Absolute Script Paths
+
+**Symptom:** Script references `/Users/alice/.skills/mything/scripts/helper.py`.
+
+**Fix:** Use relative paths from the skill directory. Reference scripts as `scripts/helper.py` in SKILL.md.
+
+## Routing Failures
+
+### Missing Intake Question
+
+**Symptom:** Router skill launches into the first workflow without asking what the user wants.
+
+**Fix:** Always ask first. Show a numbered menu of available commands. Support both menu selection and intent-based routing for users who skip the menu.
+
+### Broken References
+
+**Symptom:** Router table points to files that don't exist, or file paths are wrong.
+
+**Fix:** After writing the router table, verify every referenced file exists. Use consistent paths (`references/command.md`, not `./references/command.md` or `references/commands/command.md`).
+
+### Redundant Content
+
+**Symptom:** Same instructions appear in SKILL.md and in a referenced workflow file.
+
+**Fix:** Single-source everything. If principles must always apply, they live in SKILL.md. If instructions are command-specific, they live in the reference file. Never both.

--- a/skills/skill-maker/templates/router-skill.md
+++ b/skills/skill-maker/templates/router-skill.md
@@ -1,0 +1,43 @@
+---
+name: SKILL_NAME
+description: |
+  What the skill does broadly. Use when [trigger phrases for any sub-command].
+  Also use when [edge phrasings, related terms].
+---
+
+# SKILL_TITLE
+
+Brief statement of the skill's domain and purpose.
+
+## Essential Principles
+
+Rules that apply to ALL commands. Keep this section short — it's always loaded.
+
+- Principle with reasoning
+- Another principle — explain why
+
+## Commands
+
+| Command | Description | Reference |
+|---|---|---|
+| `command-a [args]` | What it does | [references/command-a.md](references/command-a.md) |
+| `command-b [args]` | What it does | [references/command-b.md](references/command-b.md) |
+
+## Routing Rules
+
+1. **No argument**: Show the command table. Ask what the user wants to do.
+2. **First word matches a command**: Load its reference file and follow it.
+3. **First word doesn't match**: Treat the full input as context for the most likely command. State which command you chose and why.
+
+## Setup (if applicable)
+
+| Gate | Required check | If fail |
+|---|---|---|
+| Context | Project config loaded | Run the loader first |
+| Command | Sub-command reference is loaded | Load the reference |
+
+## References
+
+- `references/command-a.md` — loaded when running command-a
+- `references/command-b.md` — loaded when running command-b
+- `references/shared-patterns.md` — loaded when [specific condition]

--- a/skills/skill-maker/templates/simple-skill.md
+++ b/skills/skill-maker/templates/simple-skill.md
@@ -1,0 +1,32 @@
+---
+name: SKILL_NAME
+description: |
+  What the skill does in one sentence. Use when [specific trigger phrases].
+  Also use when [additional triggers, edge phrasings].
+---
+
+# SKILL_TITLE
+
+Brief statement of what this skill does and why it exists.
+
+## Quick Start
+
+Immediate guidance for the most common use case.
+
+## Workflow
+
+Step-by-step instructions:
+
+1. Step one — what to do and why
+2. Step two — expected output or validation
+3. Step three — completion criteria
+
+## Key Guidelines
+
+- Guideline with reasoning (not just a rule)
+- Another guideline — explain the tradeoff
+
+## Gotchas
+
+- Common mistake → what to do instead
+- Non-obvious behavior → how to handle it


### PR DESCRIPTION
## Summary

Improvements to the `skill-maker` skill inspired by patterns from [durandom/skills/skill-architect](https://github.com/durandom/skills/tree/main/skills/meta/skill-architect).

## Changes

### New files
- **`references/anti-patterns.md`** — 6 categories of failures (discovery, structure, content, script, routing) with symptom/fix pairs and before/after examples
- **`templates/simple-skill.md`** — Starter template for single-purpose skills
- **`templates/router-skill.md`** — Starter template for multi-command router skills

### SKILL.md improvements
- **Audit workflow** — New 4-step section for reviewing/improving existing skills (locate → checklist → severity report → surgical fixes). Points to anti-patterns.md and reuses Phase 5 checklist.
- **Architecture decision tree** — Replaced buried sub-bullet in Phase 1 with a prominent, question-based decision tree (3 branching questions → Simple / Router / Domain expertise) plus example mappings table.
- **Writing patterns** — Added "Explain WHY, not just what" (principle-based > rigid rules), "Don't explain what the agent already knows" (trust training data), and XML/Markdown format choice note.
- **Description** — Updated to cover audit trigger phrases: "review a skill", "audit a SKILL.md", "check why a skill never triggers", "improve an existing skill", "fix a skill" (859/1024 chars).
- **Template pointers** — Phase 2 now points to starter templates.
- **Anti-patterns pointer** — Phase 2 drafting section now references anti-patterns.md.

### Constraints verified
- SKILL.md: 402 lines (under 500 ✓)
- Description: 859 chars (under 1024 ✓)
- All referenced files exist ✓
- Markdownlint passes ✓