### PR TITLE
fix: skill audit fixes — broken refs, descriptions, fallbacks

### DIFF
--- a/skills/create-plugin/SKILL.md
+++ b/skills/create-plugin/SKILL.md
@@ -8,7 +8,9 @@ description: >
   "configure mount points", "create dynamic route", "add entity card", "scaffold
   RHDH plugin", "publish plugin to registry", "create tgz archive", or mentions
   creating, exporting, packaging, or wiring a Backstage plugin for Red Hat Developer
-  Hub. Covers backend plugins (APIs, scaffolder actions, processors), frontend plugins
+  Hub. Also use when asked to "build a plugin from scratch", "dynamic plugin
+  tutorial", "RHDH plugin from scratch", or "build Backstage plugin for RHDH".
+  Covers backend plugins (APIs, scaffolder actions, processors), frontend plugins
   (pages, cards, themes), export/packaging (OCI, tgz, npm), and frontend wiring
   configuration (mount points, routes, entity tabs, themes).
 compatibility: "Node.js 22+, Yarn, podman or docker. Windows, macOS, Linux."
@@ -29,6 +31,8 @@ compatibility: "Node.js 22+, Yarn, podman or docker. Windows, macOS, Linux."
 | `export` | Package | Export, package, and push a plugin for RHDH deployment | [references/export.md](references/export.md) |
 | `wiring` | Configure | Analyze a frontend plugin and generate wiring config | [references/wiring.md](references/wiring.md) |
 
+Single source of truth for command descriptions: `scripts/command-metadata.json`
+
 ### Routing rules
 
 1. **No argument**: Show the command table. Ask what the user wants to do.
@@ -41,7 +45,7 @@ compatibility: "Node.js 22+, Yarn, podman or docker. Windows, macOS, Linux."
 
 ### RHDH Version Resolution
 
-Before scaffolding, determine the target RHDH version. Consult `../rhdh/references/versions.md` for the compatibility matrix. Ask the user if not specified.
+Before scaffolding, determine the target RHDH version. Consult `../rhdh/references/versions.md` for the compatibility matrix. If that file is not found (skill installed standalone), ask the user for the target RHDH version directly.
 
 ### Scaffold Script
 

--- a/skills/create-plugin/SKILL.md
+++ b/skills/create-plugin/SKILL.md
@@ -16,28 +16,44 @@ description: >
 compatibility: "Node.js 22+, Yarn, podman or docker. Windows, macOS, Linux."
 ---
 
+<essential_principles>
+
 ## Prerequisites
 
 - Node.js 22+ and Yarn
 - Container runtime (`podman` or `docker`) for OCI packaging
 - Access to a container registry (e.g., quay.io) for publishing
 
-## Commands
+</essential_principles>
 
-| Command | Category | Description | Reference |
-|---------|----------|-------------|-----------|
-| `backend` | Create | Scaffold and implement a backend dynamic plugin | [references/backend.md](references/backend.md) |
-| `frontend` | Create | Scaffold and implement a frontend dynamic plugin | [references/frontend.md](references/frontend.md) |
-| `export` | Package | Export, package, and push a plugin for RHDH deployment | [references/export.md](references/export.md) |
-| `wiring` | Configure | Analyze a frontend plugin and generate wiring config | [references/wiring.md](references/wiring.md) |
+<intake>
+
+## What would you like to do?
+
+| # | Category | Command | Description |
+|---|----------|---------|-------------|
+| 1 | Create | `backend` | Scaffold and implement a backend dynamic plugin |
+| 2 | Create | `frontend` | Scaffold and implement a frontend dynamic plugin |
+| 3 | Package | `export` | Export, package, and push a plugin for RHDH deployment |
+| 4 | Configure | `wiring` | Analyze a frontend plugin and generate wiring config |
 
 Single source of truth for command descriptions: `scripts/command-metadata.json`
 
-### Routing rules
+**Wait for response before proceeding.**
 
-1. **No argument**: Show the command table. Ask what the user wants to do.
-2. **First word matches a command**: Load its reference file and follow it.
-3. **First word doesn't match**: Infer intent from context. "Create a new API plugin" → `backend`. "Package my plugin as OCI" → `export`. "Generate mount points" → `wiring`.
+</intake>
+
+<routing>
+
+| Response | Reference |
+|----------|----------|
+| 1, "backend", "create backend", "API plugin", "scaffolder action" | [references/backend.md](references/backend.md) |
+| 2, "frontend", "create frontend", "page", "card", "theme" | [references/frontend.md](references/frontend.md) |
+| 3, "export", "package", "OCI", "tgz", "publish", "push" | [references/export.md](references/export.md) |
+| 4, "wiring", "mount points", "routes", "entity tabs" | [references/wiring.md](references/wiring.md) |
+| First word doesn't match | Infer intent from context. "Create a new API plugin" → `backend`. "Package my plugin as OCI" → `export`. "Generate mount points" → `wiring`. |
+
+</routing>
 
 ## Shared Knowledge
 
@@ -83,6 +99,8 @@ The typical workflow chains these commands:
 
 Each reference file is self-contained. Load only the one you need.
 
+<reference_index>
+
 ## Reference Index
 
 ### Command References
@@ -110,6 +128,8 @@ Each reference file is self-contained. Load only the one you need.
 |------|----------|
 | `examples/dynamic-plugins.yaml` | Backend, frontend, multi-plugin, tgz, npm, and local config patterns |
 | `examples/frontend-wiring.yaml` | All frontend wiring patterns — tabs, cards, search, themes, scaffolder |
+
+</reference_index>
 
 ## Common Issues
 

--- a/skills/create-plugin/scripts/command-metadata.json
+++ b/skills/create-plugin/scripts/command-metadata.json
@@ -1,18 +1,18 @@
 {
   "backend": {
-    "description": "Scaffold and implement a backend dynamic plugin for RHDH. Use when creating a new backend API plugin, backend module, scaffolder action, catalog processor, or authentication module for Red Hat Developer Hub.",
-    "argumentHint": "[plugin description or name]"
+    "description": "Scaffold and implement a backend dynamic plugin (API, scaffolder action, processor).",
+    "argumentHint": "[plugin description or plugin ID]"
   },
   "frontend": {
-    "description": "Scaffold and implement a frontend dynamic plugin for RHDH. Use when creating a new page, entity card, sidebar item, theme, scaffolder field extension, or TechDocs addon for Red Hat Developer Hub.",
-    "argumentHint": "[plugin description or name]"
+    "description": "Scaffold and implement a frontend dynamic plugin (page, card, theme).",
+    "argumentHint": "[plugin description or plugin ID]"
   },
   "export": {
-    "description": "Export and package a Backstage plugin as an RHDH dynamic plugin. Use when exporting as OCI image, tgz archive, or npm package, pushing to a container registry, or bundling multiple plugins.",
-    "argumentHint": "[plugin directory or packaging options]"
+    "description": "Export, package, and push a plugin for RHDH deployment (OCI, tgz, npm).",
+    "argumentHint": "[plugin directory or plugin ID]"
   },
   "wiring": {
-    "description": "Analyze an existing Backstage frontend plugin and generate the RHDH dynamic plugin wiring configuration. Use when generating dynamic-plugins.yaml config, mount points, routes, entity tabs, or theme config.",
-    "argumentHint": "[plugin directory to analyze]"
+    "description": "Analyze a frontend plugin and generate dynamic-plugins.yaml wiring config.",
+    "argumentHint": "[plugin directory or plugin ID]"
   }
 }

--- a/skills/overlay/SKILL.md
+++ b/skills/overlay/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: overlay
-description: Manages the rhdh-plugin-export-overlays repository — onboards plugins to the Extensions Catalog, updates plugin versions, fixes overlay build failures, triages and analyzes PRs, triggers publishes, and manages plugin workspaces. Use when working with overlays, importing plugins, debugging CI, checking PRs, or bumping versions.
+description: >-
+  Manages the rhdh-plugin-export-overlays repository — onboards plugins to the
+  Extensions Catalog, updates plugin versions, fixes overlay build failures,
+  triages and analyzes PRs, triggers publishes, and manages plugin workspaces.
+  Use when working with overlays, importing plugins, debugging CI, checking PRs,
+  bumping versions, or mentions "Extensions Catalog", "overlay build failed",
+  "plugin registry", "overlay PR", "overlay doctor", "plugin import",
+  "add plugin to catalog", "onboard plugin", or "plugin workspace".
 ---
 
 <cli_setup>
@@ -136,7 +143,7 @@ gh pr view <number> --repo $REPO --json statusCheckRollup \
 2. No `do-not-merge` label
 3. Publish check not already successful
 
-See `../rhdh/references/github-reference.md` for full patterns.
+See `../rhdh/references/github-reference.md` for full patterns. If unavailable, use standard `gh` CLI patterns.
 </inline_publish_trigger>
 
 <reference_index>
@@ -146,7 +153,7 @@ See `../rhdh/references/github-reference.md` for full patterns.
 **PR label priorities:** references/label-priority.md
 **RHDH Local testing:** references/rhdh-local.md
 
-**For GitHub/JIRA patterns:** See `../rhdh/references/`
+**For GitHub/JIRA patterns:** See `../rhdh/references/` (if unavailable, use standard `gh` / `acli` patterns)
 </reference_index>
 
 <workflows_index>

--- a/skills/rhdh-jira/SKILL.md
+++ b/skills/rhdh-jira/SKILL.md
@@ -5,9 +5,15 @@ description: |
 compatibility: "acli (Atlassian CLI) on PATH. Python 3 for scripts. Windows, macOS, Linux."
 ---
 
+<essential_principles>
+
 # RHDH Jira
 
 Foundational skill for interacting with RHDH's Jira instance via the Atlassian CLI (`acli`). Covers all four active projects, issue types, workflows, custom fields, and JQL patterns.
+
+</essential_principles>
+
+<intake>
 
 ## Commands
 
@@ -25,11 +31,19 @@ Foundational skill for interacting with RHDH's Jira instance via the Atlassian C
 
 Single source of truth for command descriptions: `scripts/command-metadata.json`
 
+**Wait for response before proceeding.**
+
+</intake>
+
+<routing>
+
 ### Routing rules
 
 1. **No argument**: Show the command menu. Ask what to do.
 2. **First word matches a command**: Load its reference file and follow it.
 3. **First word doesn't match**: General Jira invocation using the full argument as context — use the reference files table below to decide what to load.
+
+</routing>
 
 ## Prerequisites
 
@@ -95,6 +109,8 @@ RHDHPAI (Plugins and AI) is **archived** — JQL queries against it will fail.
 - **Sub-task** — child of any issue type above
 - **Vulnerability** — CVE tracking in RHIDP (Product Security)
 
+<reference_index>
+
 ## Reference Files
 
 Load only what the current task requires.
@@ -122,6 +138,8 @@ Load only what the current task requires.
 | `references/duplicates.md` | Duplicate detection for pre-creation checks and refinement audits. Shared across creation commands and refine. |
 | `references/grill.md` | Shared challenging behavior for issue creation grills: sizing, completeness, scope, risks, cross-referencing. |
 | `references/sizing.md` | T-shirt sizing guide for Features/Epics and Fibonacci story points for Stories/Tasks. Used during grills and refinement. |
+
+</reference_index>
 
 ## Common Gotchas
 

--- a/skills/rhdh-local/SKILL.md
+++ b/skills/rhdh-local/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: rhdh-local
-description: Skill for testing RHDH plugins locally using the rhdh-local-setup customization system. Covers enabling/disabling plugins, switching modes, running end-to-end plugin tests, starting/stopping RHDH (up/down), health checks, troubleshooting errors (504, startup failures), and backup/restore of configurations.
+description: >-
+  Test RHDH plugins locally using the rhdh-local-setup customization system.
+  Covers enabling/disabling plugins, switching modes, running end-to-end plugin
+  tests, starting/stopping RHDH (up/down), health checks, troubleshooting errors
+  (504, startup failures), and backup/restore of configurations. Use when asked
+  to "test plugin locally", "local RHDH setup", "start local Developer Hub",
+  "rhdh-local-setup", "local development environment", "podman compose RHDH",
+  or "run RHDH on my machine".
 ---
 
 <essential_principles>
@@ -58,7 +65,7 @@ What would you like to do with your local RHDH instance?
 **Environment variables (.env reference):** `references/env-reference.md`
 **Troubleshooting & comparative testing:** `references/troubleshooting.md`
 **Container lifecycle, startup scripts, network namespace:** `references/troubleshooting.md` — restart patterns, 504 debugging, network namespace rules
-**Dynamic plugin YAML format, OCI references:** `../overlay/references/rhdh-local.md` section `<dynamic_plugins_config>`
+**Dynamic plugin YAML format, OCI references:** `../overlay/references/rhdh-local.md` section `<dynamic_plugins_config>` (if unavailable, see `rhdh-plugin-export-overlays` repo README for YAML format)
 </reference_index>
 
 <skills_index>

--- a/skills/rhdh-pr-review/SKILL.md
+++ b/skills/rhdh-pr-review/SKILL.md
@@ -9,6 +9,7 @@ This skill uses the orchestrator CLI for activity tracking. **Set up first:**
 ```bash
 RHDH=../rhdh/scripts/rhdh
 ```
+
 </cli_setup>
 
 <essential_principles>
@@ -66,9 +67,8 @@ Both paths preserve existing Backstage CRs, config, and Keycloak state — only 
 | Reference | Purpose | Path |
 |-----------|---------|------|
 | operator-pr-images | CI image extraction and validation | `references/operator-pr-images.md` |
-| github-reference | gh CLI patterns, PR queries | `../rhdh/references/github-reference.md` |
-| rhdh-repos | RHDH ecosystem repository map | `../rhdh/references/rhdh-repos.md` |
-
+| github-reference | gh CLI patterns, PR queries | `../rhdh/references/github-reference.md` (if unavailable, use standard `gh` CLI patterns) |
+| rhdh-repos | RHDH ecosystem repository map | `../rhdh/references/rhdh-repos.md` (if unavailable, see CONTEXT.md for repo list) |
 
 </reference_index>
 

--- a/skills/rhdh-test-plan-review/SKILL.md
+++ b/skills/rhdh-test-plan-review/SKILL.md
@@ -59,7 +59,7 @@ Provide a Jira ticket ID or URL (e.g., `RHIDP-8994`) to begin.
 |-----------|---------|------|
 | sources | Lifecycle URLs and extraction guidance per platform/integration | `references/sources.md` |
 | google-sheets-setup | One-time gcloud auth setup for schedule sheet access | `references/google-sheets-setup.md` |
-| rhdh-jira auth | Jira REST API token setup and curl patterns | `~/.claude/skills/rhdh-jira/references/auth.md` |
+| rhdh-jira auth | Jira REST API token setup and curl patterns | `../rhdh-jira/references/auth.md` |
 
 </reference_index>
 

--- a/skills/rhdh-test-plan-review/scripts/gcloud_token.py
+++ b/skills/rhdh-test-plan-review/scripts/gcloud_token.py
@@ -1,4 +1,8 @@
-"""Shared gcloud access token helper for rhdh-test-plan-review scripts."""
+"""Shared gcloud access token helper for rhdh-test-plan-review scripts.
+
+Library module — imported by check_gsheets.py and fetch_schedule.py.
+Not a CLI script; do not invoke directly.
+"""
 
 import shutil
 import subprocess

--- a/skills/rhdh/SKILL.md
+++ b/skills/rhdh/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: rhdh
-description: Handles all RHDH-related work — "RHDH", "Red Hat Developer Hub", or "Developer Hub". Primary entry point for plugin development, overlay management, environment setup, repo navigation, version compatibility, CI/CD, configuration, debugging, and general RHDH ecosystem knowledge. Routes to specialized sub-skills as needed.
+description: >-
+  Handles all RHDH-related work — "RHDH", "Red Hat Developer Hub", or "Developer
+  Hub". Primary entry point for plugin development, overlay management,
+  environment setup, repo navigation, version compatibility, CI/CD,
+  configuration, debugging, and general RHDH ecosystem knowledge. Routes to
+  specialized sub-skills as needed. Use when asked about RHDH version
+  compatibility, RHDH CI pipeline, RHDH configuration, which RHDH repo to use,
+  RHDH release status, RHDH debugging, or any Developer Hub question.
 ---
 
 <cli_setup>
@@ -112,7 +119,7 @@ What would you like to do?
 
 ### Test Plan Tasks
 
-*For rhdh test plan review in jira* 
+*For rhdh test plan review in jira*
 
 9. **Review Test Plan content** — Reviews an RHDH test plan Jira ticket and suggests platform/integration version updates based on support lifecycle pages and RHDH release milestones
 

--- a/skills/skill-maker/SKILL.md
+++ b/skills/skill-maker/SKILL.md
@@ -15,6 +15,7 @@ What do you need to do?
 2. **Create a new skill** — Interview, draft, and review from scratch
 3. **Consolidate skills** — Merge multiple skills into fewer
 
+**Wait for response before proceeding.**
 </intake>
 
 <routing>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,9 @@ RHDH_SKILL_DIR = PROJECT_ROOT / "skills" / "rhdh"
 # Path to the overlay skill directory (markdown-only)
 OVERLAY_SKILL_DIR = PROJECT_ROOT / "skills" / "overlay"
 
+# Path to the skill-maker skill directory (markdown-only)
+SKILL_MAKER_DIR = PROJECT_ROOT / "skills" / "skill-maker"
+
 # Add orchestrator skill directory to path for testing
 if str(RHDH_SKILL_DIR) not in sys.path:
     sys.path.insert(0, str(RHDH_SKILL_DIR))
@@ -63,6 +66,12 @@ def skills_dir():
 def overlay_skill_dir():
     """Return the overlay skill directory path (skills/overlay)."""
     return OVERLAY_SKILL_DIR
+
+
+@pytest.fixture
+def skill_maker_dir():
+    """Return the skill-maker directory path (skills/skill-maker)."""
+    return SKILL_MAKER_DIR
 
 
 @pytest.fixture

--- a/tests/unit/test_skill_structure.py
+++ b/tests/unit/test_skill_structure.py
@@ -165,6 +165,22 @@ class TestOverlaySkillMd:
                     pytest.fail(f"Found markdown heading in <{section_name}>: {line.strip()}")
 
 
+class TestSkillMakerSkillMd:
+    """Test that skill-maker SKILL.md keeps router intake pause instructions."""
+
+    @pytest.fixture
+    def skill_md(self, skill_maker_dir):
+        """Load skill-maker SKILL.md content."""
+        skill_path = skill_maker_dir / "SKILL.md"
+        return skill_path.read_text(encoding="utf-8")
+
+    def test_intake_waits_for_user_response(self, skill_md):
+        """The intake section must tell the agent to wait before routing."""
+        match = re.search(r"<intake>(.*?)</intake>", skill_md, re.DOTALL)
+        assert match, "SKILL.md missing <intake> section"
+        assert "**Wait for response before proceeding.**" in match.group(1)
+
+
 class TestWorkflowStructure:
     """Test that workflow files have required structure."""
 


### PR DESCRIPTION
## Summary
- convert `create-plugin` and `rhdh-jira` to explicit XML router sections so intake, routing, and reference boundaries are clearer for agents; align `create-plugin` command metadata with that structure
- fix the audited skill follow-ups across `overlay`, `rhdh`, `rhdh-local`, `rhdh-pr-review`, and `rhdh-test-plan-review` by adding standalone fallbacks, correcting broken cross-skill references, expanding trigger phrases, and clarifying `gcloud_token.py` usage
- fix `skill-maker`'s own `<intake>` block to explicitly wait for user input before routing, and add a focused regression test so that pause instruction stays covered

## Test plan
- [x] `uv run pytest`