### PR TITLE
feat(skill-maker): add XML structure guidance and update examples

### DIFF
--- a/skills/skill-maker/SKILL.md
+++ b/skills/skill-maker/SKILL.md
@@ -51,8 +51,7 @@ Check each category. Note issues as you go.
 - [ ] Router table maps commands to reference files
 - [ ] All referenced workflow/reference files exist
 - [ ] Essential principles are in SKILL.md, not only in sub-command references
-- [ ] XML tags used consistently if skill has multiple semantic sections (see `references/xml-structure-guide.md`)
-- [ ] Tag names match the established vocabulary (`<essential_principles>`, `<intake>`, `<routing>`, `<reference_index>`, `<success_criteria>`)
+- [ ] If skill has multiple semantic sections, consider XML tags for structure (see `references/xml-structure-guide.md`)
 
 **Scripts** (if present):
 
@@ -192,15 +191,20 @@ Read `references/anti-patterns.md` during drafting to avoid known pitfalls.
 
 ### XML structure (router and domain expertise skills)
 
-Agents parse XML tags more reliably than markdown headings when a skill has multiple semantically distinct sections (principles, intake, routing, references). Use XML tags as structural containers with markdown content inside.
+Agents parse XML tags more reliably than markdown headings when a skill has semantically distinct sections (principles, intake, routing, references). XML tags create unambiguous containers; markdown headings blend together in long prompts.
 
-Read `references/xml-structure-guide.md` for the full tag vocabulary, patterns, and anti-patterns.
+Read `references/xml-structure-guide.md` for suggested patterns and anti-patterns.
 
-**Format decision:**
+**When XML helps:**
 
-- **Simple skill** (single workflow) → Markdown headings. Not enough structure to benefit from XML.
-- **Router skill** (multiple commands) → XML tags for sections, markdown within.
-- **Domain expertise skill** (full lifecycle) → XML tags for sections, markdown within.
+- Skills with an intake question + routing table + essential principles
+- Skills where an agent needs to quickly locate a specific section
+- Skills with inline workflows that need clear start/end boundaries
+
+**When markdown is enough:**
+
+- Simple skills with a single linear workflow
+- Sequential instructional content (phases, steps) where order matters more than section lookup
 
 ### Sub-command router (when applicable)
 
@@ -379,8 +383,7 @@ Before presenting the final skill, verify against this checklist:
 - [ ] Setup gates are defined with fail actions for each gate
 - [ ] Register/mode system classifies before loading references
 - [ ] Capability-gated steps degrade gracefully with one-line skip reasons
-- [ ] Router/domain skills use XML tags for semantic sections (`references/xml-structure-guide.md`)
-- [ ] XML tag names are consistent with established vocabulary (no invented synonyms)
+- [ ] Router/domain skills with distinct sections (intake, routing, principles) consider XML tags for clarity (`references/xml-structure-guide.md`)
 
 ### References
 

--- a/skills/skill-maker/SKILL.md
+++ b/skills/skill-maker/SKILL.md
@@ -51,6 +51,8 @@ Check each category. Note issues as you go.
 - [ ] Router table maps commands to reference files
 - [ ] All referenced workflow/reference files exist
 - [ ] Essential principles are in SKILL.md, not only in sub-command references
+- [ ] XML tags used consistently if skill has multiple semantic sections (see `references/xml-structure-guide.md`)
+- [ ] Tag names match the established vocabulary (`<essential_principles>`, `<intake>`, `<routing>`, `<reference_index>`, `<success_criteria>`)
 
 **Scripts** (if present):
 
@@ -140,7 +142,7 @@ Do not proceed to Phase 2 until the user confirms the scope is complete.
 
 Write the skill following the spec. Read `references/spec-guide.md` for the full format reference before drafting.
 
-**Starter templates:** Use `templates/simple-skill.md` for single-purpose skills or `templates/router-skill.md` for multi-command skills. Copy the template as a starting point, then customize.
+**Starter templates:** Use `templates/simple-skill.md` for single-purpose skills, `templates/router-skill.md` for multi-command skills using markdown headings, or `templates/router-skill-xml.md` for multi-command skills using XML structure. Copy the template as a starting point, then customize.
 
 ### Frontmatter
 
@@ -188,25 +190,38 @@ Common trap: a new sub-command reference duplicates tables from an existing refe
 
 Read `references/anti-patterns.md` during drafting to avoid known pitfalls.
 
+### XML structure (router and domain expertise skills)
+
+Agents parse XML tags more reliably than markdown headings when a skill has multiple semantically distinct sections (principles, intake, routing, references). Use XML tags as structural containers with markdown content inside.
+
+Read `references/xml-structure-guide.md` for the full tag vocabulary, patterns, and anti-patterns.
+
+**Format decision:**
+
+- **Simple skill** (single workflow) → Markdown headings. Not enough structure to benefit from XML.
+- **Router skill** (multiple commands) → XML tags for sections, markdown within.
+- **Domain expertise skill** (full lifecycle) → XML tags for sections, markdown within.
+
 ### Sub-command router (when applicable)
 
 For skills with multiple distinct operations, use a router table in SKILL.md.
 
-**Format choice:** Markdown headings work for most skills. For complex multi-agent orchestration or skills needing machine-parseable sections, XML tags (`<intake>`, `<routing>`, `<essential_principles>`) are also valid. You can mix them — XML tags for structural sections, markdown within content. Use whichever makes the skill easier to follow.
+```xml
+<intake>
+## What would you like to do?
 
-```markdown
-## Commands
+1. **Craft a feature** — Build end-to-end
+2. **Audit code** — Technical quality checks
 
-| Command | Description | Reference |
-|---|---|---|
-| `craft [feature]` | Build a feature end-to-end | [references/craft.md](references/craft.md) |
-| `audit [target]` | Technical quality checks | [references/audit.md](references/audit.md) |
+**Wait for response before proceeding.**
+</intake>
 
-### Routing rules
-
-1. **No argument**: Show the command menu. Ask what to do.
-2. **First word matches a command**: Load its reference file and follow it.
-3. **First word doesn't match**: General invocation using the full argument as context.
+<routing>
+| Response | Workflow |
+|----------|----------|
+| 1, "craft", "build" | `references/craft.md` |
+| 2, "audit", "check" | `references/audit.md` |
+</routing>
 ```
 
 Back the router with a `scripts/command-metadata.json` as the single source of truth:
@@ -364,6 +379,8 @@ Before presenting the final skill, verify against this checklist:
 - [ ] Setup gates are defined with fail actions for each gate
 - [ ] Register/mode system classifies before loading references
 - [ ] Capability-gated steps degrade gracefully with one-line skip reasons
+- [ ] Router/domain skills use XML tags for semantic sections (`references/xml-structure-guide.md`)
+- [ ] XML tag names are consistent with established vocabulary (no invented synonyms)
 
 ### References
 

--- a/skills/skill-maker/SKILL.md
+++ b/skills/skill-maker/SKILL.md
@@ -21,9 +21,9 @@ What do you need to do?
 
 | Response | Workflow |
 |----------|----------|
-| 1, "audit", "review", "check", "fix", "improve" | Follow the Audit Workflow below |
-| 2, "create", "write", "build", "new", "draft" | Follow Phases 1–5 below |
-| 3, "consolidate", "merge", "combine" | Read `references/consolidation-guide.md` and follow its workflow. Return to Phase 5 (Review) for the final checklist. |
+| 1, "audit", "review", "check", "fix", "improve" | Audit Workflow (Step 1–4 in this file) |
+| 2, "create", "write", "build", "new", "draft" | Phases 1–5 (Interview → Draft → Description → Scripts → Review) in this file |
+| 3, "consolidate", "merge", "combine" | `references/consolidation-guide.md` — return to Phase 5 for final checklist |
 
 </routing>
 

--- a/skills/skill-maker/SKILL.md
+++ b/skills/skill-maker/SKILL.md
@@ -3,13 +3,29 @@ name: skill-maker
 description: Create, audit, or consolidate agent skills following the Agent Skills open standard (agentskills.io). Interviews the user relentlessly about intent, scope, and edge cases before drafting. Covers SKILL.md structure, frontmatter, progressive disclosure, description optimization, script bundling, sub-command architecture, setup gates, context systems, and review. Use when the user wants to create a skill, write a skill, build a new skill, make a skill, draft a SKILL.md, or mentions "skill-maker". Also use when asked to review a skill, audit a SKILL.md, check why a skill never triggers, improve an existing skill, or fix a skill. Also use when asked to package expertise, workflows, or domain knowledge into a reusable skill. Also use when asked to consolidate skills, merge skills, combine skills, reduce skill count, or refactor multiple skills into one.
 ---
 
+<intake>
+
 # Create, Audit, or Consolidate Skills
 
 Create agent skills following the [Agent Skills open standard](https://agentskills.io/specification).
 
-**If auditing an existing skill**, follow the Audit Workflow below instead of the creation phases.
+What do you need to do?
 
-**If consolidating existing skills** (merging multiple skills into fewer), read `references/consolidation-guide.md` and follow its workflow instead of the phases below. Return to Phase 5 (Review) for the final checklist.
+1. **Audit an existing skill** — Review, improve, or debug a SKILL.md
+2. **Create a new skill** — Interview, draft, and review from scratch
+3. **Consolidate skills** — Merge multiple skills into fewer
+
+</intake>
+
+<routing>
+
+| Response | Workflow |
+|----------|----------|
+| 1, "audit", "review", "check", "fix", "improve" | Follow the Audit Workflow below |
+| 2, "create", "write", "build", "new", "draft" | Follow Phases 1–5 below |
+| 3, "consolidate", "merge", "combine" | Read `references/consolidation-guide.md` and follow its workflow. Return to Phase 5 (Review) for the final checklist. |
+
+</routing>
 
 ## Audit Workflow
 
@@ -430,3 +446,20 @@ Before presenting the final skill, verify against this checklist:
 - [ ] Concrete examples included for non-obvious workflows
 - [ ] Absolute bans defined for patterns that are always wrong
 - [ ] Self-critique loops defined for build/implementation commands with explicit exit bars
+
+<reference_index>
+
+## Reference Index
+
+| Reference | Load when... |
+|-----------|-------------|
+| `references/spec-guide.md` | Drafting a SKILL.md (Phase 2) — full format reference |
+| `references/description-guide.md` | Optimizing the description (Phase 3) |
+| `references/scripts-guide.md` | Writing scripts (Phase 4) |
+| `references/anti-patterns.md` | Drafting or auditing — common failures to avoid |
+| `references/architecture-patterns.md` | Choosing between simple, router, and domain expertise patterns |
+| `references/api-skill-patterns.md` | Skill calls external APIs or services |
+| `references/consolidation-guide.md` | Merging multiple skills into fewer |
+| `references/xml-structure-guide.md` | Deciding on XML vs markdown structure |
+
+</reference_index>

--- a/skills/skill-maker/references/anti-patterns.md
+++ b/skills/skill-maker/references/anti-patterns.md
@@ -165,7 +165,19 @@ Migration is complete when: all tests pass, no deprecated imports remain
 
 **Symptom:** Router skill launches into the first workflow without asking what the user wants.
 
-**Fix:** Always ask first. Show a numbered menu of available commands. Support both menu selection and intent-based routing for users who skip the menu.
+**Fix:** Wrap the menu in `<intake>` and the routing table in `<routing>`. Ask first, then route:
+
+```xml
+<intake>
+What would you like to do?
+1. **Command A** — description
+2. **Command B** — description
+
+**Wait for response before proceeding.**
+</intake>
+```
+
+Support both menu selection and intent-based routing for users who skip the menu.
 
 ### Broken References
 

--- a/skills/skill-maker/references/architecture-patterns.md
+++ b/skills/skill-maker/references/architecture-patterns.md
@@ -29,12 +29,14 @@ Do not delay the migration until the skill is "complete" — add the router as s
 
 ### Structure
 
-The SKILL.md contains:
+The SKILL.md contains these sections, using XML tags to create unambiguous boundaries:
 
-1. **Setup section** — shared gates that run before any command
-2. **Shared rules** — domain laws that apply to every command
-3. **Router table** — maps command names to reference files
-4. **Routing rules** — how to interpret user input
+1. `<essential_principles>` — domain laws that apply to every command
+2. `<intake>` — ask the user what they want to do
+3. `<routing>` — maps responses to reference/workflow files
+4. `<reference_index>` — lists reference files with "load when..." guidance
+
+Setup gates, success criteria, and CLI setup can use additional tags as needed (e.g., `<cli_setup>`, `<success_criteria>`). Invent descriptive tag names that fit the skill's domain.
 
 Each command gets its own `references/<command>.md` file. The SKILL.md never contains command-specific instructions — it delegates.
 
@@ -64,26 +66,27 @@ This tells the agent which references to load together and prevents redundant AP
 
 ### Router table pattern
 
-```markdown
-## Commands
+```xml
+<intake>
+## What would you like to do?
 
-| Command | Category | Description | Reference |
-|---|---|---|---|
-| `init [project]` | Setup | Initialize a new project | [references/init.md](references/init.md) |
-| `check [target]` | Evaluate | Run quality checks | [references/check.md](references/check.md) |
-| `fix [target]` | Repair | Auto-fix common issues | [references/fix.md](references/fix.md) |
-```
+| # | Category | Command | Description |
+|---|----------|---------|-------------|
+| 1 | Setup | `init [project]` | Initialize a new project |
+| 2 | Evaluate | `check [target]` | Run quality checks |
+| 3 | Repair | `fix [target]` | Auto-fix common issues |
 
-Group commands by category (Setup, Evaluate, Repair, Generate, etc.) for the user-facing menu.
+**Wait for response before proceeding.**
+</intake>
 
-### Routing rules
-
-```markdown
-### Routing rules
-
-1. **No argument**: Render the table as a user-facing command menu, grouped by category. Ask what to do.
-2. **First word matches a command**: Load its reference file and follow its instructions. Everything after the command name is the target.
-3. **First word doesn't match**: General invocation. Apply setup, shared rules, and the full argument as context.
+<routing>
+| Response | Reference |
+|----------|----------|
+| 1, "init", "initialize", "new project" | `references/init.md` |
+| 2, "check", "quality", "lint" | `references/check.md` |
+| 3, "fix", "repair", "auto-fix" | `references/fix.md` |
+| First word doesn't match | General invocation — apply shared rules with full input as context |
+</routing>
 ```
 
 Setup runs before routing. Sub-commands don't re-invoke the parent skill.

--- a/skills/skill-maker/references/spec-guide.md
+++ b/skills/skill-maker/references/spec-guide.md
@@ -33,9 +33,30 @@ description: What the skill does. Use when [triggers].
 | metadata      | No       | Arbitrary key-value mapping.                                   |
 | allowed-tools | No       | Space-separated string of pre-approved tools. (Experimental)   |
 
-### Body (markdown instructions)
+### Body
 
 Everything after the frontmatter closing `---` is the skill's instructions. This is loaded into the agent's context when the skill activates.
+
+Use XML tags to create unambiguous section boundaries when a skill has multiple distinct sections (principles, intake, routing, references). Markdown content works inside the tags:
+
+```xml
+<essential_principles>
+- Principle with reasoning
+</essential_principles>
+
+<intake>
+## What would you like to do?
+1. **Option A** — description
+</intake>
+
+<routing>
+| Response | Workflow |
+|----------|----------|
+| 1, "keyword" | `references/option-a.md` |
+</routing>
+```
+
+Simple skills with a single linear workflow can use markdown headings alone.
 
 ## Progressive Disclosure
 

--- a/skills/skill-maker/references/xml-structure-guide.md
+++ b/skills/skill-maker/references/xml-structure-guide.md
@@ -12,33 +12,33 @@ XML tags help agents parse complex prompts unambiguously — especially when a s
 
 **Rule of thumb:** If a skill has an intake question, a routing table, and essential principles, use XML tags. They give agents clear section boundaries that markdown headings can't reliably provide — headings blend together in long prompts, while XML tags create unambiguous containers.
 
-## Established tag vocabulary
+## Suggested tag patterns
 
-Use these consistently across skills. Descriptive, lowercase, underscored names.
+These are patterns that have worked well in practice. Invent new tags as needed — the goal is descriptive, consistent names (lowercase, underscored) that make section boundaries unambiguous.
 
-### Structural tags
+### Common structural tags
 
-| Tag | Purpose | When to use |
+| Tag | Purpose | Example use |
 |---|---|---|
-| `<essential_principles>` | Rules that apply to ALL commands — always loaded | Every router/domain skill |
-| `<intake>` | User-facing menu or intake question | Skills that ask "what do you want to do?" |
-| `<routing>` | Routing table mapping responses to workflows/references | After `<intake>` |
-| `<reference_index>` | List of reference files with "load when..." guidance | Skills with 3+ references |
-| `<success_criteria>` | Observable, verifiable outcomes checklist | Skills with measurable completion |
+| `<essential_principles>` | Rules that apply across all commands | Cross-cutting constraints |
+| `<intake>` | User-facing menu or intake question | "What do you want to do?" |
+| `<routing>` | Table mapping responses to workflows/references | After `<intake>` |
+| `<reference_index>` | Reference files with "load when..." guidance | Skills with multiple references |
+| `<success_criteria>` | Observable, verifiable outcomes checklist | Measurable completion |
 | `<cli_setup>` | CLI initialization — path discovery, variable setup | Skills that depend on a CLI tool |
-| `<context_scan>` | Environment detection run on invocation | Skills that adapt to environment state |
-| `<skills_index>` | Related skills with paths | Skills that route to or depend on other skills |
+| `<context_scan>` | Environment detection run on invocation | Adapting to environment state |
+| `<skills_index>` | Related skills with paths | Cross-skill routing |
 
-### Content tags
+### Other patterns seen in the wild
 
-| Tag | Purpose | When to use |
-|---|---|---|
-| `<principle name="...">` | Individual principle inside `<essential_principles>` | When principles need named identifiers for cross-referencing |
-| `<cli_commands>` | CLI command reference | Skills with a custom CLI |
-| `<workflows_index>` | Workflow files listing | Skills with 3+ workflow files |
-| `<templates_index>` | Template files listing | Skills that provide starter templates |
-| `<tracking_system>` | Activity logging and context persistence | Skills with session tracking |
-| `<inline_*>` | Inline mini-workflows (e.g., `<inline_status_check>`) | Short workflows that don't warrant a separate file |
+| Tag | Purpose |
+|---|---|
+| `<principle name="...">` | Named principle inside `<essential_principles>` for cross-referencing |
+| `<cli_commands>` | CLI command reference |
+| `<workflows_index>` | Workflow files listing |
+| `<templates_index>` | Template files listing |
+| `<tracking_system>` | Activity logging and context persistence |
+| `<inline_*>` | Inline mini-workflows (e.g., `<inline_status_check>`) |
 
 ## Patterns
 
@@ -124,6 +124,6 @@ XML tags are containers — use markdown freely inside them for formatting, tabl
 
 **Don't nest XML deeply.** One level of nesting (`<essential_principles>` → `<principle>`) is the maximum. Deeper nesting creates parsing ambiguity and is harder to read.
 
-**Don't invent new tags when an established one fits.** Check the vocabulary table above first. Consistency across skills means agents learn the pattern once.
+**Prefer existing tag names when they fit.** If your skill has an intake question, `<intake>` is clearer than `<user_prompt>` or `<menu>`. But don't force a tag name that doesn't describe your content — invent a better one.
 
 **Don't put XML tags inside code blocks as examples and expect them to be parsed.** If showing XML as an example, use fenced code blocks. Only bare XML tags in the skill body are treated as structural.

--- a/skills/skill-maker/references/xml-structure-guide.md
+++ b/skills/skill-maker/references/xml-structure-guide.md
@@ -1,0 +1,129 @@
+# XML Structure Guide for Skills
+
+XML tags help agents parse complex prompts unambiguously — especially when a skill mixes instructions, context, examples, and variable inputs. Wrapping each type of content in its own tag reduces misinterpretation.
+
+## When to use XML vs markdown
+
+| Pattern | Structure | Rationale |
+|---|---|---|
+| **Simple skill** (single workflow) | Markdown headings | Not enough structure to benefit from XML overhead |
+| **Router skill** (multiple commands) | XML tags for sections, markdown within | Sections are semantically distinct — XML makes boundaries unambiguous |
+| **Domain expertise skill** (full lifecycle) | XML tags for sections, markdown within | Many interleaved concerns need clear separation |
+
+**Rule of thumb:** If a skill has an intake question, a routing table, and essential principles, use XML tags. They give agents clear section boundaries that markdown headings can't reliably provide — headings blend together in long prompts, while XML tags create unambiguous containers.
+
+## Established tag vocabulary
+
+Use these consistently across skills. Descriptive, lowercase, underscored names.
+
+### Structural tags
+
+| Tag | Purpose | When to use |
+|---|---|---|
+| `<essential_principles>` | Rules that apply to ALL commands — always loaded | Every router/domain skill |
+| `<intake>` | User-facing menu or intake question | Skills that ask "what do you want to do?" |
+| `<routing>` | Routing table mapping responses to workflows/references | After `<intake>` |
+| `<reference_index>` | List of reference files with "load when..." guidance | Skills with 3+ references |
+| `<success_criteria>` | Observable, verifiable outcomes checklist | Skills with measurable completion |
+| `<cli_setup>` | CLI initialization — path discovery, variable setup | Skills that depend on a CLI tool |
+| `<context_scan>` | Environment detection run on invocation | Skills that adapt to environment state |
+| `<skills_index>` | Related skills with paths | Skills that route to or depend on other skills |
+
+### Content tags
+
+| Tag | Purpose | When to use |
+|---|---|---|
+| `<principle name="...">` | Individual principle inside `<essential_principles>` | When principles need named identifiers for cross-referencing |
+| `<cli_commands>` | CLI command reference | Skills with a custom CLI |
+| `<workflows_index>` | Workflow files listing | Skills with 3+ workflow files |
+| `<templates_index>` | Template files listing | Skills that provide starter templates |
+| `<tracking_system>` | Activity logging and context persistence | Skills with session tracking |
+| `<inline_*>` | Inline mini-workflows (e.g., `<inline_status_check>`) | Short workflows that don't warrant a separate file |
+
+## Patterns
+
+### Named principles
+
+Use `<principle name="...">` when principles need to be referenced by name from other sections or workflow files:
+
+```xml
+<essential_principles>
+
+<principle name="token_safety">
+Never read `.jira-token` into context. Always use shell substitution: `"$(cat "$TOKEN_FILE")"`.
+Tokens in context risk leaking into outputs and persist across compacted sessions.
+</principle>
+
+<principle name="data_sources">
+Plugin package definitions come from rhdh-plugin-export-overlays on GitHub.
+Always fetch the OCI reference from `spec.dynamicArtifact` — do NOT construct OCI URLs manually.
+Manually constructed URLs miss the PR number and commit SHA that CI embeds.
+</principle>
+
+</essential_principles>
+```
+
+When principles are short and don't need cross-referencing, plain `<essential_principles>` with bullet points or markdown content inside works fine.
+
+### Intake → routing flow
+
+The `<intake>` and `<routing>` tags form a natural pair. Keep them adjacent:
+
+```xml
+<intake>
+## What would you like to do?
+
+1. **Create an issue** — New feature, epic, story, task, or bug
+2. **Refine an issue** — Size, complete fields, challenge scope
+3. **Plan the sprint** — Capacity, assignments, sprint goals
+
+**Wait for response before proceeding.**
+</intake>
+
+<routing>
+| Response | Workflow |
+|----------|----------|
+| 1, "create", "new issue" | `references/to-issue.md` |
+| 2, "refine", "groom" | `references/refine.md` |
+| 3, "plan", "sprint" | `references/plan.md` |
+</routing>
+```
+
+### Reference index with conditional loading
+
+The `<reference_index>` tag replaces a flat markdown list with structured guidance about when each reference should be loaded:
+
+```xml
+<reference_index>
+
+| Reference | Purpose | Path |
+|-----------|---------|------|
+| sources | Lifecycle URLs per platform | `references/sources.md` |
+| auth | Token setup and curl patterns | `../rhdh-jira/references/auth.md` |
+
+</reference_index>
+```
+
+### Nesting markdown inside XML
+
+XML tags are containers — use markdown freely inside them for formatting, tables, code blocks, and lists. This mixes the structural clarity of XML with the readability of markdown:
+
+```xml
+<essential_principles>
+
+- **Copy-sync first** — all edits go in `rhdh-customizations/`, never in `rhdh-local/` directly.
+  After every edit, run `rhdh local apply` to sync.
+- **Use scripts** — run `rhdh local up` / `rhdh local down`, never `podman compose` directly.
+
+</essential_principles>
+```
+
+## Anti-patterns
+
+**Don't wrap everything in XML.** Simple skills with a linear workflow don't benefit — XML just adds noise. Only use XML when the skill has semantically distinct sections that need unambiguous boundaries.
+
+**Don't nest XML deeply.** One level of nesting (`<essential_principles>` → `<principle>`) is the maximum. Deeper nesting creates parsing ambiguity and is harder to read.
+
+**Don't invent new tags when an established one fits.** Check the vocabulary table above first. Consistency across skills means agents learn the pattern once.
+
+**Don't put XML tags inside code blocks as examples and expect them to be parsed.** If showing XML as an example, use fenced code blocks. Only bare XML tags in the skill body are treated as structural.

--- a/skills/skill-maker/references/xml-structure-guide.md
+++ b/skills/skill-maker/references/xml-structure-guide.md
@@ -73,9 +73,9 @@ The `<intake>` and `<routing>` tags form a natural pair. Keep them adjacent:
 <intake>
 ## What would you like to do?
 
-1. **Create an issue** — New feature, epic, story, task, or bug
-2. **Refine an issue** — Size, complete fields, challenge scope
-3. **Plan the sprint** — Capacity, assignments, sprint goals
+1. **Command A** — Short description of first option
+2. **Command B** — Short description of second option
+3. **Command C** — Short description of third option
 
 **Wait for response before proceeding.**
 </intake>
@@ -83,9 +83,9 @@ The `<intake>` and `<routing>` tags form a natural pair. Keep them adjacent:
 <routing>
 | Response | Workflow |
 |----------|----------|
-| 1, "create", "new issue" | `references/to-issue.md` |
-| 2, "refine", "groom" | `references/refine.md` |
-| 3, "plan", "sprint" | `references/plan.md` |
+| 1, "keyword-a" | `references/command-a.md` |
+| 2, "keyword-b" | `references/command-b.md` |
+| 3, "keyword-c" | `references/command-c.md` |
 </routing>
 ```
 
@@ -98,8 +98,8 @@ The `<reference_index>` tag replaces a flat markdown list with structured guidan
 
 | Reference | Purpose | Path |
 |-----------|---------|------|
-| sources | Lifecycle URLs per platform | `references/sources.md` |
-| auth | Token setup and curl patterns | `../rhdh-jira/references/auth.md` |
+| setup | Environment setup and prerequisites | `references/setup.md` |
+| patterns | Reusable patterns for common tasks | `references/patterns.md` |
 
 </reference_index>
 ```

--- a/skills/skill-maker/templates/router-skill-xml.md
+++ b/skills/skill-maker/templates/router-skill-xml.md
@@ -1,0 +1,51 @@
+---
+name: SKILL_NAME
+description: |
+  What the skill does broadly. Use when [trigger phrases for any sub-command].
+  Also use when [edge phrasings, related terms].
+---
+
+<essential_principles>
+
+<principle name="PRINCIPLE_NAME">
+Rule that applies to ALL commands. Explain why — agents generalize from reasoning, not rigid rules.
+</principle>
+
+<principle name="ANOTHER_PRINCIPLE">
+Another cross-cutting rule with reasoning.
+</principle>
+
+</essential_principles>
+
+<intake>
+## What would you like to do?
+
+1. **Command A** — What it does
+2. **Command B** — What it does
+
+**Wait for response before proceeding.**
+</intake>
+
+<routing>
+| Response | Workflow |
+|----------|----------|
+| 1, "keyword-a", "alt-phrase" | `references/command-a.md` |
+| 2, "keyword-b", "alt-phrase" | `references/command-b.md` |
+</routing>
+
+<reference_index>
+
+| Reference | Load when... | Path |
+|-----------|-------------|------|
+| command-a | Running command A | `references/command-a.md` |
+| command-b | Running command B | `references/command-b.md` |
+| shared-patterns | [specific condition] | `references/shared-patterns.md` |
+
+</reference_index>
+
+<success_criteria>
+
+- [ ] Criterion that proves the skill completed correctly
+- [ ] Another observable, verifiable outcome
+
+</success_criteria>


### PR DESCRIPTION
## Summary

Agents parse XML tags more reliably than markdown headings for skills with multiple semantic sections. This updates skill-maker to recommend and demonstrate XML structure throughout.

### Changes

**New files:**
- `references/xml-structure-guide.md` — suggested tag patterns, when to use XML vs markdown, anti-patterns
- `templates/router-skill-xml.md` — XML-based starter template for router skills

**SKILL.md updates:**
- Uses `<intake>`, `<routing>`, `<reference_index>` tags (practices what it preaches)
- Adds XML structure guidance section with when-to-use decision criteria
- Updates audit and review checklists to consider XML for multi-section skills

**Reference file updates:**
- `architecture-patterns.md` — router structure section lists XML tags, router table example uses `<intake>`/`<routing>`
- `anti-patterns.md` — missing intake question fix shows `<intake>` example
- `spec-guide.md` — body section shows XML structure example

**Audit fixes:**
- `xml-structure-guide.md` examples use generic placeholder paths instead of paths from sibling skills
- `SKILL.md` routing table uses specific section names instead of vague "follow below"

### Design decisions

- XML is presented as **suggested patterns**, not a rigid vocabulary — skills should invent tags that fit their domain
- Skill-maker phases (1–5) stay as markdown headings — sequential instructional content where order matters more than section lookup
- XML recommended for skills with semantically distinct sections (intake, routing, principles) that agents need to jump between