### PR TITLE
feat(rhdh-jira): incorporate COPE standup 5/14 decisions and process docs

### DIFF
--- a/skills/rhdh-jira/SKILL.md
+++ b/skills/rhdh-jira/SKILL.md
@@ -121,7 +121,8 @@ Load only what the current task requires.
 | `references/fields.md` | Need to know a field name, custom field ID, accepted values, or label conventions. Custom fields, labels, link types, components, priorities. |
 | `references/workflows.md` | Transitioning issues, checking exit criteria, or verifying readiness for the next status. |
 | `references/templates.md` | Creating new issues. Also load `references/workflows.md` for required fields at entry status. |
-| `references/support.md` | Handling support cases, filing bugs from customer cases, or creating feature requests from support. |
+| `references/support.md` | Handling support cases, filing bugs from customer cases, or creating feature requests from support. Full RHDHSUPP workflow, SLA, and anti-patterns. |
+| `references/feature-exploration.md` | Feature Exploration Process checklist: component validation, labels (demo, rhdh-testday), Doc Epic automation, cross-team dependencies, rescoping. Load when creating Features, refining Features, or checking Feature readiness. |
 | `references/jql-patterns.md` | Building a JQL query, finding a board ID, or looking up sprint information. JQL cookbook with 23+ tested queries. |
 | `references/auth.md` | Setting up authentication for REST API or GraphQL calls. Token file format, path discovery, security, instance config, common auth errors. |
 | `references/rest-api-fallback.md` | `acli` failed to update a custom field (Team, Size, Story Points, Release Note Type). Curl examples, response handling, OpenAPI spec discovery. |
@@ -156,6 +157,8 @@ Load only what the current task requires.
 11. **GraphQL search is beta.** `issueSearchStable` requires `X-ExperimentalApi: JiraIssueSearch` header. Load `references/graphql-queries.md` before attempting GraphQL queries.
 12. **`.jira-token` format is `email:token`, not bare token.** A file containing only the API token without the email prefix will cause 401 errors on REST/GraphQL calls. The `setup.py` script validates the format.
 13. **`acli search` silently truncates results.** The default page size is 30. If your JQL matches more than 30 issues, you get the first 30 with no warning. Always pass `--limit 200` for bulk queries, or use `--count` first to check the total, then `--paginate` to fetch all pages. This is the #2 cause of incorrect reports after skipping `--enrich`.
+14. **"Feature Exploration" vs "Feature Refinement."** The meeting/process is called **Feature Exploration**. The Jira workflow status is **Refinement**. These are different things. When referring to the meeting or process, always use "Feature Exploration." When referring to the Jira status, use "Refinement." The meeting is sometimes mislabeled as "Feature Refinement" in calendar invites — this is incorrect.
+15. **Don't remove `rhdh-X.Y-candidate` labels.** Candidate labels track release targeting. Removing them without PM approval can silently drop a feature from release tracking.
 
 ## Error Handling
 

--- a/skills/rhdh-jira/references/acli-commands.md
+++ b/skills/rhdh-jira/references/acli-commands.md
@@ -87,7 +87,7 @@ acli jira workitem edit --key "RHIDP-123,RHIDP-124" --assignee "jdoe@example.com
 acli jira workitem edit --jql "project = RHIDP AND labels = 'needs-info'" --labels "needs-pm" --yes
 
 # Add/remove labels
-acli jira workitem edit --key RHIDP-123 --labels "demo,test-day" --yes
+acli jira workitem edit --key RHIDP-123 --labels "demo,rhdh-testday" --yes
 acli jira workitem edit --key RHIDP-123 --remove-labels "needs-info" --yes
 
 # Edit description from file

--- a/skills/rhdh-jira/references/feature-exploration.md
+++ b/skills/rhdh-jira/references/feature-exploration.md
@@ -1,0 +1,131 @@
+# Feature Exploration Process
+
+Checklist for reviewing and refining Features and Epics before sprint planning. This is the process followed during **Feature Exploration** meetings (not "Feature Refinement" — see Terminology note below).
+
+## Terminology
+
+The meeting is called **Feature Exploration**. The Jira workflow status is **Refinement**. These are different things:
+
+- **Feature Exploration** — the meeting where team leads, architects, and engineers review candidate features, ask questions, and identify risks
+- **Refinement (Jira status)** — the workflow status a Feature enters after initial fields are set
+
+Do not confuse the two. When referring to the meeting or process, use "Feature Exploration."
+
+## Feature Exploration Checklist
+
+Team leads, architects, and engineers review feature candidates to identify dependencies and risks.
+
+### 1. Set Required Jira Fields
+
+- **Priority** — set based on business value and urgency
+- **Team** — assign the owning scrum team
+- **Assignee** — assign a Feature Owner (single point of contact)
+
+### 2. Cross-Team Engagement
+
+- Identify if the feature requires work from other scrum teams
+- Engage with those teams to design the solution
+- Document dependencies in the Jira issue
+- Confirm the other teams are aware and have capacity
+
+### 3. Labels for PM and Reporter Communication
+
+- Add `needs-pm` if there are questions for Product Management
+- Add `needs-info` if there are questions for the feature reporter from Engineering
+- Use Feature Exploration meetings to ask unanswered questions after discussing in the Jira issue first
+
+### 4. Update Jira with Decisions
+
+- Document decisions, questions, and next steps in the issue (as comments, not description bloat)
+- Consider rescoping if the feature is too large to fit within a single release
+
+### 5. Set Components
+
+Components must be accurate — they affect Feature Freeze and Code Freeze queries.
+
+- Validate components against the project's component list (see Component Validation below)
+- If the feature involves documentation, set the `Documentation` component and invoke the doc automation: **Feature → More → Create Doc EPIC from RHDHPlan**
+  - Note: This is a Jira UI automation action. The agent should prompt the user to perform this step manually after the Feature is created.
+  - Note: Doc EPIC automation is only available for the Documentation component. If it's not available, coordinate with the Docs team directly.
+- Some components may be excluded from Feature Freeze (FF) or Code Freeze (CF). Check the component's FF/CF status before assuming it blocks a freeze.
+
+### 6. Set Labels
+
+- `demo` — if the feature requires a customer-facing feature demo
+- `rhdh-testday` — if this feature should be tested as part of release test day
+- `rhdh-X.Y-candidate` — candidate for a specific release (e.g., `rhdh-2.1-candidate`)
+- `stretch` — stretch goal for the release (may be descoped)
+
+### 7. Create Epics for Each Scrum Team
+
+Refine the Feature and create Epic(s) for work to be delivered by each scrum team. For each Epic:
+
+- Set the **Team** field to the owning scrum team
+- Assign an **Epic Owner** (Assignee) — work with the scrum team to identify
+- The Epic Owner is responsible for sizing the Epic
+
+Set these fields on each Epic:
+
+| Field | What to set |
+|-------|------------|
+| Component(s) | Validate against project component list |
+| Size | T-shirt size per the sizing guide |
+| Links (Dependencies) | Link or note key dependencies on other issues, teams, upstream work |
+
+### 8. Size the Feature
+
+- Feature Owner sizes the Feature by updating the **Size** field
+- Base Feature size on the sizing guide and the aggregate of Epic T-shirt sizes
+- If multiple L or XL Epics exist within a Feature, reassess scope — the Feature may be too large
+
+### 9. Set Feature Status
+
+After exploration is complete:
+
+- Set Feature Status to **Backlog**
+- Ensure all child Epics are created and linked
+
+## Component Validation
+
+Components are critical for freeze queries and team routing. Validate proposed components against the live Jira data.
+
+> Same validation pattern as `fields.md` Component Validation — duplicated here to avoid transitive loading.
+
+```bash
+# List all components for a project
+curl -s -H "Authorization: Basic $(cat "$TOKEN_FILE")" \
+  "https://redhat.atlassian.net/rest/api/3/project/RHIDP/components" | \
+  python -c "import sys,json; [print(c['name']) for c in json.load(sys.stdin)]"
+
+# For RHDHPLAN
+curl -s -H "Authorization: Basic $(cat "$TOKEN_FILE")" \
+  "https://redhat.atlassian.net/rest/api/3/project/RHDHPLAN/components" | \
+  python -c "import sys,json; [print(c['name']) for c in json.load(sys.stdin)]"
+```
+
+When setting components during feature creation or refinement:
+
+1. **Infer components** from the issue summary and description — match against known component names
+2. **Validate** the proposed components exist in the project
+3. **Flag mismatches** — if a component doesn't exist, suggest the closest match
+4. **Check FF/CF status** — note if a component is excluded from freeze queries (this affects release planning)
+
+The agent should suggest components based on issue details, but always confirm with the user before setting them.
+
+## Feature Demo and Test Day
+
+Features that are customer-facing should be assessed for:
+
+- **Demo requirement** — does this need a feature demo? If yes, add the `demo` label. A link to the Feature Demo is required at **Release Pending** status.
+- **Test day candidacy** — should this be tested during release test day? If yes, add the `rhdh-testday` label.
+
+Ask about both during feature creation and refinement.
+
+## Rescoping
+
+If a feature is too large for a single release:
+
+1. Consider splitting into multiple Features across releases
+2. Identify the minimum viable scope for the current release
+3. Document what's being deferred and why (as a comment on the Feature)
+4. Adjust the `rhdh-X.Y-candidate` label if the target release changes

--- a/skills/rhdh-jira/references/fields.md
+++ b/skills/rhdh-jira/references/fields.md
@@ -50,12 +50,13 @@ All lowercase, hyphen-separated. Labels are global to the Jira instance.
 
 | Label | Usage |
 |-------|-------|
-| `demo` | Customer-facing Features/Epics requiring a feature demo |
-| `needs-info` | Release planning — needs more information |
+| `demo` | Customer-facing Features/Epics requiring a feature demo. See `references/feature-exploration.md`. |
+| `needs-info` | Release planning — needs more information from the feature reporter (Engineering → reporter) |
 | `needs-pm` | Release planning — needs product management input |
 | `stretch` | Feature is a stretch goal for a release |
-| `test-day` | Feature is a Test Day candidate |
-| `rhdh-n.n-candidate` | Feature is a candidate for release n.n (e.g., `rhdh-1.10-candidate`) |
+| `rhdh-testday` | Feature should be tested as part of release test day. Set during Feature Exploration. |
+| `quality` | Continuous improvement issues. **Excluded from code freeze release queries** — use this label (not `ci`) to ensure the issue doesn't block a code freeze. |
+| `rhdh-n.n-candidate` | Feature is a candidate for release n.n (e.g., `rhdh-2.1-candidate`). **Do not remove without PM approval** — removing this label can silently drop a feature from release tracking. |
 | `ci-fail` | Identifies CI failures |
 | `must-have` | Documentation team — must-have for release doc plan |
 | `nice-to-have` | Documentation team — nice-to-have for release doc plan |
@@ -79,17 +80,42 @@ Match by **name** in `issuelinks`, not by ID.
 
 List all available link types with: `acli jira workitem link type`
 
-## Components (RHIDP)
+## Components
 
-Heavily used for filtering and routing. Key components:
+Heavily used for filtering, routing, and freeze queries. Components affect Feature Freeze and Code Freeze scope — some components may be excluded from FF/CF.
 
-Key components (run `acli jira workitem search --jql "project = RHIDP AND component = 'X'" --count` for current counts):
+Key components in RHIDP (run `acli jira workitem search --jql "project = RHIDP AND component = 'X'" --count` for current counts):
 
 Documentation, Security, UI, Lightspeed, Orchestrator, Continuous Improvement, Plugins, Topology
 
 Query by component: `project = RHIDP AND component = 'Documentation'`
 
 Components are not available via `--fields` on search. Use `--json` to get component data.
+
+### Component Validation
+
+When setting components during issue creation or refinement, validate against the project's live component list:
+
+```bash
+# List all components for RHIDP
+curl -s -H "Authorization: Basic $(cat "$TOKEN_FILE")" \
+  "https://redhat.atlassian.net/rest/api/3/project/RHIDP/components" | \
+  python -c "import sys,json; [print(c['name']) for c in json.load(sys.stdin)]"
+
+# List all components for RHDHPLAN
+curl -s -H "Authorization: Basic $(cat "$TOKEN_FILE")" \
+  "https://redhat.atlassian.net/rest/api/3/project/RHDHPLAN/components" | \
+  python -c "import sys,json; [print(c['name']) for c in json.load(sys.stdin)]"
+```
+
+During creation grills:
+
+1. Infer likely components from the issue summary and description
+2. Validate the proposed components exist in the target project
+3. If a component doesn't exist, suggest the closest match
+4. Confirm with the user before setting
+
+See `references/feature-exploration.md` for the full Feature Exploration component checklist.
 
 ## Priorities
 

--- a/skills/rhdh-jira/references/refine.md
+++ b/skills/rhdh-jira/references/refine.md
@@ -142,6 +142,27 @@ For issues in the current sprint, verify they meet the "Planned" criteria:
 
 Flag any sprint issue missing these as "not sprint-ready."
 
+### Check 7 — Feature Exploration Readiness (when context is feature freeze triage or Features are in scope)
+
+For Features, check against the Feature Exploration checklist (`references/feature-exploration.md`):
+
+| Check | How to verify | Severity |
+|-------|---------------|----------|
+| Candidate label | Labels include `rhdh-X.Y-candidate` pattern | error — feature is invisible to release tracking |
+| Components set and valid | At least one component in `JiraComponentsField` | error |
+| `demo` label decision | If feature is customer-facing, check for `demo` label | warning — ask if demo is needed |
+| `rhdh-testday` label decision | If feature is customer-facing, check for `rhdh-testday` label | warning — ask if test day is needed |
+| Child Epics exist | Query `parent = {key}` for Epic children | error if status ≥ Backlog |
+| Cross-team dependencies noted | Check issue links for `Blocks`/`Depend` to other teams | warning if none and feature involves multiple teams |
+| Feature Demo link | Check for demo link in issue links (required at Release Pending) | warning if status approaching Release Pending |
+
+**Freeze-aware filtering:** When running in feature freeze triage context, exclude issues labeled `quality` from the release query — continuous improvement issues are not subject to code freeze.
+
+```jql
+-- Feature freeze query (excludes quality-labeled issues)
+project = RHDHPLAN AND issuetype = Feature AND labels in ("rhdh-X.Y-candidate") AND labels != "quality" AND status != Closed
+```
+
 ## Output
 
 ### Data Contract

--- a/skills/rhdh-jira/references/release.md
+++ b/skills/rhdh-jira/references/release.md
@@ -87,7 +87,7 @@ For each Feature, verify expected labels:
 | Label | Required when | Flag if missing |
 |-------|--------------|----------------|
 | `demo` | Customer-facing Feature | "Customer-facing Feature missing `demo` label — needs Feature Demo." |
-| `test-day` | Test Day candidate | Informational only — note if present. |
+| `rhdh-testday` | Test Day candidate | Informational only — note if present. |
 | Documentation component | Feature requires docs | "No Documentation component — will Docs team create an Epic?" |
 
 ### Step 5 — Readiness Score

--- a/skills/rhdh-jira/references/support.md
+++ b/skills/rhdh-jira/references/support.md
@@ -2,25 +2,72 @@
 
 How support cases flow between RHDHSUPP, RHDHBUGS, and RHDHPLAN.
 
-## Overview
+## Key Concepts
 
-1. Customer creates request on Customer Portal (access.redhat.com)
-2. Support team investigates, reviews documentation and KCS articles
-3. If engineering help needed → Support creates **RHDHSUPP Bug** to track discussion
-4. Investigation continues until resolution
-5. Resolution may produce a **RHDHBUGS Bug** (defect) or **RHDHPLAN Feature Request**
+- **RHDHSUPP** — Internal project for engineering-support conversations. Not public.
+- **RHDHBUGS** — Public project for product defects. **Never include customer information.**
+- **RHDHPLAN** — Public project for feature requests.
+- The engineering support liaison owns the relationship with the support team. Route questions about the support process to them.
 
-## RHDHSUPP → RHDHBUGS (Defect Path)
+## Anti-Pattern: Don't Comment on External Support Tickets
 
-When a product defect is identified during support investigation:
+Engineering discussions happen in **RHDHSUPP issues only**. Do not comment directly on external customer support cases. Instead:
+
+1. Create an internal RHDHSUPP issue
+2. Link it to the external support case
+3. Keep all engineering discussion in the RHDHSUPP issue
+
+This keeps customer-facing communication controlled through the support team.
+
+## Full Workflow
+
+### Step 1 — Customer Creates Request
+
+Customer submits a request on the Customer Portal. Support ensures it has the correct:
+
+- Product and version
+- Severity (1–4, where 1 is highest: 1-hour SLA)
+- Description, trace logs, entitlement
+
+### Step 2 — Support Investigates
+
+A support representative is assigned. They:
+
+- Review documentation and KCS articles
+- Attempt to reproduce and diagnose
+
+### Step 3 — Engineering Engaged (if needed)
+
+If support needs engineering help, they open an **RHDHSUPP Bug** to track the discussion.
+
+- Each RHDHSUPP Bug should be linked to the support ticket
+- Priority, Component, and issue template must be set
+
+### Step 4 — Investigation
+
+Engineering responds following SLA. Investigation continues until an agreed solution is reached.
+
+During investigation, if defects are found that are **unrelated** to the customer case, the engineer should still create RHDHBUGS Bugs to capture them for future work.
+
+### Step 5 — Resolution
+
+Resolutions include:
+
+- Solution or workaround provided
+- Termination of investigation (not supported, no further work possible, technical limitations)
+- Identification of a product defect → go to Step 6
+- Identification of a feature request → go to Step 7
+
+### Step 6 — Product Defect (RHDHSUPP → RHDHBUGS)
+
+When a product defect is identified:
 
 1. Create `Bug` in **RHDHBUGS** with:
    - Priority, Component (use `Documentation` for doc defects)
    - Bug template filled out (reproduction steps, expected behavior)
    - **No customer information** — RHDHBUGS is a public project
    - Link to Customer Case via SFDC Cases Links
-2. Comment on the RHDHSUPP issue with the RHDHBUGS link
-3. This tells the customer when the fix is expected
+2. Comment on the RHDHSUPP issue with the RHDHBUGS link — this tells the customer when the fix is expected
 
 ```bash
 # Create the bug
@@ -38,7 +85,7 @@ acli jira workitem comment create --key RHDHSUPP-456 \
   --body "Defect captured in RHDHBUGS-789. Fix targeted for next y-stream release."
 ```
 
-## RHDHSUPP → RHDHPLAN (Feature Request Path)
+### Step 7 — Feature Request (RHDHSUPP → RHDHPLAN)
 
 When a support case reveals a missing capability:
 
@@ -56,31 +103,33 @@ acli jira workitem create --project RHDHPLAN --type "Feature Request" \
 acli jira workitem link create --out RHDHSUPP-456 --in RHDHPLAN-123 --type "Related" --yes
 ```
 
-## Bug Fix Prioritization
-
-| Scenario | Target Release | Priority |
-|----------|---------------|----------|
-| Default | Next y-stream (e.g., 1.11.0) | As determined by triage |
-| Critical to customer | Current z-stream (e.g., 1.10.4) | Set to **Blocker** |
-| Customer request, not urgent | Future y-stream | As determined by triage |
-
-For z-stream targeting, discuss with the engineer to prioritize. If committed, set Priority to Blocker and the target fix version.
-
-## Closing RHDHSUPP Issues
+### Step 8 — Close RHDHSUPP Issue
 
 Close the RHDHSUPP Bug when:
 
 - Investigation is resolved, OR
 - No response from customer within SLA
 
-On close, set **Story Points** to capture the effort spent on the investigation. See the sizing guide for reference.
+On close, set **Story Points** to capture the effort spent on the investigation. See the sizing guide for RHDHSUPP-specific point scale.
+
+## Bug Fix Prioritization
+
+| Scenario | Target Release | Priority |
+|----------|---------------|----------|
+| Default | Next y-stream (e.g., 1.11.0) | As determined by triage |
+| Critical to customer | Current z-stream (e.g., 1.10.4) | Set to **Blocker** + target fix version |
+| Customer request, not urgent | Future y-stream | As determined by triage |
+
+For z-stream targeting, discuss with the engineer to prioritize. If committed, set Priority to Blocker and the target fix version.
 
 ## Communication Channels
 
 | Channel | Purpose |
 |---------|---------|
 | `#rhdh-support` | Engineering and Developer Hub support team communication |
-| `#rhdh-support-cases` | Notification channel for new RHDHSUPP bugs from support |
+| `#rhdh-support-cases` | Notification channel for new RHDHSUPP bugs from support team |
+
+New support case notifications are managed through Hydra (the internal notification routing tool). Contact the engineering support liaison if notification configuration changes are needed.
 
 ## Ticket SLA
 
@@ -103,3 +152,27 @@ SLA may be negotiated (Negotiated Entitlement Process) or adjusted when a workar
 | **TAM customer** | Technical Account Manager assists with implementation |
 | **Consulting/Partner** | Cases opened during project implementation |
 | **CSE customer** | Customer Success Executive helps communication (non-technical) |
+
+## Reference Resources
+
+The following internal resources exist for deeper reference (access required):
+
+- **RHDH Support Plan** — overall support strategy and staffing
+- **RHDHSUPP CEE Process** — detailed CEE-side workflow
+- **RHDH Support Dashboard / RHDH Supp Kanban Board** — operational views in Jira
+- **RHDH CVE Management** — CVE fix tracking and justifications
+- **RHDH Troubleshooting Guide** — common troubleshooting steps for support cases
+- **Lifecycle Policies** — RHDH, RHPIB, and Red Hat Plug-Ins lifecycle policies (determines support scope per version)
+- **Severity Definition & 24x7 Qualifications** — detailed severity criteria and eligibility
+
+These are internal documents. Do not embed their URLs in agent output or share externally.
+
+## Jira Projects Used in Support
+
+| Project | Purpose | Public? |
+|---------|---------|---------|
+| RHDHSUPP | Internal conversations between support and engineering | No |
+| RHDHBUGS | Product defects — bugs and doc defects | Yes |
+| RHDHPLAN | Feature requests from customers | Yes |
+
+**Security rule:** Never copy customer-identifying information from RHDHSUPP into RHDHBUGS or RHDHPLAN. Those projects are public.

--- a/skills/rhdh-jira/references/to-epic.md
+++ b/skills/rhdh-jira/references/to-epic.md
@@ -54,6 +54,10 @@ Follow the challenging behavior in `references/grill.md`.
 
 Infer all Jira fields per `references/grill.md` Field Inference. If chained, inherit Priority and Team from parent Feature. Key fields: Team, Priority, Size (T-shirt), Component, Assignee (Epic Owner).
 
+**Components:** Infer from the epic description and validate against the project's component list per `references/fields.md` → Component Validation. If the epic involves documentation, set the `Documentation` component.
+
+**Dependencies:** Link or note key dependencies on other issues, teams, or upstream work.
+
 ### Step 6 — Review
 
 Render the filled template and inferred fields as a temporary markdown file for user review:
@@ -136,6 +140,7 @@ If yes:
 
 ## Caveats
 
-1. **Epic Owner responsibility.** The assignee is the Epic Owner — single point of contact for delivery, works with the Feature Owner to align execution.
-2. **Component is required at New status.** Don't skip this during the grill. See `references/fields.md` for the component list.
+1. **Epic Owner responsibility.** The assignee is the Epic Owner — single point of contact for delivery, works with the Feature Owner to align execution. The Epic Owner is responsible for sizing the Epic.
+2. **Component is required at New status.** Don't skip this during the grill. Validate against `references/fields.md` → Component Validation.
 3. **Multi-team Features create multiple Epics.** When chained from a Feature, each team gets its own Epic. The Feature Owner coordinates across them.
+4. **Size via sizing guide.** Use T-shirt sizing per `references/sizing.md`. If the parent Feature has multiple L or XL Epics, flag for the Feature Owner — the Feature scope may need reassessment.

--- a/skills/rhdh-jira/references/to-feature.md
+++ b/skills/rhdh-jira/references/to-feature.md
@@ -34,7 +34,24 @@ Follow the challenging behavior in `references/grill.md` on the completed draft.
 
 ### Step 4 — Infer Fields
 
-Infer all Jira fields from the conversation per the Field Inference section in `references/grill.md`. Present recommendations for confirmation. Key fields for Features: Priority, Team, Size (T-shirt), Assignee (Feature Owner), and Labels (`demo`, `rhdh-X.Y-candidate`, `stretch`).
+Infer all Jira fields from the conversation per the Field Inference section in `references/grill.md`. Present recommendations for confirmation.
+
+Key fields for Features: Priority, Team, Size (T-shirt), Assignee (Feature Owner), Components, and Labels.
+
+**Components:** Infer likely components from the feature description. Validate them against the project's component list per `references/feature-exploration.md` → Component Validation. Confirm with the user.
+
+**Labels — ask about each during the grill:**
+
+| Label | Question |
+|-------|----------|
+| `demo` | Does this feature need a customer-facing demo? |
+| `rhdh-testday` | Should this feature be tested during release test day? |
+| `rhdh-X.Y-candidate` | Which release does this target? |
+| `stretch` | Is this a stretch goal? |
+
+**Documentation:** If the feature involves documentation, set the `Documentation` component. After creation, prompt: "Create a Doc EPIC from this Feature? (Feature → More → Create Doc EPIC from RHDHPlan)"
+
+**Cross-team dependencies:** Ask if other scrum teams are affected. If yes, note them — they become Epics in Step 9.
 
 ### Step 5 — Review
 
@@ -128,6 +145,8 @@ If yes:
 
 ## Caveats
 
-1. **Feature Owner responsibility.** Creating a Feature implies ownership. Ensure the assignee understands the Feature Owner responsibilities defined in the RHDH Agile Workflow (single point of contact, coordinates cross-team dependencies, ensures sizing and labels).
-2. **Candidate label convention.** The label format is `rhdh-X.Y-candidate` (e.g., `rhdh-2.1-candidate`). Ask which release this targets during the grill.
+1. **Feature Owner responsibility.** Creating a Feature implies ownership. Ensure the assignee understands the Feature Owner responsibilities (single point of contact, coordinates cross-team dependencies, ensures sizing and labels).
+2. **Candidate label convention.** The label format is `rhdh-X.Y-candidate` (e.g., `rhdh-2.1-candidate`). Ask which release this targets during the grill. **Do not remove candidate labels without PM approval.**
 3. **Description stays structured.** Only template sections go in the description. Decision trail, elaboration, and abandoned approaches go in comments.
+4. **Rescoping.** If the feature is too large for a single release, suggest splitting. Document what's deferred and why as a comment. Adjust the candidate label if the target release changes. See `references/feature-exploration.md` → Rescoping.
+5. **Feature Exploration checklist.** After creation, the Feature should pass the full checklist in `references/feature-exploration.md` before moving to Backlog.


### PR DESCRIPTION
## Summary

Incorporates decisions and process documentation from the **COPE Standup on 5/14/2026** into the rhdh-jira skill.

### Sources
- COPE Standup 5/14 Gemini notes, chat transcript, and meeting recording
- RHDHSUPP Engineering Process doc (content embedded, no URLs)
- RHDH Feature Exploration Process doc (content embedded, no URLs)

### Changes

| File | Change |
|------|--------|
| `SKILL.md` | Added `feature-exploration.md` to reference_index; Gotchas #14 (Feature Exploration vs Refinement terminology) and #15 (candidate label protection) |
| `references/support.md` | Major expansion: full 8-step RHDHSUPP workflow, anti-pattern (don't comment on external tickets), reference resources list, security rules |
| `references/feature-exploration.md` | **New file**: Feature Exploration Process checklist with component validation, labels, Doc Epic automation, cross-team dependencies, rescoping |
| `references/fields.md` | Added `quality` label (code freeze exclusion), `rhdh-testday` label, candidate label protection, Component Validation section |
| `references/to-feature.md` | Added component inference, label prompts, Doc Epic automation, cross-team deps, rescoping caveat |
| `references/to-epic.md` | Added component validation, dependency linking, sizing caveats |
| `references/refine.md` | Added Check 7 (Feature Exploration Readiness) with freeze-aware label checks |
| `references/acli-commands.md` | Fixed `test-day` → `rhdh-testday` label |
| `references/release.md` | Fixed `test-day` → `rhdh-testday` label |

### Key Decisions Captured
- **Feature Exploration** is the correct meeting name (not Feature Refinement)
- **`quality` label** mandated for continuous improvement issues (excluded from code freeze queries)
- **Don't comment on external support tickets** — create internal RHDHSUPP issue instead
- **Candidate labels** (`rhdh-X.Y-candidate`) must not be removed without PM approval
- **Component validation** via Jira REST API during feature/epic creation and refinement

### Security
- No internal URLs (Google Docs, Sheets, dashboards behind VPN/auth)
- No person names as process contacts (role titles only)
- No customer data or case numbers
- Slack channel names only (`#rhdh-support`, `#rhdh-support-cases`)

### Verification
- 273 tests pass ✅
- All 34 referenced files exist ✅
- SKILL.md is 282 lines (under 500 limit) ✅
- Skill-maker expert agent audit: **PASS WITH NOTES** (all findings addressed)