### PR TITLE
feat(rhdh-jira): add component catalog, freeze flags, gotchas, and validation

### DIFF
--- a/skills/rhdh-jira/SKILL.md
+++ b/skills/rhdh-jira/SKILL.md
@@ -87,6 +87,7 @@ Before attempting any REST API or GraphQL call:
 | `scripts/setup.py` | Verify acli install + auth. Run with `--json` for structured output. |
 | `scripts/parse_issues.py` | Flatten, enrich, and filter acli JSON output. Solves the core problem: `acli search --json` can't return custom fields (team, story points, sprint). Pipe search results in, get clean data out. Use `--enrich` to fetch full fields, `-f team="X"` to filter by team. |
 | `scripts/command-metadata.json` | Single source of truth for sub-command descriptions and argument hints. |
+| `scripts/validate_components.py` | Validate `references/fields.md` component catalog against live Jira projects (RHIDP + RHDHPLAN). Reports drift in both directions. Run with `--json` for structured output. |
 
 ## Projects
 
@@ -159,6 +160,8 @@ Load only what the current task requires.
 13. **`acli search` silently truncates results.** The default page size is 30. If your JQL matches more than 30 issues, you get the first 30 with no warning. Always pass `--limit 200` for bulk queries, or use `--count` first to check the total, then `--paginate` to fetch all pages. This is the #2 cause of incorrect reports after skipping `--enrich`.
 14. **"Feature Exploration" vs "Feature Refinement."** The meeting/process is called **Feature Exploration**. The Jira workflow status is **Refinement**. These are different things. When referring to the meeting or process, always use "Feature Exploration." When referring to the Jira status, use "Refinement." The meeting is sometimes mislabeled as "Feature Refinement" in calendar invites — this is incorrect.
 15. **Don't remove `rhdh-X.Y-candidate` labels.** Candidate labels track release targeting. Removing them without PM approval can silently drop a feature from release tracking.
+16. **Feature→Epic child links use Parent Link, not issuelinks.** Cross-project parent-child relationships (RHDHPLAN Feature → RHIDP Epic) use the `Parent Link` field (`customfield_10018`), not `issuelinks`. To find child Epics of a Feature, use JQL: `project = RHIDP AND type = Epic AND "Parent Link" = RHDHPLAN-XXX`. Checking `issuelinks` will show zero results and produce false "no child Epics" reports.
+17. **REST `/rest/api/3/search` returns 410 Gone.** This endpoint has been removed. Use POST to `/rest/api/3/search/jql` with body `{"jql": "...", "fields": [...], "maxResults": N}` instead. This only affects direct REST calls — `acli search` still works.
 
 ## Error Handling
 

--- a/skills/rhdh-jira/references/feature-exploration.md
+++ b/skills/rhdh-jira/references/feature-exploration.md
@@ -11,6 +11,10 @@ The meeting is called **Feature Exploration**. The Jira workflow status is **Ref
 
 Do not confuse the two. When referring to the meeting or process, use "Feature Exploration."
 
+**Features in New status is expected going into Feature Exploration.** The exploration meeting is where the team reviews candidates, identifies risks, and produces the information needed to advance features through the pipeline. Do not frame New→Refinement transition as a prerequisite for exploration — it is an *outcome*. Sizing and field population happen during and after exploration.
+
+**Epic creation can happen before or during exploration.** Teams often create child Epics before the exploration meeting to help size the Feature — aggregate Epic sizes inform the Feature’s T-shirt size. Do not treat Epic creation as exclusively an output of exploration.
+
 ## Feature Exploration Checklist
 
 Team leads, architects, and engineers review feature candidates to identify dependencies and risks.

--- a/skills/rhdh-jira/references/feature-exploration.md
+++ b/skills/rhdh-jira/references/feature-exploration.md
@@ -11,7 +11,7 @@ The meeting is called **Feature Exploration**. The Jira workflow status is **Ref
 
 Do not confuse the two. When referring to the meeting or process, use "Feature Exploration."
 
-**Features in New status is expected going into Feature Exploration.** The exploration meeting is where the team reviews candidates, identifies risks, and produces the information needed to advance features through the pipeline. Do not frame New→Refinement transition as a prerequisite for exploration — it is an *outcome*. Sizing and field population happen during and after exploration.
+**Features in New status are expected going into Feature Exploration.** The exploration meeting is where the team reviews candidates, identifies risks, and produces the information needed to advance features through the pipeline. Do not frame New→Refinement transition as a prerequisite for exploration — it is an *outcome*. Sizing and field population happen during and after exploration.
 
 **Epic creation can happen before or during exploration.** Teams often create child Epics before the exploration meeting to help size the Feature — aggregate Epic sizes inform the Feature’s T-shirt size. Do not treat Epic creation as exclusively an output of exploration.
 
@@ -91,30 +91,13 @@ After exploration is complete:
 
 ## Component Validation
 
-Components are critical for freeze queries and team routing. Validate proposed components against the live Jira data.
+Components are critical for freeze queries and team routing. Use the component catalog and validation script from `references/fields.md`:
 
-> Same validation pattern as `fields.md` Component Validation — duplicated here to avoid transitive loading.
-
-```bash
-# List all components for a project
-curl -s -H "Authorization: Basic $(cat "$TOKEN_FILE")" \
-  "https://redhat.atlassian.net/rest/api/3/project/RHIDP/components" | \
-  python -c "import sys,json; [print(c['name']) for c in json.load(sys.stdin)]"
-
-# For RHDHPLAN
-curl -s -H "Authorization: Basic $(cat "$TOKEN_FILE")" \
-  "https://redhat.atlassian.net/rest/api/3/project/RHDHPLAN/components" | \
-  python -c "import sys,json; [print(c['name']) for c in json.load(sys.stdin)]"
-```
-
-When setting components during feature creation or refinement:
-
-1. **Infer components** from the issue summary and description — match against known component names
-2. **Validate** the proposed components exist in the project
-3. **Flag mismatches** — if a component doesn't exist, suggest the closest match
+1. **Match** components from the Component Catalog table in `references/fields.md` — it includes descriptions and freeze exclusion flags
+2. **Infer** from parent — when creating Epics chained from a Feature, inherit the parent's components
+3. **Validate** against live Jira data: `python scripts/validate_components.py`
 4. **Check FF/CF status** — note if a component is excluded from freeze queries (this affects release planning)
-
-The agent should suggest components based on issue details, but always confirm with the user before setting them.
+5. **Confirm** with the user before setting — never auto-set components
 
 ## Feature Demo and Test Day
 

--- a/skills/rhdh-jira/references/fields.md
+++ b/skills/rhdh-jira/references/fields.md
@@ -84,36 +84,149 @@ List all available link types with: `acli jira workitem link type`
 
 Heavily used for filtering, routing, and freeze queries. Components affect Feature Freeze and Code Freeze scope — some components may be excluded from FF/CF.
 
-Key components in RHIDP (run `acli jira workitem search --jql "project = RHIDP AND component = 'X'" --count` for current counts):
-
-Documentation, Security, UI, Lightspeed, Orchestrator, Continuous Improvement, Plugins, Topology
-
 Query by component: `project = RHIDP AND component = 'Documentation'`
 
 Components are not available via `--fields` on search. Use `--json` to get component data.
 
-### Component Validation
+### Component Catalog
 
-When setting components during issue creation or refinement, validate against the project's live component list:
+Full list of RHDH project components with descriptions, grouped by category. Freeze exclusion flags indicate which components are excluded from Feature Freeze (FF), Code Freeze (CF), Post-CF, and Release Notes (RN) queries.
+
+**RHDH Core:**
+
+| Component | Description | Excl FF | CF | Post CF | Excl RN |
+|-----------|-------------|---------|----|---------|---------|
+| Adoption Insights | Plugin tracking adoption metrics and usage patterns | | | | |
+| AI Demo | Demo server showcasing AI capabilities in RHDH | Yes | Yes | Yes | Yes |
+| AI Installer | Automated installer for AI-related RHDH components | | | | |
+| ai-templates | Software templates for AI/ML workflows and model onboarding | | | | |
+| ArgoCD | ArgoCD plugin integration (Roadie version migration) | | | | |
+| Authentication | Static auth provider module, dynamic auth provider, service-service auth, SCM auth | | | | |
+| Build | Container image builds, Konflux pipelines, and build infrastructure | Yes | | | Yes |
+| Bulk Import | Bulk import of repositories and entities into the catalog | | | | |
+| Catalog | Backstage software catalog (entity metadata, sources, composability) | | | | |
+| Database | PostgreSQL database support, migrations, and compatibility | | | | |
+| Dynamic Plugins | Dynamic plugin loading, frontend/backend plugin lifecycle | | | | |
+| Dynamic Plugins Factory | Build tooling for producing dynamic plugin artifacts | | | | |
+| Event Systems | Internal event bus for cross-plugin communication | | | | |
+| Extensions | Extension registry, OCI plugin hosting, and catalog sources | | | | |
+| FIPS | FIPS 140-2/140-3 compliance onboarding and validation testing | | | | |
+| Gitlab | Gitlab integration (SCM, events, auth provider) | | | | |
+| Helm Chart | Helm chart for RHDH deployment on OpenShift/Kubernetes | | | | |
+| High Availability | Multi-replica and HA deployment configurations | | | | |
+| Homepage | Dynamic homepage plugin and backend | | | | |
+| LDAP | LDAP auth provider and entity ingestion | | | | |
+| Lightspeed | AI-powered developer assistant plugin | | | | |
+| Localization | i18n and RTL language support | | | | |
+| LTS | Long Term Support release stream and lifecycle management | | | | |
+| MCP | Model Context Protocol server and AI permissions | | | | |
+| model-catalog | AI/ML model catalog plugin for browsing and discovering models | | | | |
+| model-registry-bridge | Bridge plugin connecting RHDH to OpenShift AI model registry | | | | |
+| msgraph/Azure | Microsoft Graph and Azure AD integration | | | | |
+| Mustgather | Diagnostic data collection tool for support case troubleshooting | | | | |
+| News Feed | RSS news feed plugin | | | | |
+| Operator | OLM-based operator for deploying and managing RHDH on OpenShift | | | | |
+| Orchestrator | Serverless workflow orchestration plugin | | | | |
+| Overlay | Overlay repository for plugin packaging and export | | | | |
+| Permissions | Role-based access control (RBAC) and permission policies | | | | |
+| Plugin Development | Plugin SDK, development tooling, and plugin onboarding guides | | | | |
+| Quay | Quay container registry plugin | | | | |
+| Quickstart | Quickstart plugin for guided setup | Yes | | | |
+| RHDH CLI | CLI tooling for plugin export, dependency checks, and scaffolding | | | | |
+| RHDH Local | Local development environment for running RHDH on a developer machine | Yes | | | |
+| rhdh-ai-external | AI related issues for other stakeholders (RHOAI, etc) | | | | |
+| RHEL | RHEL-based container image build and RPM installer | | | | |
+| RHOAI Bridge | Integration bridge between RHDH and Red Hat OpenShift AI | | | | |
+| Scorecard | Scorecard plugin for project health assessment | | | | |
+| Segment | Product telemetry collection and analytics integration | Yes | | | |
+| Tekton | Plugin for viewing and managing Tekton pipelines and tasks | | | | |
+| Test Framework | Shared test utilities and helpers | Yes | | | Yes |
+| Test Infrastructure | Issues related to the team's testing cluster(s) and infra | Yes | | | Yes |
+| Topology | Plugin to visualise Kubernetes workloads and relationships | | | | |
+| UI | RHDH frontend UI shell, theming, and layout | | | | |
+| UX | User experience design, research, and usability | Yes | | | |
+
+**Backstage (upstream):**
+
+| Component | Description | Excl FF | CF | Post CF | Excl RN |
+|-----------|-------------|---------|----|---------|---------|
+| Actions | Scaffolder actions for software template steps | | | | |
+| Audit Log | Audit logging and verification for compliance | | | | |
+| Catalog | Backstage software catalog (upstream) | | | | |
+| Community Plugin | Track updates to Community Plugin repository | | | | Yes |
+| Core Platform & Lifecycle | Backstage core framework, app lifecycle, and platform APIs | | | | |
+| Corporate Proxy | Proxy configuration for corporate/enterprise network environments | | | | |
+| Event Module | Backstage event module for plugin-to-plugin messaging | | | | |
+| Github | GitHub integration (SCM, actions, auth, discovery) | | | | |
+| Kubernetes | Kubernetes plugin for cluster and workload visibility | | | | |
+| Notifications | Email and in-app notification plugins | | | | |
+| On Behalf Of | On-behalf-of (OBO) token delegation for service-to-service auth | | | | |
+| Proxy | Backstage backend proxy for forwarding API requests to external services | | | | |
+| Redis | Redis caching and session store integration | | | | |
+| RHDH Plugin Repo | RHDH-specific plugin repository and distribution | Yes | Yes | Yes | |
+| Software Templates | Scaffolder templates for project and component creation | | | | |
+| TechDocs | Technical documentation generation and rendering | | | | |
+| Upstream & Community | Tracking Backstage contributions | Yes | Yes | Yes | |
+
+**Extension Plugins:**
+
+| Component | Description | Excl FF | CF | Post CF | Excl RN |
+|-----------|-------------|---------|----|---------|---------|
+| 3rd Party Plugin | Plugins for products not built by Red Hat | | | | Yes |
+| 3scale | 3scale API management plugin | | | | |
+| ACR | Azure Container Registry plugin | | | | |
+| Keycloak Provider | Keycloak auth provider and entity ingestion | | | | |
+| Nexus Repository Manager | Nexus Repository Manager plugin | | | | |
+| Open Cluster Management | OCM multi-cluster management plugin | | | | |
+| Regex | Regex-based entity provider plugin | | | | |
+| ServiceNow | ServiceNow integration plugin | | | | |
+
+**Program (non-engineering):**
+
+| Component | Description | Excl FF | CF | Post CF | Excl RN |
+|-----------|-------------|---------|----|---------|---------|
+| AEM Migration | Adobe Experience Manager to docs-as-code migration | Yes | Yes | Yes | Yes |
+| AI | Internal team initiatives leveraging AI for productivity and tooling | Yes | Yes | Yes | Yes |
+| Certification | Plugin certification process and compliance verification | Yes | | | Yes |
+| Conference | Conference talk preparation, demos, and booth materials | Yes | Yes | Yes | Yes |
+| Continuous Improvement | Tracks opportunities to improve team efficiency | Yes | Yes | Yes | Yes |
+| Documentation | Downstream product documentation (guides, API refs, release notes) | Yes | Yes | | |
+| JTBD | Jobs to Be Done - Doc team | Yes | Yes | Yes | Yes |
+| Knowledge | Blogs, articles, KCS artifacts to supplement downstream docs | Yes | Yes | Yes | Yes |
+| Performance | Performance and Scaling for RHDH | Yes | Yes | | |
+| PQC | Post-quantum cryptography readiness and compliance | Yes | Yes | | |
+| Quality | Quality Engineering for RHDH | Yes | | | |
+| Release | Release engineering, version management, and GA/z-stream processes | Yes | Yes | | Yes |
+| Security | Security related JIRAs & CVEs | Yes | Yes | Yes | |
+| Security Tooling | Security tooling like CVE status checker | Yes | Yes | Yes | Yes |
+| Serviceability | Surfacing internal diagnostics and catalog health info | Yes | | | |
+| Support | Customer support case tracking and engineering follow-up | Yes | Yes | | Yes |
+| Team Operations | Scrum ceremonies, team process improvements, and operational tasks | Yes | Yes | Yes | Yes |
+
+### Component Inference
+
+When suggesting components during issue creation or refinement:
+
+1. **Chained from parent:** Inherit the parent Feature's or Epic's components as the starting point
+2. **Standalone:** Match keywords in the summary and description against the component catalog above
+3. **Validate** the proposed components exist in the target project (RHIDP vs RHDHPLAN have different component sets)
+4. **Flag mismatches** — if a component doesn't exist in the target project, suggest the closest match
+5. **Confirm** with the user before setting — never auto-set components without confirmation
+
+If the issue involves documentation, set the `Documentation` component and invoke the Doc Epic automation (see `references/feature-exploration.md`).
+
+### Component Validation (live)
+
+The component catalog above is maintained manually. Components may be added or renamed in Jira without updating this file. Run the validation script to detect drift:
 
 ```bash
-# List all components for RHIDP
-curl -s -H "Authorization: Basic $(cat "$TOKEN_FILE")" \
-  "https://redhat.atlassian.net/rest/api/3/project/RHIDP/components" | \
-  python -c "import sys,json; [print(c['name']) for c in json.load(sys.stdin)]"
-
-# List all components for RHDHPLAN
-curl -s -H "Authorization: Basic $(cat "$TOKEN_FILE")" \
-  "https://redhat.atlassian.net/rest/api/3/project/RHDHPLAN/components" | \
-  python -c "import sys,json; [print(c['name']) for c in json.load(sys.stdin)]"
+python scripts/validate_components.py        # human-readable report
+python scripts/validate_components.py --json  # structured output
 ```
 
-During creation grills:
+The script compares this catalog against live components in RHIDP and RHDHPLAN. It reports components that exist in Jira but are missing from this file (add them), and components listed here that no longer exist in Jira (remove them).
 
-1. Infer likely components from the issue summary and description
-2. Validate the proposed components exist in the target project
-3. If a component doesn't exist, suggest the closest match
-4. Confirm with the user before setting
+Note: Jira may contain legacy or duplicate components that were never cleaned up. Not every Jira component needs to be in this catalog — only components that are actively used for issue routing and freeze queries.
 
 See `references/feature-exploration.md` for the full Feature Exploration component checklist.
 

--- a/skills/rhdh-jira/scripts/parse_issues.py
+++ b/skills/rhdh-jira/scripts/parse_issues.py
@@ -144,6 +144,7 @@ ENRICHED_SELECT = [
     "assignee",
     "team",
     "story_points",
+    "size",
     "sprint",
     "summary",
 ]

--- a/skills/rhdh-jira/scripts/validate_components.py
+++ b/skills/rhdh-jira/scripts/validate_components.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Validate components in fields.md against live Jira project data.
+
+Compares the Component Catalog table in references/fields.md against the
+components actually configured in RHIDP and RHDHPLAN Jira projects. Reports
+components that exist in Jira but are missing from fields.md, and components
+listed in fields.md that no longer exist in Jira.
+
+Usage:
+  python scripts/validate_components.py
+  python scripts/validate_components.py --json
+
+Requires:
+  - .jira-token file next to acli (email:token format)
+  - Network access to redhat.atlassian.net
+
+Exit codes:
+  0  All components match
+  1  Drift detected (missing or extra components)
+  2  Argument error
+  3  Token file not found
+  4  API request failed
+"""
+
+import argparse
+import base64
+import json
+import shutil
+import sys
+import urllib.request
+from pathlib import Path
+
+
+def find_token_file() -> Path | None:
+    """Find .jira-token next to acli executable."""
+    acli = shutil.which("acli")
+    if not acli:
+        return None
+    token_path = Path(acli).resolve().parent / ".jira-token"
+    return token_path if token_path.exists() else None
+
+
+def fetch_components(token: str, project: str) -> list[str]:
+    """Fetch component names from a Jira project via REST API."""
+    url = f"https://redhat.atlassian.net/rest/api/3/project/{project}/components"
+    auth = base64.b64encode(token.encode()).decode()
+    req = urllib.request.Request(url, headers={"Authorization": f"Basic {auth}"})
+    try:
+        with urllib.request.urlopen(req) as resp:
+            data = json.loads(resp.read())
+    except Exception as e:
+        print(f"Error fetching {project} components: {e}", file=sys.stderr)
+        sys.exit(4)
+    return sorted(c["name"] for c in data)
+
+
+def parse_fields_md(fields_path: Path) -> set[str]:
+    """Extract component names from the Component Catalog tables in fields.md."""
+    text = fields_path.read_text(encoding="utf-8")
+    components = set()
+    # Match table rows: | ComponentName | Description | ... |
+    # Skip header rows (contain "Component" or "---")
+    for line in text.splitlines():
+        if not line.startswith("|"):
+            continue
+        cells = [c.strip() for c in line.split("|")]
+        # cells[0] is empty (before first |), cells[1] is the component name
+        if len(cells) < 3:
+            continue
+        name = cells[1]
+        if not name or name == "Component" or name.startswith("---"):
+            continue
+        # Skip non-component table rows (from other tables in fields.md)
+        # Component tables come after "### Component Catalog"
+        components.add(name)
+    return components
+
+
+def parse_component_section(fields_path: Path) -> set[str]:
+    """Extract only components from the Component Catalog section."""
+    text = fields_path.read_text(encoding="utf-8")
+    components = set()
+    in_catalog = False
+    in_table = False
+
+    for line in text.splitlines():
+        if "### Component Catalog" in line:
+            in_catalog = True
+            continue
+        if in_catalog and line.startswith("### "):
+            # Hit next section
+            in_catalog = False
+            continue
+        if not in_catalog:
+            continue
+
+        if line.startswith("|") and "---" in line:
+            in_table = True
+            continue
+        if in_table and line.startswith("|"):
+            cells = [c.strip() for c in line.split("|")]
+            if len(cells) >= 3 and cells[1] and cells[1] != "Component":
+                components.add(cells[1])
+        elif in_table and not line.startswith("|"):
+            if line.strip() == "" or line.startswith("**"):
+                in_table = False  # gap between tables, reset
+            else:
+                in_table = False
+
+    return components
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Validate fields.md components against live Jira data."
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output results as JSON",
+    )
+    args = parser.parse_args()
+
+    # Find fields.md relative to this script
+    script_dir = Path(__file__).resolve().parent
+    fields_path = script_dir.parent / "references" / "fields.md"
+    if not fields_path.exists():
+        print(f"fields.md not found at {fields_path}", file=sys.stderr)
+        sys.exit(2)
+
+    # Find token
+    token_path = find_token_file()
+    if not token_path:
+        print("Token file not found. Run scripts/setup.py first.", file=sys.stderr)
+        sys.exit(3)
+    token = token_path.read_text().strip()
+
+    # Parse fields.md
+    documented = parse_component_section(fields_path)
+
+    # Fetch live components from both projects
+    rhidp_components = set(fetch_components(token, "RHIDP"))
+    rhdhplan_components = set(fetch_components(token, "RHDHPLAN"))
+    live = rhidp_components | rhdhplan_components
+
+    # Compare
+    in_jira_not_doc = sorted(live - documented)
+    in_doc_not_jira = sorted(documented - live)
+
+    if args.json_output:
+        result = {
+            "documented_count": len(documented),
+            "live_count": len(live),
+            "missing_from_docs": in_jira_not_doc,
+            "missing_from_jira": in_doc_not_jira,
+            "in_sync": len(in_jira_not_doc) == 0 and len(in_doc_not_jira) == 0,
+        }
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"Documented components: {len(documented)}")
+        print(f"Live Jira components:  {len(live)}")
+        print(f"  RHIDP:    {len(rhidp_components)}")
+        print(f"  RHDHPLAN: {len(rhdhplan_components)}")
+        print()
+
+        if in_jira_not_doc:
+            print(f"⚠️  In Jira but NOT in fields.md ({len(in_jira_not_doc)}):")
+            for c in in_jira_not_doc:
+                projects = []
+                if c in rhidp_components:
+                    projects.append("RHIDP")
+                if c in rhdhplan_components:
+                    projects.append("RHDHPLAN")
+                print(f"  + {c}  ({', '.join(projects)})")
+            print()
+
+        if in_doc_not_jira:
+            print(f"⚠️  In fields.md but NOT in Jira ({len(in_doc_not_jira)}):")
+            for c in in_doc_not_jira:
+                print(f"  - {c}")
+            print()
+
+        if not in_jira_not_doc and not in_doc_not_jira:
+            print("✅ All components in sync.")
+        else:
+            print(
+                f"❌ Drift detected: {len(in_jira_not_doc)} missing from docs, "
+                f"{len(in_doc_not_jira)} missing from Jira."
+            )
+
+    sys.exit(0 if not in_jira_not_doc and not in_doc_not_jira else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/rhdh-jira/scripts/validate_components.py
+++ b/skills/rhdh-jira/scripts/validate_components.py
@@ -54,28 +54,6 @@ def fetch_components(token: str, project: str) -> list[str]:
     return sorted(c["name"] for c in data)
 
 
-def parse_fields_md(fields_path: Path) -> set[str]:
-    """Extract component names from the Component Catalog tables in fields.md."""
-    text = fields_path.read_text(encoding="utf-8")
-    components = set()
-    # Match table rows: | ComponentName | Description | ... |
-    # Skip header rows (contain "Component" or "---")
-    for line in text.splitlines():
-        if not line.startswith("|"):
-            continue
-        cells = [c.strip() for c in line.split("|")]
-        # cells[0] is empty (before first |), cells[1] is the component name
-        if len(cells) < 3:
-            continue
-        name = cells[1]
-        if not name or name == "Component" or name.startswith("---"):
-            continue
-        # Skip non-component table rows (from other tables in fields.md)
-        # Component tables come after "### Component Catalog"
-        components.add(name)
-    return components
-
-
 def parse_component_section(fields_path: Path) -> set[str]:
     """Extract only components from the Component Catalog section."""
     text = fields_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Session learnings from the 2.1 Feature Exploration readiness check. Fixes issues encountered when auditing COPE's 27 candidate features.

## Sources

- COPE 2.1 readiness check session (May 19)
- COPE Standup 5/14 transcript
- Hope Hadfield's feedback on component suggestion quality
- RHDH Jira Component/Release Automation Sheet

## Changes

| File | Change |
|------|--------|
| `scripts/parse_issues.py` | Added `size` to `ENRICHED_SELECT` — T-shirt sizing now appears in enriched output alongside story_points |
| `scripts/validate_components.py` | **New file**: validates fields.md component catalog against live RHIDP + RHDHPLAN Jira projects. Reports drift in both directions. Supports `--json`. |
| `SKILL.md` | Gotcha #16 (Parent Link for Feature→Epic, not issuelinks), Gotcha #17 (REST search 410 Gone), validate_components.py in scripts table |
| `references/fields.md` | Full 90-component catalog with descriptions grouped by category, freeze exclusion flags (FF/CF/Post-CF/RN), component inference instructions, validation script reference |
| `references/feature-exploration.md` | Clarified New status expected pre-exploration; Epic creation can happen before exploration to help sizing |

## Key Decisions Captured

- **Parent Link (`customfield_10018`) is the correct field** for Feature→Epic parent-child relationships — not `issuelinks`. Checking issuelinks produces false "no child Epics" reports.
- **Size (T-shirt) is the primary sizing field for Features** — `customfield_10795`, not Story Points (`customfield_10028`). Both should be checked.
- **REST `/rest/api/3/search` returns 410 Gone** on this Jira instance. Use POST to `/rest/api/3/search/jql` instead.
- **Component descriptions and freeze flags** now match the Release Automation Sheet. Descriptions also written directly to the Google Sheet (37 new, 40 improved — revertible via version history).

## Verification

- 273 tests pass ✅
- All referenced files exist ✅
- SKILL.md is 286 lines (under 500 limit) ✅
- `validate_components.py` runs successfully against live Jira (90 documented, 125 live — 35 legacy/duplicates in Jira not in catalog, 0 missing from Jira) ✅