### PR TITLE
chore: bump version to 0.3.0 and document version-bump workflow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Orchestrator skill for RHDH plugin development - onboard, update, and maintain plugins in the Extensions Catalog",
-    "version": "0.2.0"
+    "version": "0.3.0"
   },
   "plugins": [
     {
       "name": "rhdh",
       "source": "./",
       "description": "Skills for RHDH plugin lifecycle management",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "strict": true
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rhdh",
   "description": "All-in-one toolkit for Red Hat Developer Hub (RHDH). Covers plugin development, overlay management, environment setup, version compatibility, CI/CD, and RHDH ecosystem navigation.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "RHDH Store Manager"
   },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,13 +66,26 @@ If told an implementation was wrong, apply the correction and then record what w
 
 ## Versioning
 
-Single version (`0.2.0`) kept in sync across three files:
+Single version kept in sync across three files:
 
 - `pyproject.toml` — Python package version
 - `.claude-plugin/plugin.json` — plugin manifest
 - `.claude-plugin/marketplace.json` — marketplace listing (2 occurrences)
 
-Bump all three when releasing.
+### When to bump
+
+Include a **patch** version bump (`x.y.Z`) in any PR that changes skill behavior, scripts, or SKILL.md files. Use **minor** (`x.Y.0`) for new skills/features, **major** (`X.0.0`) for breaking changes. Do NOT bump for docs-only or CI-only changes.
+
+### How to bump
+
+1. Read the current version from `pyproject.toml`.
+2. Compute the new version (patch/minor/major as appropriate).
+3. Update all three files (4 occurrences total) in the same commit.
+4. The PR title should include the new version, e.g., `feat: add foo skill (v0.4.0)`.
+
+### Git tags
+
+The `skills` CLI (`npx skills add`) resolves versions via git tags, not from the JSON version fields. After merging a version-bump PR, create a tag: `git tag v<VERSION> && git push origin v<VERSION>`.
 
 ## Shared modules (lifecycle ↔ prow)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rhdh-skill"
-version = "0.2.0"
+version = "0.3.0"
 description = "Claude Code skill for RHDH plugin development"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -195,7 +195,7 @@ wheels = [
 
 [[package]]
 name = "rhdh-skill"
-version = "0.2.0"
+version = "0.3.0"
 source = { virtual = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- Bump version `0.2.0` → `0.3.0` across `pyproject.toml`, `plugin.json`, and `marketplace.json`
- Expand the Versioning section in `AGENTS.md` with agent-facing instructions:
  - **When to bump**: patch for behavior changes, minor for new features, major for breaking changes; skip for docs/CI-only
  - **How to bump**: read current version, compute new, update all 3 files (4 occurrences), include version in PR title
  - **Git tags**: document that `skills` CLI resolves via git tags, with tagging instructions post-merge

## Test plan
- [x] All 283 tests pass (`uv run pytest`)
- [x] Pre-commit hooks pass
- [ ] After merge, create tag `v0.3.0` and verify `npx skills add redhat-developer/rhdh-skill@v0.3.0` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)