### PR TITLE
fix(rhdh-release): improve release_notes JQL to check all required fields

### DIFF
--- a/skills/rhdh-release/references/jql-release.md
+++ b/skills/rhdh-release/references/jql-release.md
@@ -116,12 +116,12 @@ project in (RHDHPlan, rhidp) AND issuetype = feature AND fixVersion = "{{RELEASE
 Find issues missing Release Note Type field.
 
 ```jql
-project in (RHIDP, "Red Hat Developer Hub Bugs", "RHDH Support", rhdhplan) and issuetype in (Feature, bug) and "Release Note Type" is EMPTY and fixVersion = "{{RELEASE_VERSION}}"
+project in (RHIDP, "Red Hat Developer Hub Bugs", "RHDH Support", rhdhplan) and issuetype in (Feature, bug) and ("Release Note Type" not in ("Release Note Not Required") or "release note type" is empty) and ("Release Note Status" not in ("In Progress", Proposed, Done) or "Release Note Text[Paragraph]" is empty or "Release Note Type[Dropdown]" is empty) and summary !~ "CVE-*" and (resolution not in (obsolete, duplicate, "Won't Do") or resolution is empty) and fixVersion = "{{RELEASE_VERSION}}"
 ```
 
 - **Placeholders:** `{{RELEASE_VERSION}}`
-- **Example:** `... AND "Release Note Type" is EMPTY and fixVersion = "1.9.0"`
-- **Notes:** Critical for documentation — must be filled before release.
+- **Example:** `... and fixVersion = "2.1.0"`
+- **Notes:** Critical for documentation — must be filled before release. Excludes CVEs, obsolete/duplicate/Won't Do resolutions, and issues marked "Release Note Not Required". Checks that Release Note Status, Text, and Type are all properly completed.
 
 ## blockers
 


### PR DESCRIPTION
## Summary

- Updates the `release_notes` JQL template to comprehensively check all release note fields, not just whether Release Note Type is empty
- Excludes CVEs (`summary !~ "CVE-*"`), obsolete/duplicate/Won't Do resolutions, and issues marked "Release Note Not Required"
- Verifies that Release Note Status, Release Note Text, and Release Note Type Dropdown are all properly completed

## Before

```jql
... and "Release Note Type" is EMPTY and fixVersion = "{{RELEASE_VERSION}}"
```

Only caught issues where Release Note Type was completely empty.

## After

```jql
... and ("Release Note Type" not in ("Release Note Not Required") or "release note type" is empty)
and ("Release Note Status" not in ("In Progress", Proposed, Done) or "Release Note Text[Paragraph]" is empty or "Release Note Type[Dropdown]" is empty)
and summary !~ "CVE-*"
and (resolution not in (obsolete, duplicate, "Won't Do") or resolution is empty)
and fixVersion = "{{RELEASE_VERSION}}"
```

## Test plan

- [x] Verified query returns 22 results for COPE team on 2.1.0 (vs 23 with old query)
- [x] Results correctly exclude CVEs and completed release notes


Made with [Cursor](https://cursor.com)