### PR TITLE
feat: add policy-controlled session sharing (v0.7.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ Track work across the four RHDH Jira projects.
 
 - **[agent-ready](./skills/agent-ready/SKILL.md)** — Assess RHDH repositories against agentready criteria and address each gap. RHDH-aware: detects the repo from its remote URL, uses `rhdh-repos.md` context to pre-fill `AGENTS.md` and skip inapplicable findings. Supports single-repo and batch modes (assess all RHDH repos in one pass).
 
+### Shared Agent Sessions
+
+- **[fs-sessions](./skills/fs-sessions/SKILL.md)** — Share Claude Code transcripts through a global SessionEnd hook with ordered repository allow/deny rules. Configures whitelist, blacklist, mixed exceptions, hook migration, explicit sharing, synchronization, and AgentsView.
+
 ### Meta
 
 - **[skill-maker](./skills/skill-maker/SKILL.md)** — Create new skills or consolidate existing ones following the [Agent Skills open standard](https://agentskills.io/specification). Interviews you about scope and edge cases before drafting.
@@ -156,6 +160,61 @@ npx skills add -g redhat-developer/rhdh-skill
 ```
 
 Global install is the right default — `rhdh` manages paths across multiple repos via its config, so it doesn't need to live inside any single project.
+
+### Shared Claude Code sessions
+
+Install only the session-sharing skill if you do not need the rest of the RHDH skill set:
+
+```bash
+npx skills add -g redhat-developer/rhdh-skill --skill fs-sessions -a claude-code -a codex -y
+FS_SESSIONS="$HOME/.agents/skills/fs-sessions/scripts/fs-sessions"
+"$FS_SESSIONS" --help
+```
+
+Initialize the shared sessions repository, choose a safe default, allow the repositories that should export transcripts, and install the single global Claude Code `SessionEnd` hook:
+
+```bash
+"$FS_SESSIONS" config init \
+  --repo /absolute/path/to/fullsend-sessions \
+  --default deny
+"$FS_SESSIONS" policy allow --origin 'github.com/example-org/*'
+"$FS_SESSIONS" policy check /path/to/an/allowed-repository
+"$FS_SESSIONS" hook install
+"$FS_SESSIONS" status
+```
+
+Configuration is stored in `~/.config/rhdh-skill/config.json`. Repository rules are evaluated in order and the last matching rule wins, so whitelist, blacklist, and exception policies can be combined:
+
+```bash
+# Allow the organization, exclude sensitive repositories, then add one exception.
+"$FS_SESSIONS" policy default deny
+"$FS_SESSIONS" policy allow --origin 'github.com/example-org/*'
+"$FS_SESSIONS" policy deny --path '/work/customer-*'
+"$FS_SESSIONS" policy allow --path '/work/customer-sanitized-demo'
+
+"$FS_SESSIONS" policy rules
+"$FS_SESSIONS" policy remove 3
+```
+
+Automatic sharing requires a Git repository. A project may opt out locally, but it cannot opt itself into sharing. See [policy.md](./skills/fs-sessions/references/policy.md) for matching details and the project opt-out format.
+
+If a repository still has the legacy project-local hook, first verify the new global hook and policy, then remove only the old managed command:
+
+```bash
+"$FS_SESSIONS" hook status
+"$FS_SESSIONS" policy check /path/to/repository
+"$FS_SESSIONS" hook uninstall \
+  --settings /path/to/repository/.claude/settings.json
+```
+
+To smoke-test the installation, end a short Claude Code session in an allowed repository. The hook should add and push one transcript commit to the configured sessions repository. Then inspect it with:
+
+```bash
+git -C /absolute/path/to/fullsend-sessions log -1 --oneline
+find /absolute/path/to/fullsend-sessions/sessions -name '*.jsonl' -type f
+```
+
+Repeat in a denied repository and confirm that neither the repository history nor `sessions/` changes. `fs-sessions hook run` is an internal, intentionally silent hook entry point; use `policy check`, `hook status`, and `status` for interactive diagnostics.
 
 ### Project-scope install
 
@@ -196,6 +255,7 @@ npx skills add ./path/to/rhdh-skill
 uv sync --extra dev                  # Install dev dependencies
 git config core.hooksPath .githooks  # Enable pre-commit hooks (one-time)
 uv run pytest                        # Run tests
+uv run pytest tests/unit/test_fs_sessions.py -q  # Session CLI tests
 ```
 
 The `core.hooksPath` setting points git at the checked-in `.githooks/` directory. If `pre-commit` is installed, linting and tests run automatically on every commit. If not, commits proceed with a warning.

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Global install is the right default — `rhdh` manages paths across multiple rep
 Install only the session-sharing skill if you do not need the rest of the RHDH skill set:
 
 ```bash
-npx skills add -g redhat-developer/rhdh-skill --skill fs-sessions -a claude-code -a codex -y
+npx skills add -g redhat-developer/rhdh-skill --skill fs-sessions --agent claude-code codex -y
 FS_SESSIONS="$HOME/.agents/skills/fs-sessions/scripts/fs-sessions"
 "$FS_SESSIONS" --help
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rhdh-skill"
-version = "0.6.1"
+version = "0.7.0"
 description = "Claude Code skill for RHDH plugin development"
 readme = "README.md"
 license = "Apache-2.0"
@@ -9,8 +9,8 @@ requires-python = ">=3.9"
 # No runtime dependencies - stdlib only!
 
 [tool.setuptools.packages.find]
-where = ["skills/rhdh"]
-include = ["rhdh*"]
+where = ["skills/rhdh", "skills/fs-sessions"]
+include = ["rhdh*", "fs_sessions*"]
 
 [project.optional-dependencies]
 dev = [
@@ -21,6 +21,7 @@ dev = [
 
 [project.scripts]
 rhdh = "rhdh.cli:main"
+fs-sessions = "fs_sessions.cli:main"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/skills/fs-sessions/SKILL.md
+++ b/skills/fs-sessions/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: fs-sessions
+description: |
+  Manage and share Claude Code session transcripts through a policy-controlled global SessionEnd hook and AgentsView. Use when asked to configure session sharing, install or migrate the session hook globally, whitelist or blacklist repositories, diagnose why a repository is or is not exporting, share/list/push/pull sessions, or start AgentsView for team transcripts. Also use for requests mentioning fs-sessions, FULLSEND_SESSIONS_REPO, session export, transcript sharing, or repository-specific session privacy.
+---
+
+# fs-sessions
+
+Share Claude Code transcripts through a global, fail-closed repository policy.
+
+<cli_setup>
+
+Resolve the CLI relative to this file and use it for every deterministic operation:
+
+```bash
+FS="<skill-directory>/scripts/fs-sessions"
+"$FS" --help
+```
+
+Consume complete command output. Do not reimplement JSON or Claude settings edits manually.
+
+</cli_setup>
+
+<essential_principles>
+
+- **Global policy grants access** — only `~/.config/rhdh-skill/config.json` may allow export. A repository's `.rhdh/config.json` may set `sessions.enabled: false`, but cannot opt itself in; this prevents checked-out code from authorizing transcript upload.
+- **Fail closed** — malformed/missing config, non-Git directories, unmatched repositories under `default: deny`, and export errors all skip silently in the SessionEnd hook.
+- **Rules are ordered** — the last matching `allow` or `deny` rule wins. This supports whitelist, blacklist, and narrow exceptions with one explainable model.
+- **One global hook** — install into `~/.claude/settings.json`. After verifying it, remove legacy project-local `export-session.sh` hooks so a session cannot be exported twice.
+- **Transcripts remain append-only in Git** — the exporter may refresh its copied file when the source grows, but do not manually alter shared transcript content.
+
+</essential_principles>
+
+<intake>
+
+## What would you like to do?
+
+1. **Setup or migrate** — configure the shared repo, safe policy, and global hook
+2. **Policy** — allow, deny, list rules, or explain a repository decision
+3. **Hook** — install, inspect, or uninstall the global SessionEnd hook
+4. **Status** — inspect configuration, hook, policy, and stored sessions
+5. **Share/list** — explicitly export or list local sessions
+6. **Push/pull** — synchronize the shared sessions repository
+7. **View** — start or stop AgentsView
+
+If the user already stated an operation, route directly without repeating this menu. Otherwise wait for their selection.
+
+</intake>
+
+<routing>
+
+| Response | Reference |
+|----------|-----------|
+| 1, "setup", "migrate", "global install" | `references/setup.md` |
+| 2, "policy", "allow", "deny", "whitelist", "blacklist" | `references/policy.md` |
+| 3, "hook", "SessionEnd", "install hook" | `references/hook.md` |
+| 4, "status", "configured?", "why not exporting?" | `references/status.md` |
+| 5, "share", "export", "list sessions" | `references/share.md` |
+| 6, "push", "pull", "sync" | `references/sync.md` |
+| 7, "view", "AgentsView", "browse sessions" | `references/view.md` |
+
+</routing>
+
+<reference_index>
+
+| Reference | Load when | Path |
+|-----------|-----------|------|
+| setup | First installation or legacy-hook migration | `references/setup.md` |
+| policy | Editing or explaining repository rules | `references/policy.md` |
+| hook | Hook-only lifecycle work | `references/hook.md` |
+| status | Diagnosing the current state | `references/status.md` |
+| share | Explicit manual export/list | `references/share.md` |
+| sync | Git synchronization | `references/sync.md` |
+| view | AgentsView lifecycle | `references/view.md` |
+
+</reference_index>
+
+<success_criteria>
+
+- Configuration preserves unrelated `rhdh-skill` keys and validates successfully.
+- `policy check <repo>` reports the intended action and matching rule.
+- Exactly one managed hook exists globally; legacy local hooks are absent after migration.
+- A denied repository produces no exported file; an allowed repository exports only its transcript path.
+
+</success_criteria>

--- a/skills/fs-sessions/fs_sessions/__init__.py
+++ b/skills/fs-sessions/fs_sessions/__init__.py
@@ -1,0 +1,3 @@
+"""Share Claude Code session transcripts according to a global policy."""
+
+__version__ = "0.1.0"

--- a/skills/fs-sessions/fs_sessions/__main__.py
+++ b/skills/fs-sessions/fs_sessions/__main__.py
@@ -1,0 +1,5 @@
+"""Run the fs-sessions CLI with ``python -m fs_sessions``."""
+
+from fs_sessions.cli import main
+
+raise SystemExit(main())

--- a/skills/fs-sessions/fs_sessions/cli.py
+++ b/skills/fs-sessions/fs_sessions/cli.py
@@ -1,0 +1,350 @@
+"""Command-line interface for session sharing, policy, and hook management."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from fs_sessions.config import (
+    ConfigError,
+    get_sessions_config,
+    get_sessions_repo,
+    get_user_config_path,
+    initialize_sessions_config,
+    load_user_config,
+    save_user_config,
+)
+from fs_sessions.discovery import SessionInfo, discover_sessions
+from fs_sessions.export import prepare_export
+from fs_sessions.git import commit_file, pull_rebase, push
+from fs_sessions.hook import (
+    DEFAULT_SETTINGS,
+    HookError,
+    hook_status,
+    install_hook,
+    uninstall_hook,
+)
+from fs_sessions.policy import add_rule, evaluate_policy, remove_rule, validate_policy
+
+
+def _emit(data: Dict[str, Any], human: Optional[str], force_json: bool) -> None:
+    if force_json or not sys.stdout.isatty():
+        json.dump(data, sys.stdout, indent=2 if force_json else None)
+        sys.stdout.write("\n")
+    elif human:
+        print(human)
+
+
+def _username() -> str:
+    try:
+        result = subprocess.run(
+            ["git", "config", "user.name"], capture_output=True, text=True, check=True
+        )
+        if result.stdout.strip():
+            return result.stdout.strip().replace(" ", "-").lower()
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        pass
+    return os.environ.get("USER", "unknown")
+
+
+def _script_path() -> Path:
+    return Path(__file__).resolve().parent.parent / "scripts" / "fs-sessions"
+
+
+def _settings(args: argparse.Namespace) -> Path:
+    return Path(args.settings).expanduser() if getattr(args, "settings", None) else DEFAULT_SETTINGS
+
+
+def cmd_config_init(args: argparse.Namespace) -> int:
+    data = initialize_sessions_config(Path(args.repo), args.default)
+    _emit(
+        {"success": True, "config": str(get_user_config_path()), "sessions": data["sessions"]},
+        f"Initialized session config: {get_user_config_path()}",
+        args.json,
+    )
+    return 0
+
+
+def cmd_config_show(args: argparse.Namespace) -> int:
+    data = load_user_config(missing_ok=False)
+    payload = {
+        "config": str(get_user_config_path()),
+        "repo": str(get_sessions_repo(data)),
+        "sessions": get_sessions_config(data),
+    }
+    _emit(payload, json.dumps(payload, indent=2), args.json)
+    return 0
+
+
+def cmd_policy_check(args: argparse.Namespace) -> int:
+    decision = evaluate_policy(load_user_config(missing_ok=False), Path(args.path))
+    data = decision.to_dict()
+    detail = f"Policy: {decision.action} ({decision.reason})"
+    if decision.matched_rule is not None:
+        detail += f", rule {decision.matched_rule}"
+    _emit(data, detail, args.json)
+    return 0 if decision.allowed else 1
+
+
+def cmd_policy_default(args: argparse.Namespace) -> int:
+    data = load_user_config(missing_ok=False)
+    sessions = get_sessions_config(data)
+    policy = validate_policy(sessions.setdefault("policy", {}))
+    policy["default"] = args.action
+    sessions["policy"] = policy
+    save_user_config(data)
+    _emit({"success": True, "default": args.action}, f"Default policy: {args.action}", args.json)
+    return 0
+
+
+def cmd_policy_add(args: argparse.Namespace) -> int:
+    selector = "origin" if args.origin is not None else "path"
+    pattern = args.origin if args.origin is not None else args.path
+    data = load_user_config(missing_ok=False)
+    index = add_rule(data, args.action, selector, pattern)
+    save_user_config(data)
+    payload = {"success": True, "index": index, "rule": {"action": args.action, selector: pattern}}
+    _emit(payload, f"Added rule {index}: {args.action} {selector} {pattern}", args.json)
+    return 0
+
+
+def cmd_policy_rules(args: argparse.Namespace) -> int:
+    data = load_user_config(missing_ok=False)
+    policy = validate_policy(get_sessions_config(data).get("policy", {}))
+    payload = {"default": policy["default"], "rules": policy["rules"]}
+    lines = [f"Default: {policy['default']}"]
+    for index, rule in enumerate(policy["rules"], 1):
+        selector = "origin" if "origin" in rule else "path"
+        lines.append(f"{index}. {rule['action']} {selector} {rule[selector]}")
+    _emit(payload, "\n".join(lines), args.json)
+    return 0
+
+
+def cmd_policy_remove(args: argparse.Namespace) -> int:
+    data = load_user_config(missing_ok=False)
+    removed = remove_rule(data, args.index)
+    save_user_config(data)
+    _emit({"success": True, "removed": removed}, f"Removed rule {args.index}", args.json)
+    return 0
+
+
+def cmd_hook_install(args: argparse.Namespace) -> int:
+    result = install_hook(_script_path(), _settings(args))
+    _emit(result, f"Installed global SessionEnd hook in {result['settings']}", args.json)
+    return 0
+
+
+def cmd_hook_status(args: argparse.Namespace) -> int:
+    result = hook_status(_settings(args))
+    message = (
+        f"Hook: {'installed' if result['installed'] else 'not installed'} ({result['settings']})"
+    )
+    _emit(result, message, args.json)
+    return 0 if result["installed"] else 1
+
+
+def cmd_hook_uninstall(args: argparse.Namespace) -> int:
+    result = uninstall_hook(_settings(args))
+    _emit(result, f"Removed {result['removed']} session hook(s)", args.json)
+    return 0
+
+
+def _run_hook() -> int:
+    """Run fail-closed and silent so SessionEnd itself can never fail."""
+    try:
+        event = json.load(sys.stdin)
+        cwd = event.get("cwd")
+        transcript_value = event.get("transcript_path")
+        session_id = event.get("session_id")
+        if not cwd or not transcript_value or not session_id:
+            return 0
+
+        config = load_user_config(missing_ok=False)
+        decision = evaluate_policy(config, Path(cwd))
+        if not decision.allowed:
+            return 0
+
+        transcript = Path(transcript_value)
+        project = Path(decision.context.git_root or cwd).name
+        repo = get_sessions_repo(config)
+        result = prepare_export(transcript, session_id, project, repo, _username())
+        if result is None:
+            return 0
+        relative = result.dest.relative_to(repo).as_posix()
+        if not commit_file(
+            repo,
+            relative,
+            f"feat: {result.verb} session {result.username}/{result.project}/{session_id}",
+        ):
+            return 0
+        if not pull_rebase(repo):
+            return 0
+        push(repo)
+    except Exception:
+        return 0
+    return 0
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    config = load_user_config(missing_ok=False)
+    repo = get_sessions_repo(config)
+    status = hook_status(_settings(args))
+    count = sum(1 for _ in (repo / "sessions").glob("*/*.jsonl"))
+    sessions = get_sessions_config(config)
+    payload = {
+        "config": str(get_user_config_path()),
+        "repo": str(repo),
+        "enabled": sessions.get("enabled", True),
+        "policy": validate_policy(sessions.get("policy", {})),
+        "hook": status,
+        "session_count": count,
+    }
+    message = f"Sessions: {count}\nRepo: {repo}\nHook: {'installed' if status['installed'] else 'not installed'}"
+    _emit(payload, message, args.json)
+    return 0
+
+
+def _session_payload(session: SessionInfo) -> Dict[str, Any]:
+    return {
+        "path": str(session.path),
+        "cwd": session.cwd,
+        "title": session.title,
+        "size": session.size,
+        "messages": session.line_count,
+        "mtime": session.mtime,
+    }
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    sessions = discover_sessions(max_results=args.limit)
+    payload = {"count": len(sessions), "sessions": [_session_payload(item) for item in sessions]}
+    lines = [
+        f"{index}. {item.title} — {item.cwd or item.path.parent.name}"
+        for index, item in enumerate(sessions, 1)
+    ]
+    _emit(payload, "\n".join(lines) if lines else "No sessions found", args.json)
+    return 0 if sessions else 1
+
+
+def cmd_share(args: argparse.Namespace) -> int:
+    if args.last:
+        sessions = discover_sessions(max_results=1)
+        if not sessions:
+            raise ConfigError("no Claude Code sessions found")
+        session = sessions[0]
+        transcript = session.path
+        cwd = session.cwd
+    else:
+        transcript = Path(args.transcript).expanduser().resolve()
+        cwd = args.cwd
+    project = Path(cwd).name if cwd else transcript.parent.name.lstrip("-")
+    repo = get_sessions_repo()
+    result = prepare_export(transcript, transcript.stem, project, repo, _username())
+    if result is None:
+        _emit({"changed": False}, "Session unchanged", args.json)
+        return 0
+    relative = result.dest.relative_to(repo).as_posix()
+    if not commit_file(
+        repo, relative, f"feat: {result.verb} session {result.username}/{project}/{transcript.stem}"
+    ):
+        raise ConfigError(f"failed to commit {relative}")
+    _emit({"changed": True, "path": relative}, f"Committed {relative}", args.json)
+    return 0
+
+
+def _add_rule_parser(parent: argparse._SubParsersAction, action: str) -> None:
+    parser = parent.add_parser(action, help=f"Append an ordered {action} rule")
+    selectors = parser.add_mutually_exclusive_group(required=True)
+    selectors.add_argument("--origin", help="Normalized origin glob, e.g. github.com/org/*")
+    selectors.add_argument("--path", help="Canonical git-root path glob")
+    parser.set_defaults(func=cmd_policy_add, action=action)
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Share Claude Code sessions under a global repository policy"
+    )
+    parser.add_argument("--json", action="store_true", help="Force JSON output")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    status = sub.add_parser("status", help="Show config, policy, hook, and session status")
+    status.add_argument("--settings", help="Claude settings path override")
+    status.set_defaults(func=cmd_status)
+
+    config = sub.add_parser("config", help="Manage global session configuration")
+    config_sub = config.add_subparsers(dest="config_command", required=True)
+    config_init = config_sub.add_parser(
+        "init", help="Initialize config without replacing other rhdh-skill keys"
+    )
+    config_init.add_argument("--repo", required=True, help="Shared sessions repository")
+    config_init.add_argument("--default", choices=["allow", "deny"], default="deny")
+    config_init.set_defaults(func=cmd_config_init)
+    config_show = config_sub.add_parser("show", help="Show effective global session config")
+    config_show.set_defaults(func=cmd_config_show)
+
+    policy = sub.add_parser("policy", help="Manage ordered repository allow/deny rules")
+    policy_sub = policy.add_subparsers(dest="policy_command", required=True)
+    check = policy_sub.add_parser("check", help="Explain the decision for a repository")
+    check.add_argument("path", nargs="?", default=".")
+    check.set_defaults(func=cmd_policy_check)
+    default = policy_sub.add_parser("default", help="Set the policy fallback action")
+    default.add_argument("action", choices=["allow", "deny"])
+    default.set_defaults(func=cmd_policy_default)
+    _add_rule_parser(policy_sub, "allow")
+    _add_rule_parser(policy_sub, "deny")
+    rules = policy_sub.add_parser("rules", help="List ordered policy rules")
+    rules.set_defaults(func=cmd_policy_rules)
+    remove = policy_sub.add_parser("remove", help="Remove a policy rule by one-based index")
+    remove.add_argument("index", type=int)
+    remove.set_defaults(func=cmd_policy_remove)
+
+    hook = sub.add_parser("hook", help="Manage the global Claude Code SessionEnd hook")
+    hook_sub = hook.add_subparsers(dest="hook_command", required=True)
+    for name, func in (
+        ("install", cmd_hook_install),
+        ("status", cmd_hook_status),
+        ("uninstall", cmd_hook_uninstall),
+    ):
+        command = hook_sub.add_parser(name, help=f"{name.capitalize()} the global hook")
+        command.add_argument("--settings", help="Claude settings path override")
+        command.set_defaults(func=func)
+    run = hook_sub.add_parser("run", help=argparse.SUPPRESS)
+    run.set_defaults(internal_hook=True)
+
+    listing = sub.add_parser("list", help="List recent local Claude Code sessions")
+    listing.add_argument("--limit", type=int, default=20)
+    listing.set_defaults(func=cmd_list)
+    share = sub.add_parser(
+        "share", help="Explicitly export one local session without policy evaluation"
+    )
+    source = share.add_mutually_exclusive_group(required=True)
+    source.add_argument("--last", action="store_true")
+    source.add_argument("--transcript")
+    share.add_argument("--cwd", help="Original session working directory")
+    share.set_defaults(func=cmd_share)
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = create_parser()
+    args = parser.parse_args(argv)
+    if getattr(args, "internal_hook", False):
+        return _run_hook()
+    try:
+        return args.func(args)
+    except (ConfigError, HookError, OSError) as exc:
+        if args.json or not sys.stdout.isatty():
+            json.dump({"success": False, "error": str(exc)}, sys.stdout)
+            sys.stdout.write("\n")
+        else:
+            print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/fs-sessions/fs_sessions/config.py
+++ b/skills/fs-sessions/fs_sessions/config.py
@@ -1,0 +1,123 @@
+"""Global and project-local configuration for session sharing."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+USER_CONFIG_ENV = "RHDH_SKILL_CONFIG"
+USER_CONFIG_FILE = Path.home() / ".config" / "rhdh-skill" / "config.json"
+PROJECT_CONFIG_DIR = ".rhdh"
+
+
+class ConfigError(ValueError):
+    """Raised when session configuration is missing or invalid."""
+
+
+def get_user_config_path() -> Path:
+    """Return the user configuration path, honoring the test/automation override."""
+    override = os.environ.get(USER_CONFIG_ENV)
+    return Path(override).expanduser() if override else USER_CONFIG_FILE
+
+
+def load_json(path: Path, missing_ok: bool = True) -> Dict[str, Any]:
+    """Load a JSON object without silently accepting malformed configuration."""
+    if not path.exists():
+        if missing_ok:
+            return {}
+        raise ConfigError(f"configuration not found: {path}")
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ConfigError(f"invalid configuration {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ConfigError(f"configuration must contain a JSON object: {path}")
+    return data
+
+
+def load_user_config(missing_ok: bool = True) -> Dict[str, Any]:
+    return load_json(get_user_config_path(), missing_ok=missing_ok)
+
+
+def save_user_config(data: Dict[str, Any]) -> Path:
+    """Atomically save global config while preserving unrelated rhdh-skill keys."""
+    path = get_user_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temp_name = tempfile.mkstemp(prefix="config-", suffix=".json", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            json.dump(data, stream, indent=2, sort_keys=True)
+            stream.write("\n")
+        os.chmod(temp_name, 0o600)
+        os.replace(temp_name, path)
+    except Exception:
+        try:
+            os.unlink(temp_name)
+        except OSError:
+            pass
+        raise
+    return path
+
+
+def initialize_sessions_config(repo: Path, default: str = "deny") -> Dict[str, Any]:
+    """Add safe session defaults to the existing global rhdh-skill config."""
+    if default not in {"allow", "deny"}:
+        raise ConfigError("policy default must be 'allow' or 'deny'")
+    repo = repo.expanduser().resolve()
+    if not repo.is_dir():
+        raise ConfigError(f"sessions repository does not exist: {repo}")
+
+    data = load_user_config()
+    repos = data.setdefault("repos", {})
+    if not isinstance(repos, dict):
+        raise ConfigError("config key 'repos' must be an object")
+    repos["sessions"] = str(repo)
+
+    sessions = data.setdefault("sessions", {})
+    if not isinstance(sessions, dict):
+        raise ConfigError("config key 'sessions' must be an object")
+    sessions.setdefault("enabled", True)
+    policy = sessions.setdefault("policy", {})
+    if not isinstance(policy, dict):
+        raise ConfigError("config key 'sessions.policy' must be an object")
+    policy.setdefault("default", default)
+    policy.setdefault("rules", [])
+    save_user_config(data)
+    return data
+
+
+def get_sessions_config(data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    config = data if data is not None else load_user_config(missing_ok=False)
+    sessions = config.get("sessions")
+    if not isinstance(sessions, dict):
+        raise ConfigError("missing config object: sessions")
+    return sessions
+
+
+def get_sessions_repo(data: Optional[Dict[str, Any]] = None) -> Path:
+    config = data if data is not None else load_user_config(missing_ok=False)
+    repos = config.get("repos")
+    repo_value = repos.get("sessions") if isinstance(repos, dict) else None
+    if not isinstance(repo_value, str) or not repo_value:
+        raise ConfigError("missing config key: repos.sessions")
+    repo = Path(repo_value).expanduser().resolve()
+    if not repo.is_dir():
+        raise ConfigError(f"sessions repository does not exist: {repo}")
+    return repo
+
+
+def find_project_config(git_root: Path) -> Path:
+    return git_root / PROJECT_CONFIG_DIR / "config.json"
+
+
+def project_disables_sessions(git_root: Path) -> bool:
+    """Project config may opt out, but cannot elevate global permission."""
+    path = find_project_config(git_root)
+    if not path.exists():
+        return False
+    data = load_json(path)
+    sessions = data.get("sessions")
+    return isinstance(sessions, dict) and sessions.get("enabled") is False

--- a/skills/fs-sessions/fs_sessions/discovery.py
+++ b/skills/fs-sessions/fs_sessions/discovery.py
@@ -1,0 +1,64 @@
+"""Discover local Claude Code session transcripts."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+
+CLAUDE_PROJECTS_DIR = Path.home() / ".claude" / "projects"
+
+
+@dataclass
+class SessionInfo:
+    path: Path
+    mtime: float
+    title: str
+    cwd: Optional[str]
+    size: int
+    line_count: int
+
+
+def _metadata(path: Path) -> tuple[str, Optional[str]]:
+    title = ""
+    cwd = None
+    try:
+        with path.open(encoding="utf-8") as stream:
+            for line in stream:
+                try:
+                    item = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if item.get("type") == "ai-title":
+                    title = item.get("aiTitle", "")
+                if (
+                    cwd is None
+                    and item.get("type") == "user"
+                    and item.get("sessionId") is not None
+                    and item.get("cwd") is not None
+                ):
+                    cwd = item["cwd"]
+    except OSError:
+        pass
+    return title or "(untitled)", cwd
+
+
+def discover_sessions(
+    projects_dir: Optional[Path] = None, max_results: int = 20
+) -> List[SessionInfo]:
+    base = projects_dir or CLAUDE_PROJECTS_DIR
+    if not base.is_dir():
+        return []
+    sessions = []
+    for transcript in base.glob("*/*.jsonl"):
+        try:
+            stat = transcript.stat()
+            with transcript.open(encoding="utf-8") as stream:
+                lines = sum(1 for _ in stream)
+        except OSError:
+            continue
+        title, cwd = _metadata(transcript)
+        sessions.append(SessionInfo(transcript, stat.st_mtime, title, cwd, stat.st_size, lines))
+    sessions.sort(key=lambda item: item.mtime, reverse=True)
+    return sessions[:max_results]

--- a/skills/fs-sessions/fs_sessions/export.py
+++ b/skills/fs-sessions/fs_sessions/export.py
@@ -1,0 +1,65 @@
+"""Build metadata and copy session transcripts to the shared repository."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass
+class ExportResult:
+    dest: Path
+    verb: str
+    project: str
+    username: str
+
+
+def build_metadata_line(project: str, username: str, timestamp: Optional[str] = None) -> str:
+    ts = timestamp or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    cwd = f"/sessions/{username}_{project}"
+    meta = {
+        "type": "user",
+        "timestamp": ts,
+        "message": {"content": f"[Session: {project}] by {username}\nProject: {cwd}"},
+        "cwd": cwd,
+    }
+    return json.dumps(meta, separators=(",", ":"))
+
+
+def destination(repo: Path, username: str, project: str, session_id: str) -> Path:
+    return repo / "sessions" / f"{username}_{project}" / f"{session_id}.jsonl"
+
+
+def _content_size(exported: Path) -> int:
+    with exported.open("rb") as stream:
+        first_line = stream.readline()
+        return exported.stat().st_size - len(first_line)
+
+
+def prepare_export(
+    transcript: Path,
+    session_id: str,
+    project: str,
+    sessions_repo: Path,
+    username: str,
+    timestamp: Optional[str] = None,
+) -> Optional[ExportResult]:
+    if not transcript.is_file() or transcript.stat().st_size == 0:
+        return None
+    dest = destination(sessions_repo, username, project, session_id)
+    verb = "add"
+    if dest.exists():
+        if transcript.stat().st_size == _content_size(dest):
+            return None
+        verb = "update"
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with dest.open("w", encoding="utf-8") as output:
+        output.write(build_metadata_line(project, username, timestamp) + "\n")
+        with transcript.open(encoding="utf-8") as source:
+            shutil.copyfileobj(source, output)
+    return ExportResult(dest, verb, project, username)

--- a/skills/fs-sessions/fs_sessions/git.py
+++ b/skills/fs-sessions/fs_sessions/git.py
@@ -1,0 +1,32 @@
+"""Small, testable wrappers around the Git operations used by the hook."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import List
+
+
+def run(repo: Path, args: List[str]) -> bool:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+def commit_file(repo: Path, relative_path: str, message: str) -> bool:
+    """Commit only the exported transcript, leaving unrelated staged files alone."""
+    if not run(repo, ["add", "--", relative_path]):
+        return False
+    return run(repo, ["commit", "-q", "--only", "-m", message, "--", relative_path])
+
+
+def pull_rebase(repo: Path) -> bool:
+    return run(repo, ["pull", "--rebase", "-q"])
+
+
+def push(repo: Path) -> bool:
+    return run(repo, ["push", "-q"])

--- a/skills/fs-sessions/fs_sessions/hook.py
+++ b/skills/fs-sessions/fs_sessions/hook.py
@@ -1,0 +1,136 @@
+"""Claude Code SessionEnd hook installation and lifecycle management."""
+
+from __future__ import annotations
+
+import json
+import shlex
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+DEFAULT_SETTINGS = Path.home() / ".claude" / "settings.json"
+
+
+class HookError(ValueError):
+    """Raised when Claude settings cannot be safely updated."""
+
+
+def _load_settings(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise HookError(f"invalid Claude settings {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise HookError(f"Claude settings must contain a JSON object: {path}")
+    return data
+
+
+def _save_settings(path: Path, data: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temp_name = tempfile.mkstemp(prefix="settings-", suffix=".json", dir=path.parent)
+    try:
+        with open(fd, "w", encoding="utf-8", closefd=True) as stream:
+            json.dump(data, stream, indent=2)
+            stream.write("\n")
+        Path(temp_name).replace(path)
+    except Exception:
+        Path(temp_name).unlink(missing_ok=True)
+        raise
+
+
+def is_managed_command(command: Any) -> bool:
+    if not isinstance(command, str):
+        return False
+    return "export-session" in command or ("fs-sessions" in command and "hook run" in command)
+
+
+def _remove_managed(entries: Any) -> Tuple[List[Dict[str, Any]], int]:
+    if entries is None:
+        return [], 0
+    if not isinstance(entries, list):
+        raise HookError("hooks.SessionEnd must be an array")
+    kept = []
+    removed = 0
+    for entry in entries:
+        if not isinstance(entry, dict):
+            kept.append(entry)
+            continue
+        hooks = entry.get("hooks")
+        if not isinstance(hooks, list):
+            kept.append(entry)
+            continue
+        remaining = []
+        for hook in hooks:
+            command = hook.get("command") if isinstance(hook, dict) else None
+            if is_managed_command(command):
+                removed += 1
+            else:
+                remaining.append(hook)
+        if remaining:
+            updated = dict(entry)
+            updated["hooks"] = remaining
+            kept.append(updated)
+    return kept, removed
+
+
+def hook_command(script_path: Path) -> str:
+    return f"python3 {shlex.quote(str(script_path.resolve()))} hook run"
+
+
+def install_hook(script_path: Path, settings_path: Path = DEFAULT_SETTINGS) -> Dict[str, Any]:
+    data = _load_settings(settings_path)
+    hooks = data.setdefault("hooks", {})
+    if not isinstance(hooks, dict):
+        raise HookError("Claude settings key 'hooks' must be an object")
+    entries, removed = _remove_managed(hooks.get("SessionEnd"))
+    command = hook_command(script_path)
+    entries.append(
+        {
+            "matcher": "",
+            "hooks": [{"type": "command", "command": command}],
+        }
+    )
+    hooks["SessionEnd"] = entries
+    _save_settings(settings_path, data)
+    return {
+        "installed": True,
+        "settings": str(settings_path),
+        "command": command,
+        "replaced": removed,
+    }
+
+
+def uninstall_hook(settings_path: Path = DEFAULT_SETTINGS) -> Dict[str, Any]:
+    data = _load_settings(settings_path)
+    hooks = data.get("hooks")
+    if not isinstance(hooks, dict):
+        return {"installed": False, "settings": str(settings_path), "removed": 0}
+    entries, removed = _remove_managed(hooks.get("SessionEnd"))
+    if entries:
+        hooks["SessionEnd"] = entries
+    else:
+        hooks.pop("SessionEnd", None)
+    if not hooks:
+        data.pop("hooks", None)
+    _save_settings(settings_path, data)
+    return {"installed": False, "settings": str(settings_path), "removed": removed}
+
+
+def hook_status(settings_path: Path = DEFAULT_SETTINGS) -> Dict[str, Any]:
+    data = _load_settings(settings_path)
+    hooks = data.get("hooks")
+    entries = hooks.get("SessionEnd", []) if isinstance(hooks, dict) else []
+    commands = []
+    if isinstance(entries, list):
+        for entry in entries:
+            for hook in entry.get("hooks", []) if isinstance(entry, dict) else []:
+                command = hook.get("command") if isinstance(hook, dict) else None
+                if is_managed_command(command):
+                    commands.append(command)
+    return {
+        "installed": bool(commands),
+        "settings": str(settings_path),
+        "commands": commands,
+    }

--- a/skills/fs-sessions/fs_sessions/policy.py
+++ b/skills/fs-sessions/fs_sessions/policy.py
@@ -1,0 +1,154 @@
+"""Repository identity discovery and ordered allow/deny policy evaluation."""
+
+from __future__ import annotations
+
+import fnmatch
+import os
+import re
+import subprocess
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from fs_sessions.config import ConfigError, get_sessions_config, project_disables_sessions
+
+
+@dataclass
+class RepositoryContext:
+    requested_path: str
+    git_root: Optional[str]
+    origin: Optional[str]
+
+
+@dataclass
+class PolicyDecision:
+    allowed: bool
+    action: str
+    reason: str
+    matched_rule: Optional[int]
+    context: RepositoryContext
+
+    def to_dict(self) -> Dict[str, Any]:
+        result = asdict(self)
+        result["context"] = asdict(self.context)
+        return result
+
+
+def _git(path: Path, *args: str) -> Optional[str]:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(path), *args],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+    value = result.stdout.strip()
+    return value or None
+
+
+def normalize_origin(url: str) -> str:
+    """Normalize common SSH/HTTP Git URLs to host/owner/repository."""
+    value = url.strip()
+    scp_match = re.match(r"^(?:[^@]+@)?([^:]+):(.+)$", value)
+    if scp_match and "://" not in value:
+        host, path = scp_match.groups()
+    else:
+        match = re.match(r"^(?:[a-z][a-z0-9+.-]*://)(?:[^@/]+@)?([^/]+)/(.+)$", value, re.I)
+        if not match:
+            return value[:-4] if value.endswith(".git") else value
+        host, path = match.groups()
+    normalized = f"{host.lower()}/{path.lstrip('/')}"
+    return normalized[:-4] if normalized.endswith(".git") else normalized
+
+
+def discover_repository(path: Path) -> RepositoryContext:
+    requested = path.expanduser().resolve()
+    root_value = _git(requested, "rev-parse", "--show-toplevel")
+    if root_value is None:
+        return RepositoryContext(str(requested), None, None)
+    root = Path(root_value).resolve()
+    origin_value = _git(root, "remote", "get-url", "origin")
+    origin = normalize_origin(origin_value) if origin_value else None
+    return RepositoryContext(str(requested), str(root), origin)
+
+
+def validate_policy(policy: Any) -> Dict[str, Any]:
+    if not isinstance(policy, dict):
+        raise ConfigError("sessions.policy must be an object")
+    default = policy.get("default", "deny")
+    if default not in {"allow", "deny"}:
+        raise ConfigError("sessions.policy.default must be 'allow' or 'deny'")
+    rules = policy.get("rules", [])
+    if not isinstance(rules, list):
+        raise ConfigError("sessions.policy.rules must be an array")
+    for index, rule in enumerate(rules, 1):
+        if not isinstance(rule, dict):
+            raise ConfigError(f"policy rule {index} must be an object")
+        if rule.get("action") not in {"allow", "deny"}:
+            raise ConfigError(f"policy rule {index} action must be 'allow' or 'deny'")
+        selectors = [key for key in ("origin", "path") if key in rule]
+        if len(selectors) != 1:
+            raise ConfigError(f"policy rule {index} must contain exactly one origin or path")
+        if not isinstance(rule[selectors[0]], str) or not rule[selectors[0]]:
+            raise ConfigError(f"policy rule {index} selector must be a non-empty string")
+    return {"default": default, "rules": rules}
+
+
+def _normalize_path_pattern(pattern: str) -> str:
+    expanded = os.path.expanduser(pattern)
+    return os.path.abspath(expanded)
+
+
+def _matches(rule: Dict[str, Any], context: RepositoryContext) -> bool:
+    if "origin" in rule:
+        return context.origin is not None and fnmatch.fnmatchcase(context.origin, rule["origin"])
+    if context.git_root is None:
+        return False
+    return fnmatch.fnmatchcase(context.git_root, _normalize_path_pattern(rule["path"]))
+
+
+def evaluate_policy(config: Dict[str, Any], path: Path) -> PolicyDecision:
+    context = discover_repository(path)
+    if context.git_root is None:
+        return PolicyDecision(False, "deny", "not_git_repository", None, context)
+
+    sessions = get_sessions_config(config)
+    if sessions.get("enabled", True) is not True:
+        return PolicyDecision(False, "deny", "globally_disabled", None, context)
+
+    root = Path(context.git_root)
+    if project_disables_sessions(root):
+        return PolicyDecision(False, "deny", "project_opt_out", None, context)
+
+    policy = validate_policy(sessions.get("policy", {}))
+    action = policy["default"]
+    reason = f"default_{action}"
+    matched_rule = None
+    for index, rule in enumerate(policy["rules"], 1):
+        if _matches(rule, context):
+            action = rule["action"]
+            reason = "matched_rule"
+            matched_rule = index
+    return PolicyDecision(action == "allow", action, reason, matched_rule, context)
+
+
+def add_rule(config: Dict[str, Any], action: str, selector: str, pattern: str) -> int:
+    sessions = get_sessions_config(config)
+    policy = validate_policy(sessions.setdefault("policy", {}))
+    rules: List[Dict[str, str]] = policy["rules"]
+    rules.append({"action": action, selector: pattern})
+    sessions["policy"] = policy
+    return len(rules)
+
+
+def remove_rule(config: Dict[str, Any], index: int) -> Dict[str, Any]:
+    sessions = get_sessions_config(config)
+    policy = validate_policy(sessions.get("policy", {}))
+    rules = policy["rules"]
+    if index < 1 or index > len(rules):
+        raise ConfigError(f"policy rule index out of range: {index}")
+    removed = rules.pop(index - 1)
+    sessions["policy"] = policy
+    return removed

--- a/skills/fs-sessions/references/hook.md
+++ b/skills/fs-sessions/references/hook.md
@@ -1,0 +1,17 @@
+# Global SessionEnd hook
+
+Manage the hook only through the CLI so JSON settings and unrelated hooks are preserved.
+
+```bash
+"$FS" hook install
+"$FS" hook status
+"$FS" hook uninstall
+```
+
+The global settings file defaults to `~/.claude/settings.json`. Use `--settings PATH` only to inspect/migrate a project-local settings file or for testing.
+
+`hook install` is idempotent: it replaces any managed Python hook or legacy command containing `export-session`, then writes one command pointing to this installed skill's script.
+
+The internal `hook run` command reads Claude's SessionEnd JSON from stdin. Do not invoke it without a test event. It intentionally exits successfully and silently for policy denials, malformed events, unavailable Git remotes, or export/push failures so Claude shutdown cannot be blocked.
+
+For migration, verify the global hook and policy before uninstalling the local hook. Otherwise a gap between removal and installation can drop session exports.

--- a/skills/fs-sessions/references/policy.md
+++ b/skills/fs-sessions/references/policy.md
@@ -1,0 +1,46 @@
+# Repository policy
+
+The global policy lives under `sessions.policy` in `~/.config/rhdh-skill/config.json`.
+
+## Semantics
+
+- Git `cwd` is resolved to its canonical Git root before matching.
+- `origin` values normalize SSH and HTTPS URLs to `host/owner/repo`, such as `github.com/example-org/service`.
+- `path` values match the canonical absolute Git root and may contain shell-style globs.
+- Rules are evaluated top to bottom; the last matching rule wins.
+- Non-Git directories are denied regardless of the default.
+- `.rhdh/config.json` may only opt out with `{"sessions":{"enabled":false}}`.
+
+## Common policies
+
+Whitelist:
+
+```bash
+"$FS" policy default deny
+"$FS" policy allow --origin 'github.com/example-org/*'
+```
+
+Blacklist (use only when the user explicitly accepts automatic export from otherwise-unmatched repositories):
+
+```bash
+"$FS" policy default allow
+"$FS" policy deny --path '/work/customer-*'
+```
+
+Mixed exceptions:
+
+```bash
+"$FS" policy allow --path '/work/*'
+"$FS" policy deny --path '/work/customer-*'
+"$FS" policy allow --path '/work/customer-sanitized-demo'
+```
+
+## Manage and explain
+
+```bash
+"$FS" policy rules
+"$FS" policy check /path/to/repository
+"$FS" policy remove 3
+```
+
+After every mutation, run `policy rules` and `policy check` for affected repositories. Report the default, matching rule, normalized origin, Git root, and final decision.

--- a/skills/fs-sessions/references/setup.md
+++ b/skills/fs-sessions/references/setup.md
@@ -1,0 +1,68 @@
+# Setup or migrate
+
+Use this workflow for first-time global setup or migration from the legacy project-local Bash hook.
+
+## 1. Resolve the shared sessions repository
+
+Prefer, in order:
+
+1. Existing `repos.sessions` in `~/.config/rhdh-skill/config.json`.
+2. Legacy `FULLSEND_SESSIONS_REPO` from `~/.config/fullsend/sessions.env`.
+3. A path supplied by the user.
+
+Require an existing Git repository containing or intended to contain `sessions/`.
+
+## 2. Initialize safe global configuration
+
+```bash
+"$FS" config init --repo /absolute/path/to/fullsend-sessions --default deny
+```
+
+This updates only `repos.sessions` and `sessions`; it preserves all other `rhdh-skill` configuration.
+
+## 3. Add the initial allow rule
+
+For migration, preserve the behavior of each repository that already had a local hook. Prefer an origin rule for team repositories and a path rule for local-only repositories:
+
+```bash
+"$FS" policy allow --origin 'github.com/example-org/*'
+# or
+"$FS" policy allow --path '/absolute/path/to/repository'
+```
+
+Do not change `default` to `allow` merely to make setup convenient; that would export every Git repository not explicitly denied.
+
+## 4. Preview the decision
+
+```bash
+"$FS" policy check /absolute/path/to/repository
+```
+
+Continue only when it reports `allow` and the expected rule number.
+
+## 5. Install the global hook
+
+```bash
+"$FS" hook install
+"$FS" hook status
+```
+
+The installer replaces prior managed hooks in the selected settings file and preserves unrelated settings/hooks.
+
+## 6. Remove legacy project hooks
+
+After the global status and policy check pass, inspect each formerly configured project. Remove only the managed session hook:
+
+```bash
+"$FS" hook uninstall --settings /path/to/project/.claude/settings.json
+```
+
+Keep unrelated project hooks. Commit the project settings change when that settings file is tracked.
+
+## 7. Verify
+
+```bash
+"$FS" status
+```
+
+Setup is complete when config is valid, the intended repository is allowed, exactly one global managed hook exists, and no legacy project-local session hook remains.

--- a/skills/fs-sessions/references/share.md
+++ b/skills/fs-sessions/references/share.md
@@ -1,0 +1,22 @@
+# Explicit share and list
+
+List recent local Claude Code transcripts:
+
+```bash
+"$FS" list
+"$FS" list --limit 50
+```
+
+Explicitly export the most recent transcript:
+
+```bash
+"$FS" share --last
+```
+
+Or export a known transcript:
+
+```bash
+"$FS" share --transcript /path/to/session.jsonl --cwd /path/to/project
+```
+
+Explicit sharing is a deliberate user action and does not evaluate the automatic-hook policy. It commits only the exported transcript and leaves unrelated staged files untouched. Push separately after reviewing when required.

--- a/skills/fs-sessions/references/status.md
+++ b/skills/fs-sessions/references/status.md
@@ -1,0 +1,27 @@
+# Status and diagnosis
+
+Run:
+
+```bash
+"$FS" status
+```
+
+It reports the global config path, sessions repository, enabled state, policy, global hook, and stored transcript count.
+
+For a repository-specific diagnosis, also run:
+
+```bash
+"$FS" policy check /path/to/repository
+```
+
+Interpret common denial reasons:
+
+| Reason | Meaning | Action |
+|--------|---------|--------|
+| `not_git_repository` | `cwd` has no Git root | No automatic export; use an explicit share if desired |
+| `globally_disabled` | `sessions.enabled` is false | Enable globally only after user confirmation |
+| `project_opt_out` | `.rhdh/config.json` disables sharing | Preserve the opt-out unless the user owns and changes it |
+| `default_deny` | No allow rule matched | Add the narrowest suitable origin/path allow rule |
+| `matched_rule` | An ordered rule decided | Report its one-based index and selector |
+
+If hook status is installed but no export occurs, check policy first, then validate `repos.sessions`, Git identity, and the sessions repository remote.

--- a/skills/fs-sessions/references/sync.md
+++ b/skills/fs-sessions/references/sync.md
@@ -1,0 +1,17 @@
+# Push or pull shared sessions
+
+Resolve the repository with `"$FS" config show`, then run Git inside that repository.
+
+Push:
+
+```bash
+git -C /path/to/fullsend-sessions push
+```
+
+Pull without merge commits:
+
+```bash
+git -C /path/to/fullsend-sessions pull --rebase
+```
+
+Report commits transferred and newly available session files. Do not resolve transcript conflicts by editing content; preserve both source transcripts or ask the user when paths collide.

--- a/skills/fs-sessions/references/view.md
+++ b/skills/fs-sessions/references/view.md
@@ -1,0 +1,11 @@
+# View in AgentsView
+
+Resolve the sessions repository with `"$FS" config show` and use its supported AgentsView command. For `fullsend-sessions`:
+
+```bash
+just -d /path/to/fullsend-sessions sessions
+```
+
+To force a complete re-index, stop the repository's compose stack with its volume-removal command before restarting. Do not delete or rewrite files under `sessions/`.
+
+Sessions appear under `<user>_<project>`. The first synthetic user message supplies the session title and virtual `/sessions/<user>_<project>` working directory.

--- a/skills/fs-sessions/scripts/command-metadata.json
+++ b/skills/fs-sessions/scripts/command-metadata.json
@@ -1,0 +1,30 @@
+{
+  "setup": {
+    "description": "Configure a shared sessions repo, safe default-deny policy, and global Claude SessionEnd hook; migrate legacy local hooks.",
+    "argumentHint": "[sessions repository]"
+  },
+  "policy": {
+    "description": "Whitelist, blacklist, or explain repository-specific automatic transcript export decisions.",
+    "argumentHint": "[check|allow|deny|rules|remove] [repository or pattern]"
+  },
+  "hook": {
+    "description": "Install, inspect, migrate, or remove the global Claude Code SessionEnd transcript hook.",
+    "argumentHint": "[install|status|uninstall]"
+  },
+  "status": {
+    "description": "Diagnose session config, repository policy, hook installation, and stored transcript state.",
+    "argumentHint": "[repository]"
+  },
+  "share": {
+    "description": "List local Claude sessions or explicitly export one transcript to the shared repository.",
+    "argumentHint": "[--last | transcript path]"
+  },
+  "sync": {
+    "description": "Push or pull shared session transcript commits without merge commits.",
+    "argumentHint": "[push|pull]"
+  },
+  "view": {
+    "description": "Start, stop, or rebuild AgentsView for shared team session transcripts.",
+    "argumentHint": "[start|stop|reindex]"
+  }
+}

--- a/skills/fs-sessions/scripts/fs-sessions
+++ b/skills/fs-sessions/scripts/fs-sessions
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""Run the self-contained fs-sessions CLI from an installed skill."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from fs_sessions.cli import main  # noqa: E402
+
+raise SystemExit(main())

--- a/tests/unit/test_fs_sessions.py
+++ b/tests/unit/test_fs_sessions.py
@@ -1,0 +1,289 @@
+"""Tests for fs-sessions policy, config, export, and hook management."""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+FS_SKILL = Path(__file__).parents[2] / "skills" / "fs-sessions"
+sys.path.insert(0, str(FS_SKILL))
+
+from fs_sessions import config  # noqa: E402
+from fs_sessions.cli import main  # noqa: E402
+from fs_sessions.export import prepare_export  # noqa: E402
+from fs_sessions.hook import hook_status, install_hook, uninstall_hook  # noqa: E402
+from fs_sessions.policy import (  # noqa: E402
+    RepositoryContext,
+    add_rule,
+    evaluate_policy,
+    normalize_origin,
+    remove_rule,
+    validate_policy,
+)
+
+
+@pytest.fixture()
+def global_config(tmp_path, monkeypatch):
+    path = tmp_path / "config.json"
+    monkeypatch.setenv(config.USER_CONFIG_ENV, str(path))
+    repo = tmp_path / "sessions-repo"
+    repo.mkdir()
+    (repo / "sessions").mkdir()
+    data = config.initialize_sessions_config(repo)
+    return path, repo, data
+
+
+def test_initialize_preserves_rhdh_config(tmp_path, monkeypatch):
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps({"repos": {"rhdh": "/code/rhdh"}, "github": {"username": "octo"}}))
+    monkeypatch.setenv(config.USER_CONFIG_ENV, str(path))
+    sessions_repo = tmp_path / "sessions"
+    sessions_repo.mkdir()
+
+    config.initialize_sessions_config(sessions_repo)
+
+    saved = json.loads(path.read_text())
+    assert saved["repos"]["rhdh"] == "/code/rhdh"
+    assert saved["repos"]["sessions"] == str(sessions_repo)
+    assert saved["github"]["username"] == "octo"
+    assert saved["sessions"]["policy"] == {"default": "deny", "rules": []}
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("git@github.com:redhat-developer/rhdh.git", "github.com/redhat-developer/rhdh"),
+        ("https://github.com/redhat-developer/rhdh.git", "github.com/redhat-developer/rhdh"),
+        ("ssh://git@gitlab.example.com/team/repo.git", "gitlab.example.com/team/repo"),
+    ],
+)
+def test_normalize_origin(url, expected):
+    assert normalize_origin(url) == expected
+
+
+def _context(path: Path, origin: str = "github.com/redhat-developer/rhdh") -> RepositoryContext:
+    return RepositoryContext(str(path), str(path), origin)
+
+
+def test_whitelist_and_last_match_wins(global_config):
+    _, _, data = global_config
+    rules = data["sessions"]["policy"]["rules"]
+    rules.extend(
+        [
+            {"action": "allow", "origin": "github.com/redhat-developer/*"},
+            {"action": "deny", "origin": "github.com/redhat-developer/rhdh"},
+            {"action": "allow", "path": "/code/safe-rhdh"},
+        ]
+    )
+    with patch(
+        "fs_sessions.policy.discover_repository", return_value=_context(Path("/code/safe-rhdh"))
+    ):
+        decision = evaluate_policy(data, Path("."))
+    assert decision.allowed is True
+    assert decision.matched_rule == 3
+
+
+def test_blacklist_default_allow(global_config):
+    _, _, data = global_config
+    data["sessions"]["policy"] = {
+        "default": "allow",
+        "rules": [{"action": "deny", "origin": "github.com/private/*"}],
+    }
+    with patch(
+        "fs_sessions.policy.discover_repository",
+        return_value=_context(Path("/code/repo"), "github.com/private/repo"),
+    ):
+        assert evaluate_policy(data, Path(".")).allowed is False
+
+
+def test_non_git_is_always_denied(global_config):
+    _, _, data = global_config
+    data["sessions"]["policy"]["default"] = "allow"
+    context = RepositoryContext("/tmp", None, None)
+    with patch("fs_sessions.policy.discover_repository", return_value=context):
+        decision = evaluate_policy(data, Path("/tmp"))
+    assert decision.allowed is False
+    assert decision.reason == "not_git_repository"
+
+
+def test_project_can_opt_out(global_config, tmp_path):
+    _, _, data = global_config
+    root = tmp_path / "project"
+    (root / ".rhdh").mkdir(parents=True)
+    (root / ".rhdh" / "config.json").write_text('{"sessions":{"enabled":false}}')
+    data["sessions"]["policy"]["default"] = "allow"
+    with patch("fs_sessions.policy.discover_repository", return_value=_context(root)):
+        decision = evaluate_policy(data, root)
+    assert decision.allowed is False
+    assert decision.reason == "project_opt_out"
+
+
+@pytest.mark.parametrize(
+    "policy",
+    [
+        {"default": "maybe", "rules": []},
+        {"default": "deny", "rules": {}},
+        {"default": "deny", "rules": [{"action": "allow"}]},
+        {"default": "deny", "rules": [{"action": "allow", "path": "*", "origin": "*"}]},
+    ],
+)
+def test_invalid_policies_fail_closed(policy):
+    with pytest.raises(config.ConfigError):
+        validate_policy(policy)
+
+
+def test_rule_mutation(global_config):
+    _, _, data = global_config
+    assert add_rule(data, "allow", "origin", "github.com/acme/*") == 1
+    assert add_rule(data, "deny", "path", "*/secret") == 2
+    assert remove_rule(data, 1) == {"action": "allow", "origin": "github.com/acme/*"}
+    assert data["sessions"]["policy"]["rules"] == [{"action": "deny", "path": "*/secret"}]
+
+
+def test_hook_install_migrates_legacy_and_preserves_other_hooks(tmp_path):
+    settings = tmp_path / "settings.json"
+    settings.write_text(
+        json.dumps(
+            {
+                "theme": "dark",
+                "hooks": {
+                    "SessionEnd": [
+                        {
+                            "matcher": "",
+                            "hooks": [{"type": "command", "command": "bash /x/export-session.sh"}],
+                        },
+                        {
+                            "matcher": "",
+                            "hooks": [{"type": "command", "command": "notify-send done"}],
+                        },
+                    ]
+                },
+            }
+        )
+    )
+    script = tmp_path / "skill" / "scripts" / "fs-sessions"
+    script.parent.mkdir(parents=True)
+    script.touch()
+
+    first = install_hook(script, settings)
+    second = install_hook(script, settings)
+
+    assert first["replaced"] == 1
+    assert second["replaced"] == 1
+    saved = json.loads(settings.read_text())
+    commands = [
+        hook["command"] for entry in saved["hooks"]["SessionEnd"] for hook in entry["hooks"]
+    ]
+    assert commands.count("notify-send done") == 1
+    assert len([command for command in commands if "hook run" in command]) == 1
+    assert saved["theme"] == "dark"
+
+
+def test_hook_uninstall_is_scoped_and_idempotent(tmp_path):
+    settings = tmp_path / "settings.json"
+    script = tmp_path / "fs-sessions"
+    script.touch()
+    install_hook(script, settings)
+    assert hook_status(settings)["installed"] is True
+    assert uninstall_hook(settings)["removed"] == 1
+    assert uninstall_hook(settings)["removed"] == 0
+    assert hook_status(settings)["installed"] is False
+
+
+def test_export_add_update_and_unchanged(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_text('{"type":"user"}\n')
+
+    first = prepare_export(transcript, "session", "project", repo, "user", "2026-01-01T00:00:00Z")
+    assert first is not None and first.verb == "add"
+    assert prepare_export(transcript, "session", "project", repo, "user") is None
+
+    transcript.write_text('{"type":"user"}\n{"type":"assistant"}\n')
+    updated = prepare_export(transcript, "session", "project", repo, "user")
+    assert updated is not None and updated.verb == "update"
+    metadata = json.loads(updated.dest.read_text().splitlines()[0])
+    assert metadata["message"]["content"].startswith("[Session: project] by user")
+
+
+def test_hook_run_exports_allowed_repository(global_config, tmp_path, monkeypatch):
+    _, repo, data = global_config
+    data["sessions"]["policy"]["default"] = "allow"
+    config.save_user_config(data)
+    source_repo = tmp_path / "source"
+    source_repo.mkdir()
+    transcript = tmp_path / "source.jsonl"
+    transcript.write_text('{"type":"user"}\n')
+    context = _context(source_repo)
+    event = {
+        "cwd": str(source_repo),
+        "transcript_path": str(transcript),
+        "session_id": "session-1",
+    }
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(
+        "fs_sessions.cli.evaluate_policy",
+        lambda *_: type("Decision", (), {"allowed": True, "context": context})(),
+    )
+    monkeypatch.setattr("fs_sessions.cli._username", lambda: "test-user")
+    monkeypatch.setattr("fs_sessions.cli.commit_file", lambda *args: True)
+    monkeypatch.setattr("fs_sessions.cli.pull_rebase", lambda *args: True)
+    monkeypatch.setattr("fs_sessions.cli.push", lambda *args: True)
+
+    assert main(["hook", "run"]) == 0
+    assert (repo / "sessions" / "test-user_source" / "session-1.jsonl").exists()
+
+
+def test_hook_run_skips_denied_repository(global_config, tmp_path, monkeypatch):
+    _, repo, _ = global_config
+    transcript = tmp_path / "source.jsonl"
+    transcript.write_text('{"type":"user"}\n')
+    event = {
+        "cwd": str(tmp_path),
+        "transcript_path": str(transcript),
+        "session_id": "session-1",
+    }
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(
+        "fs_sessions.cli.evaluate_policy", lambda *_: type("Decision", (), {"allowed": False})()
+    )
+
+    assert main(["hook", "run"]) == 0
+    assert list((repo / "sessions").glob("*/*.jsonl")) == []
+
+
+def test_commit_file_does_not_include_other_staged_changes(tmp_path):
+    from fs_sessions.git import commit_file
+
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True)
+    target = tmp_path / "target"
+    other = tmp_path / "other"
+    target.write_text("target")
+    other.write_text("other")
+    subprocess.run(["git", "add", "other"], cwd=tmp_path, check=True)
+
+    assert commit_file(tmp_path, "target", "feat: add target") is True
+
+    committed = subprocess.run(
+        ["git", "show", "--pretty=", "--name-only", "HEAD"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.splitlines()
+    assert committed == ["target"]
+    assert (
+        subprocess.run(
+            ["git", "diff", "--cached", "--quiet", "--", "other"], cwd=tmp_path
+        ).returncode
+        == 1
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -195,7 +195,7 @@ wheels = [
 
 [[package]]
 name = "rhdh-skill"
-version = "0.6.1"
+version = "0.7.0"
 source = { virtual = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- add the `fs-sessions` skill and its stdlib-only Python CLI
- add a global, default-deny repository policy with ordered allow/deny rules and safe project opt-out
- install or migrate one global Claude Code `SessionEnd` hook while preserving unrelated settings
- document global installation, configuration, legacy-hook migration, and smoke testing
- bump the package version to 0.7.0

## Test plan

- `uv run pytest -q` — 359 passed
- `uv run --python 3.9 --extra dev pytest tests/unit/test_fs_sessions.py -q` — 19 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- live install: global hook found exactly once; `fullsend-sessions` allowed by origin rule; `rhdh-skill` denied by default
