### PR TITLE
chore: remove version tracking from pyproject.toml

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,22 +66,15 @@ If told an implementation was wrong, apply the correction and then record what w
 
 ## Versioning
 
-Single source of truth: `pyproject.toml` (the `version` field).
+Versions are tracked exclusively via **git tags**. The `skills` CLI (`npx skills add`) resolves versions from tags, not from any file in the repo.
 
-### When to bump
+After merging a PR that changes skill behavior, scripts, or SKILL.md files, create a tag:
 
-Include a **patch** version bump (`x.y.Z`) in any PR that changes skill behavior, scripts, or SKILL.md files. Use **minor** (`x.Y.0`) for new skills/features, **major** (`X.0.0`) for breaking changes. Do NOT bump for docs-only or CI-only changes.
+```bash
+git tag v<VERSION> && git push origin v<VERSION>
+```
 
-### How to bump
-
-1. Read the current version from `pyproject.toml`.
-2. Compute the new version (patch/minor/major as appropriate).
-3. Update `pyproject.toml` and commit.
-4. The PR title should include the new version, e.g., `feat: add foo skill (v0.4.0)`.
-
-### Git tags
-
-The `skills` CLI (`npx skills add`) resolves versions via git tags, not from the version field. After merging a version-bump PR, create a tag: `git tag v<VERSION> && git push origin v<VERSION>`.
+Use **patch** (`x.y.Z`) for behavior changes, **minor** (`x.Y.0`) for new skills/features, **major** (`X.0.0`) for breaking changes. Skip tagging for docs-only or CI-only changes.
 
 ## Shared modules (lifecycle ↔ prow)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rhdh-skill"
-version = "0.6.1"
+version = "0.0.0"
 description = "Claude Code skill for RHDH plugin development"
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/unit/test_claude_md.py
+++ b/tests/unit/test_claude_md.py
@@ -49,7 +49,8 @@ class TestAgentsMdStructure:
 
     def test_has_versioning_section(self, agents_md):
         """AGENTS.md should document versioning."""
-        assert "pyproject.toml" in agents_md
+        assert "## Versioning" in agents_md
+        assert "git tag" in agents_md
 
     def test_has_agent_skills_section(self, agents_md):
         """AGENTS.md should have agent skills config section."""

--- a/uv.lock
+++ b/uv.lock
@@ -195,7 +195,7 @@ wheels = [
 
 [[package]]
 name = "rhdh-skill"
-version = "0.6.1"
+version = "0.0.0"
 source = { virtual = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- Set `pyproject.toml` version to `0.0.0` — field is required by PEP 621 but no longer meaningful
- Simplified AGENTS.md versioning section to git-tags-only — removed the file-editing steps and `pyproject.toml` source-of-truth claim

The `skills` CLI resolves versions from git tags, not from any file in the repo. After #65 removed `.claude-plugin/`, the version in `pyproject.toml` was the last piece of in-repo version bookkeeping that had to stay manually in sync with tags. This removes that friction from PRs.

## Test plan

- [x] Pre-commit hooks pass
- [ ] Verify `npx skills add` still resolves versions correctly (tags unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)