### PR TITLE
feat(rhdh-release): consume RHIDP Operational Rich Filter export

### DIFF
--- a/skills/rhdh-release/SKILL.md
+++ b/skills/rhdh-release/SKILL.md
@@ -12,7 +12,7 @@ compatibility: "acli on PATH. Python 3 + gog CLI for Google Sheets/Docs."
 <essential_principles>
 
 <principle name="use_cloud_id_for_team_queries">
-Use `"Team[Team]" = "{{CLOUD_ID}}"` in JQL to filter by team. Cloud IDs are in the RHDH Team Mapping spreadsheet (column "Cloud ID"). Use the `open_issues_by_team`, `feature_freeze_issues_by_team`, or `code_freeze_issues_by_team` JQL templates. This is fast and does not require `parse_issues.py --enrich`.
+Use `"Team[Team]" = "{{CLOUD_ID}}"` in JQL to filter by team. Cloud IDs are sourced from the Rich Filter JSON ("Scrum Team" smart filter) when available, or from the RHDH Team Mapping spreadsheet (column "Cloud ID") as fallback. Use the `open_issues_by_team`, `feature_freeze_issues_by_team`, or `code_freeze_issues_by_team` JQL templates. This is fast and does not require `parse_issues.py --enrich`.
 </principle>
 
 <principle name="include_jira_links">
@@ -109,10 +109,11 @@ What would you like to do?
 |-----------|---------|-----------|
 | `references/jql-release.md` | 13 release-specific JQL templates | Any Jira query for release data |
 | `references/slack-templates.md` | 4 Slack announcement templates | Generating freeze announcements |
-| `references/config.md` | GDrive IDs, project keys, dashboards, gog setup | Looking up config values or links |
+| `references/config.md` | GDrive IDs, project keys, dashboards, Rich Filter config, gog setup | Looking up config values or links |
 | `gog docs cat 13OkypJ3u_7Jq6kEhKhjEFwHQ12oPFDKXVzFjYW4XLdk` | Release process (live Google Doc) | Release process questions, onboarding |
 | `../../rhdh-jira/references/auth.md` | Jira auth setup | Jira prerequisite fails |
 | `../../rhdh-jira/references/acli-commands.md` | acli command reference | Building acli commands |
+| `../../rhdh/references/private-data.md` | Private data repo setup (Rich Filter JSON) | Rich Filter not found or setup questions |
 
 </reference_index>
 

--- a/skills/rhdh-release/SKILL.md
+++ b/skills/rhdh-release/SKILL.md
@@ -47,6 +47,13 @@ For team coordination:
 Never read `.jira-token` into context. Always use shell substitution: `"$(cat "$TOKEN_FILE")"`.
 </principle>
 
+<principle name="rich_filter_source_of_truth">
+Use the configured Rich Filter export for its base operational scope, freeze filters,
+release-note queues, Scrum Team IDs, demo/Test Day labels, and ad hoc exported
+queries. Run `python scripts/release.py --json check` before release workflows;
+do not replace a missing required Rich Filter entry with copied JQL.
+</principle>
+
 </essential_principles>
 
 <intake>
@@ -68,7 +75,7 @@ What would you like to do?
 6. **Blocker bugs** — Open blocker bugs for a release
 7. **EPICs** — Engineering EPICs not yet complete
 8. **CVEs** — CVE/vulnerability list for a release
-9. **Release notes** — Outstanding release notes (missing Release Note Type)
+9. **Release notes** — Release-note lifecycle (unclassified, proposed, done, with text)
 
 ### Announcements
 
@@ -76,6 +83,11 @@ What would you like to do?
 11. **Feature Freeze announcement** — Generate Feature Freeze milestone announcement
 12. **Code Freeze update** — Generate Code Freeze status update for Slack
 13. **Code Freeze announcement** — Generate Code Freeze milestone announcement
+
+### Rich Filter Operations
+
+14. **Post Code Freeze** — Issues requiring attention after Code Freeze
+15. **Rich Filter catalog/query** — Inspect or run any exported filter, queue, time series, or custom-ratio query
 
 **Wait for response before proceeding.**
 
@@ -100,6 +112,8 @@ What would you like to do?
 | 11, "feature freeze announcement", "announce feature freeze", "feature freeze reached" | `python scripts/release.py --json slack feature-freeze VERSION` | `workflows/announce-feature-freeze.md` |
 | 12, "code freeze update", "code freeze status", "code freeze progress" | `python scripts/release.py --json slack code-freeze-update VERSION` | `workflows/announce-code-freeze-update.md` |
 | 13, "code freeze announcement", "announce code freeze", "code freeze reached" | `python scripts/release.py --json slack code-freeze VERSION` | `workflows/announce-code-freeze.md` |
+| 14, "post code freeze", "post-freeze", "after code freeze" | `python scripts/release.py --json post-freeze VERSION` | `workflows/post-code-freeze.md` |
+| 15, "rich filter", "filter catalog", "smart filter", "rich queue" | `python scripts/release.py --json rich-filter inventory` | `workflows/rich-filter-catalog.md` |
 
 </routing>
 
@@ -107,7 +121,8 @@ What would you like to do?
 
 | Reference | Purpose | Load when |
 |-----------|---------|-----------|
-| `references/jql-release.md` | 16 release-specific templates (11 inline + 5 Rich Filter) | Any Jira query for release data |
+| `references/jql-release.md` | 20 release-specific templates (9 inline + 11 Rich Filter) | Any Jira query for release data |
+| `references/rich-filter-coverage.md` | Export coverage, mappings, and intentional exclusions | Auditing or extending Rich Filter integration |
 | `references/slack-templates.md` | 4 Slack announcement templates | Generating freeze announcements |
 | `references/config.md` | GDrive IDs, project keys, dashboards, Rich Filter config, gog setup | Looking up config values or links |
 | `gog docs cat 13OkypJ3u_7Jq6kEhKhjEFwHQ12oPFDKXVzFjYW4XLdk` | Release process (live Google Doc) | Release process questions, onboarding |

--- a/skills/rhdh-release/SKILL.md
+++ b/skills/rhdh-release/SKILL.md
@@ -107,7 +107,7 @@ What would you like to do?
 
 | Reference | Purpose | Load when |
 |-----------|---------|-----------|
-| `references/jql-release.md` | 13 release-specific JQL templates | Any Jira query for release data |
+| `references/jql-release.md` | 16 release-specific templates (11 inline + 5 Rich Filter) | Any Jira query for release data |
 | `references/slack-templates.md` | 4 Slack announcement templates | Generating freeze announcements |
 | `references/config.md` | GDrive IDs, project keys, dashboards, Rich Filter config, gog setup | Looking up config values or links |
 | `gog docs cat 13OkypJ3u_7Jq6kEhKhjEFwHQ12oPFDKXVzFjYW4XLdk` | Release process (live Google Doc) | Release process questions, onboarding |

--- a/skills/rhdh-release/references/config.md
+++ b/skills/rhdh-release/references/config.md
@@ -16,6 +16,19 @@ Static configuration values for the RHDH Release Manager skill.
 | `release_schedule_gdrive_id` | `1knVzlMW0l0X4c7gkoiuaGql1zuFgEGwHHBsj-ygUTnc` | RHDH Release Schedule spreadsheet |
 | `release_process_doc_id` | `13OkypJ3u_7Jq6kEhKhjEFwHQ12oPFDKXVzFjYW4XLdk` | Release process Google Doc |
 
+## Rich Filter (Private Data)
+
+| Key | Value | Description |
+|-----|-------|-------------|
+| `private_data_repo` | `../rhdh-skill-private-data` | Sibling directory with Jira Rich Filter exports |
+| `rich_filter_path` | `jira-rich-filter/rhidp-operational-rich-filter.json` | Rich Filter JSON file within the private data repo |
+
+The Rich Filter JSON is sourced from the "RHIDP Operational" Rich Filter in Jira, maintained by Matt Reid and Jasper Chui. When available, it overrides hardcoded JQL templates for Feature Freeze, Code Freeze, and Release Notes queries.
+
+**Setup:** See `../../rhdh/references/private-data.md` for clone instructions.
+
+**Override:** Set `RHDH_RICH_FILTER_PATH=/path/to/file.json` to use a specific file.
+
 ## gog CLI Setup
 
 Google Sheets and Docs access uses the [gog CLI](https://gogcli.sh).

--- a/skills/rhdh-release/references/config.md
+++ b/skills/rhdh-release/references/config.md
@@ -18,14 +18,9 @@ Static configuration values for the RHDH Release Manager skill.
 
 ## Rich Filter
 
-| Key | Value | Description |
-|-----|-------|-------------|
-| `private_data_repo` | `../rhdh-skill-private-data` | Sibling directory with Jira Rich Filter exports |
-| `rich_filter_path` | `jira-rich-filter/rhidp-operational-rich-filter.json` | Rich Filter JSON file within the private data repo |
+The Rich Filter JSON is sourced from the "RHIDP Operational" Rich Filter in Jira, maintained by Matt Reid and Jasper Chui. When available, it provides JQL for Feature Freeze, Code Freeze, and Release Notes queries.
 
-The Rich Filter JSON is sourced from the "RHIDP Operational" Rich Filter in Jira, maintained by Matt Reid and Jasper Chui. When available, it overrides hardcoded JQL templates for Feature Freeze, Code Freeze, and Release Notes queries.
-
-**Setup:** See `../../rhdh/references/private-data.md` for clone instructions.
+The repo is discovered via `rhdh.config.get_repo("private-data")`. Register it with `rhdh config set private-data /path/to/rhdh-skill-private-data`.
 
 **Override:** Set `RHDH_RICH_FILTER_PATH=/path/to/file.json` to use a specific file.
 

--- a/skills/rhdh-release/references/config.md
+++ b/skills/rhdh-release/references/config.md
@@ -18,11 +18,25 @@ Static configuration values for the RHDH Release Manager skill.
 
 ## Rich Filter
 
-The Rich Filter JSON is sourced from the "RHIDP Operational" Rich Filter in Jira, maintained by Matt Reid and Jasper Chui. When available, it provides JQL for Feature Freeze, Code Freeze, and Release Notes queries.
+The Rich Filter JSON is sourced from the "RHIDP Operational" Rich Filter in Jira, maintained by Matt Reid and Jasper Chui. It is required for freeze, demo/Test Day, post-freeze, release-note lifecycle, Scrum Team, and exported ad hoc queries.
 
 The repo is discovered via `rhdh.config.get_repo("private-data")`. Register it with `rhdh config set private-data /path/to/rhdh-skill-private-data`.
 
 **Override:** Set `RHDH_RICH_FILTER_PATH=/path/to/file.json` to use a specific file.
+
+Validate and inspect it with:
+
+```bash
+python scripts/release.py --json check
+python scripts/release.py --json rich-filter inventory
+python scripts/release.py --json rich-filter query static "Feature Freeze" --version 2.1.0 --count
+python scripts/release.py --json rich-filter query smart AI --group "Scrum Team" --version 2.1.0 --count
+python scripts/release.py --json rich-filter query queue "RNs Proposed" --version 2.1.0 --count
+python scripts/release.py --json rich-filter query time-series "Last week" --version 2.1.0 --count
+python scripts/release.py --json rich-filter query ratio-numerator "1.10 Plan to Commit" --count
+```
+
+See `rich-filter-coverage.md` for the complete coverage contract and exclusions.
 
 ## gog CLI Setup
 

--- a/skills/rhdh-release/references/config.md
+++ b/skills/rhdh-release/references/config.md
@@ -16,7 +16,7 @@ Static configuration values for the RHDH Release Manager skill.
 | `release_schedule_gdrive_id` | `1knVzlMW0l0X4c7gkoiuaGql1zuFgEGwHHBsj-ygUTnc` | RHDH Release Schedule spreadsheet |
 | `release_process_doc_id` | `13OkypJ3u_7Jq6kEhKhjEFwHQ12oPFDKXVzFjYW4XLdk` | Release process Google Doc |
 
-## Rich Filter (Private Data)
+## Rich Filter
 
 | Key | Value | Description |
 |-----|-------|-------------|

--- a/skills/rhdh-release/references/jql-release.md
+++ b/skills/rhdh-release/references/jql-release.md
@@ -111,18 +111,6 @@ project in (RHDHPlan, rhidp) AND issuetype = feature AND fixVersion = "{{RELEASE
 - **Example:** `... AND fixVersion = "1.9.0" AND fixversion changed after -14d`
 - **Notes:** Tracks scope changes to release.
 
-## release_notes
-
-Find issues missing Release Note Type field.
-
-```jql
-project in (RHIDP, "Red Hat Developer Hub Bugs", "RHDH Support", rhdhplan) and issuetype in (Feature, bug) and ("Release Note Type" not in ("Release Note Not Required") or "release note type" is empty) and ("Release Note Status" not in ("In Progress", Proposed, Done) or "Release Note Text[Paragraph]" is empty or "Release Note Type[Dropdown]" is empty) and summary !~ "CVE-*" and (resolution not in (obsolete, duplicate, "Won't Do") or resolution is empty) and fixVersion = "{{RELEASE_VERSION}}"
-```
-
-- **Placeholders:** `{{RELEASE_VERSION}}`
-- **Example:** `... AND "Release Note Type" is EMPTY and fixVersion = "1.9.0"`
-- **Notes:** Critical for documentation — must be filled before release.
-
 ## blockers
 
 Find open blocker bugs for a release.
@@ -135,28 +123,6 @@ project IN (RHIDP, RHDHBugs, RHDHPLAN, RHDHSUPP) AND fixVersion = "{{RELEASE_VER
 - **Example:** `... AND fixVersion = "1.9.0" AND status != closed AND issuetype = bug AND priority = Blocker`
 - **Notes:** Critical path items that must be resolved before release.
 
-## feature_freeze_issues
-
-Find feature work outstanding at Feature Freeze.
-
-```jql
-project IN (RHIDP, RHDHBugs, RHDHPLAN, RHDHSUPP) AND fixVersion = "{{RELEASE_VERSION}}" and resolution is EMPTY AND component not in ("AEM Migration", AI, "AI Demo", Conference, Build, Certification, "Continuous Improvement", Documentation, JTBD, Knowledge, Performance, Quality, Quickstart, Release, "RHDH Local", "RHDH Plugin Repo", Security, "Security Tooling", Segment, Serviceability, Support, "Team Operations", "Test Framework", "Test Infrastructure", "Upstream & Community", UX) AND Type not in (Bug, Vulnerability, sub-task) AND status not in ("Dev Complete", "Release Pending", Done, Closed) AND (labels is EMPTY OR labels != stretch-goal)
-```
-
-- **Placeholders:** `{{RELEASE_VERSION}}`
-- **Notes:** Excludes infrastructure/ops components and bugs. Use for Feature Freeze announcements. The component exclusion list filters out non-feature work that shouldn't block Feature Freeze.
-
-## code_freeze_issues
-
-Find all issues outstanding at Code Freeze.
-
-```jql
-project IN (RHIDP, RHDHBugs, RHDHPLAN, RHDHSUPP) AND fixVersion = "{{RELEASE_VERSION}}" and issuetype in (bug, Story, task, Vulnerability) AND status not in ("Release Pending", Closed) AND component not in ("AEM Migration", AI, "AI Demo", Conference, Documentation, JTBD, Knowledge, Performance, Release, "RHDH Plugin Repo", Security, "Security Tooling", Support, "Team Operations", "Upstream & Community") OR issuetype in (feature) AND status not in ("Release Pending", Closed) AND component not in ("AEM Migration", AI, "AI Demo", Conference, Documentation, JTBD, Knowledge, Performance, Release, "RHDH Plugin Repo", Security, "Security Tooling", Support, "Team Operations", "Upstream & Community") OR issuetype in (epic) AND status not in ("Dev Complete", "Release Pending", Closed) AND component not in ("AEM Migration", AI, "AI Demo", Conference, Documentation, JTBD, Knowledge, Performance, Release, "RHDH Plugin Repo", Security, "Security Tooling", Support, "Team Operations", "Upstream & Community")
-```
-
-- **Placeholders:** `{{RELEASE_VERSION}}`
-- **Notes:** All open work. Same as `open_issues` — used for Code Freeze announcements.
-
 ## open_issues_by_team
 
 Find all open issues for a release filtered by team using Cloud ID.
@@ -168,25 +134,3 @@ project IN (RHIDP, RHDHBugs, RHDHPLAN, RHDHSUPP) AND fixVersion = "{{RELEASE_VER
 - **Placeholders:** `{{RELEASE_VERSION}}`, `{{CLOUD_ID}}`
 - **Example:** `... AND fixVersion = "2.1.0" AND status != closed AND "Team[Team]" = "ec74d716-af36-4b3c-950f-f79213d08f71-4403"`
 - **Notes:** Cloud ID is the Jira Cloud team identifier from the RHDH Team Mapping spreadsheet (column "Cloud ID"). This is the fastest way to filter by team — no enrichment needed.
-
-## feature_freeze_issues_by_team
-
-Find feature work outstanding at Feature Freeze filtered by team.
-
-```jql
-project IN (RHIDP, RHDHBugs, RHDHPLAN, RHDHSUPP) AND fixVersion = "{{RELEASE_VERSION}}" and resolution is EMPTY AND component not in ("AEM Migration", AI, "AI Demo", Conference, Build, Certification, "Continuous Improvement", Documentation, JTBD, Knowledge, Performance, Quality, Quickstart, Release, "RHDH Local", "RHDH Plugin Repo", Security, "Security Tooling", Segment, Serviceability, Support, "Team Operations", "Test Framework", "Test Infrastructure", "Upstream & Community", UX) AND Type not in (Bug, Vulnerability, sub-task) AND status not in ("Dev Complete", "Release Pending", Done, Closed) AND (labels is EMPTY OR labels != stretch-goal) AND "Team[Team]" = "{{CLOUD_ID}}"
-```
-
-- **Placeholders:** `{{RELEASE_VERSION}}`, `{{CLOUD_ID}}`
-- **Notes:** Same as `code_freeze_issues` but scoped to a single team by Cloud ID.
-
-## code_freeze_issues_by_team
-
-Find all issues outstanding at Code Freeze filtered by team.
-
-```jql
-project IN (RHIDP, RHDHBugs, RHDHPLAN, RHDHSUPP) AND fixVersion = "{{RELEASE_VERSION}}" and issuetype in (bug, Story, task, Vulnerability) AND status not in ("Release Pending", Closed) AND component not in ("AEM Migration", AI, "AI Demo", Conference, Documentation, JTBD, Knowledge, Performance, Release, "RHDH Plugin Repo", Security, "Security Tooling", Support, "Team Operations", "Upstream & Community") OR issuetype in (feature) AND status not in ("Release Pending", Closed) AND component not in ("AEM Migration", AI, "AI Demo", Conference, Documentation, JTBD, Knowledge, Performance, Release, "RHDH Plugin Repo", Security, "Security Tooling", Support, "Team Operations", "Upstream & Community") OR issuetype in (epic) AND status not in ("Dev Complete", "Release Pending", Closed) AND component not in ("AEM Migration", AI, "AI Demo", Conference, Documentation, JTBD, Knowledge, Performance, Release, "RHDH Plugin Repo", Security, "Security Tooling", Support, "Team Operations", "Upstream & Community") AND "Team[Team]" = "{{CLOUD_ID}}"
-```
-
-- **Placeholders:** `{{RELEASE_VERSION}}`, `{{CLOUD_ID}}`
-- **Notes:** Same as `code_freeze_issues` but scoped to a single team by Cloud ID.

--- a/skills/rhdh-release/references/jql-release.md
+++ b/skills/rhdh-release/references/jql-release.md
@@ -111,6 +111,14 @@ project in (RHDHPlan, rhidp) AND issuetype = feature AND fixVersion = "{{RELEASE
 - **Example:** `... AND fixVersion = "1.9.0" AND fixversion changed after -14d`
 - **Notes:** Tracks scope changes to release.
 
+## release_notes
+
+Find issues missing Release Note Type field.
+
+- **Source:** Rich Filter — "RNs Unclassified" rich queue
+- **Placeholders:** `{{RELEASE_VERSION}}`
+- **Notes:** Critical for documentation — must be filled before release.
+
 ## blockers
 
 Find open blocker bugs for a release.
@@ -123,6 +131,22 @@ project IN (RHIDP, RHDHBugs, RHDHPLAN, RHDHSUPP) AND fixVersion = "{{RELEASE_VER
 - **Example:** `... AND fixVersion = "1.9.0" AND status != closed AND issuetype = bug AND priority = Blocker`
 - **Notes:** Critical path items that must be resolved before release.
 
+## feature_freeze_issues
+
+Find feature work outstanding at Feature Freeze.
+
+- **Source:** Rich Filter — "Feature Freeze" static filter
+- **Placeholders:** `{{RELEASE_VERSION}}`
+- **Notes:** Excludes infrastructure/ops components and bugs. Use for Feature Freeze announcements.
+
+## code_freeze_issues
+
+Find all issues outstanding at Code Freeze.
+
+- **Source:** Rich Filter — "Code Freeze" static filter
+- **Placeholders:** `{{RELEASE_VERSION}}`
+- **Notes:** All open work scoped to the release. Use for Code Freeze announcements.
+
 ## open_issues_by_team
 
 Find all open issues for a release filtered by team using Cloud ID.
@@ -134,3 +158,19 @@ project IN (RHIDP, RHDHBugs, RHDHPLAN, RHDHSUPP) AND fixVersion = "{{RELEASE_VER
 - **Placeholders:** `{{RELEASE_VERSION}}`, `{{CLOUD_ID}}`
 - **Example:** `... AND fixVersion = "2.1.0" AND status != closed AND "Team[Team]" = "ec74d716-af36-4b3c-950f-f79213d08f71-4403"`
 - **Notes:** Cloud ID is the Jira Cloud team identifier from the RHDH Team Mapping spreadsheet (column "Cloud ID"). This is the fastest way to filter by team — no enrichment needed.
+
+## feature_freeze_issues_by_team
+
+Find feature work outstanding at Feature Freeze filtered by team.
+
+- **Source:** Rich Filter — "Feature Freeze" static filter + Cloud ID
+- **Placeholders:** `{{RELEASE_VERSION}}`, `{{CLOUD_ID}}`
+- **Notes:** Same as `feature_freeze_issues` but scoped to a single team by Cloud ID.
+
+## code_freeze_issues_by_team
+
+Find all issues outstanding at Code Freeze filtered by team.
+
+- **Source:** Rich Filter — "Code Freeze" static filter + Cloud ID
+- **Placeholders:** `{{RELEASE_VERSION}}`, `{{CLOUD_ID}}`
+- **Notes:** Same as `code_freeze_issues` but scoped to a single team by Cloud ID.

--- a/skills/rhdh-release/references/jql-release.md
+++ b/skills/rhdh-release/references/jql-release.md
@@ -67,12 +67,8 @@ project IN (RHIDP, rhdhbugs) AND fixVersion = "{{RELEASE_VERSION}}" and issuetyp
 
 Find features tagged for demonstration.
 
-```jql
-project in (RHDHPlan, RHIDP) AND issuetype = feature AND labels = demo AND fixVersion = "{{RELEASE_VERSION}}" AND status != closed
-```
-
+- **Source:** Rich Filter — "demo" static filter
 - **Placeholders:** `{{RELEASE_VERSION}}`
-- **Example:** `... AND labels = demo AND fixVersion = "1.9.0" AND status != closed`
 - **Notes:** Features that need demo preparation.
 
 ## feature_subtasks
@@ -91,12 +87,8 @@ project in (RHDHPlan) AND issuetype = sub-task AND fixVersion = "{{RELEASE_VERSI
 
 Find features designated for Test Day.
 
-```jql
-Project in (RHDHPlan, rhidp) AND issuetype = feature AND labels = rhdh-testday AND fixVersion = "{{RELEASE_VERSION}}" AND status != closed
-```
-
+- **Source:** Rich Filter — "Test Day" static filter
 - **Placeholders:** `{{RELEASE_VERSION}}`
-- **Example:** `... AND labels = rhdh-testday AND fixVersion = "1.9.0" AND status != closed`
 - **Notes:** Features ready for Test Day validation.
 
 ## features_added_to_release
@@ -118,6 +110,27 @@ Find issues missing Release Note Type field.
 - **Source:** Rich Filter — "RNs Unclassified" rich queue
 - **Placeholders:** `{{RELEASE_VERSION}}`
 - **Notes:** Critical for documentation — must be filled before release.
+
+## release_notes_proposed
+
+Find issues with proposed or in-progress release notes and non-empty text.
+
+- **Source:** Rich Filter — "RNs Proposed" rich queue
+- **Placeholders:** `{{RELEASE_VERSION}}`
+
+## release_notes_done
+
+Find issues with completed release notes and non-empty text.
+
+- **Source:** Rich Filter — "RNs Done" rich queue
+- **Placeholders:** `{{RELEASE_VERSION}}`
+
+## release_notes_with_text
+
+Find release-scoped issues that have release-note text.
+
+- **Source:** Rich Filter — "Has RN Text" rich queue
+- **Placeholders:** `{{RELEASE_VERSION}}`
 
 ## blockers
 
@@ -146,6 +159,13 @@ Find all issues outstanding at Code Freeze.
 - **Source:** Rich Filter — "Code Freeze" static filter
 - **Placeholders:** `{{RELEASE_VERSION}}`
 - **Notes:** All open work scoped to the release. Use for Code Freeze announcements.
+
+## post_code_freeze_issues
+
+Find release-scoped work requiring attention after Code Freeze.
+
+- **Source:** Rich Filter — "Post Code Freeze" static filter
+- **Placeholders:** `{{RELEASE_VERSION}}`
 
 ## open_issues_by_team
 

--- a/skills/rhdh-release/references/rich-filter-coverage.md
+++ b/skills/rhdh-release/references/rich-filter-coverage.md
@@ -1,0 +1,44 @@
+# Rich Filter Coverage
+
+The configured export is the source of truth for all query-bearing data it
+contains. `rich-filter inventory` exposes every static filter, smart-filter
+clause, rich queue, time series, and custom ratio; `rich-filter query` composes
+any fragment (including either side of a ratio) with optional release scope.
+
+## First-class release mappings
+
+| Release behavior | Export source |
+|---|---|
+| Base operational scope | complete `jiraFilter.jql`, excluding `ORDER BY` |
+| Feature Freeze | static `Feature Freeze` |
+| Code Freeze | static `Code Freeze` |
+| Post Code Freeze | static `Post Code Freeze` |
+| Feature demos | static `demo` |
+| Test Day features | static `Test Day` |
+| Team Cloud IDs | smart filter `Scrum Team` |
+| Unclassified release notes | queue `RNs Unclassified` |
+| Proposed release notes | queue `RNs Proposed` |
+| Completed release notes | queue `RNs Done` |
+| Release-note text present | queue `Has RN Text` |
+
+The demo and Test Day migrations intentionally adopt the exported operational
+scope instead of preserving the narrower legacy `RHDHPlan/RHIDP + Feature +
+open` query. In a live comparison for release `2.1.0` on 2026-07-15, this
+changed demo results from 31 to 34 and Test Day results from 27 to 52. The Jira
+export is authoritative; these differences are expected, not parity defects.
+
+## Intentionally local JQL
+
+The remaining templates stay local because the export has no semantically
+equivalent named entry: active release discovery, open issue totals/by type,
+blockers, engineering EPICs, CVEs, feature subtasks, recently added features,
+and the generic open-issues-by-team constraint. Exported entries with similar
+words are not assumed equivalent.
+
+## Non-query export data
+
+Dynamic filter fields and rich views describe dashboard presentation. The
+inventory reports field labels/clauses and view columns, but the CLI does not
+execute them because they are not JQL. Time series and custom ratios do contain
+JQL and are queryable. Administrative metadata, permissions, colors, layout,
+and identifiers are not release logic.

--- a/skills/rhdh-release/scripts/jql.py
+++ b/skills/rhdh-release/scripts/jql.py
@@ -4,10 +4,9 @@ Reads the markdown file at runtime so the CLI and agent share one source of trut
 Supports placeholder rendering ({{RELEASE_VERSION}}, {{ISSUE_TYPE}}) and
 URL-encoded Jira search links.
 
-Five templates are sourced exclusively from the Rich Filter JSON export:
-feature_freeze_issues, feature_freeze_issues_by_team, code_freeze_issues,
-code_freeze_issues_by_team, and release_notes. These templates are only
-available when the Rich Filter is configured.
+Eleven templates are sourced exclusively from the Rich Filter JSON export,
+including freeze scopes, demo/Test Day filters, and release-note lifecycle
+queues. These templates are only available when the Rich Filter is configured.
 """
 
 from __future__ import annotations
@@ -80,25 +79,15 @@ def _apply_rich_filter_overlay(templates: dict[str, str]) -> dict[str, str]:
 
     result = dict(templates)
 
-    base = rf_mod.base_jql(_RICH_FILTER_PATH)
-    if base:
-        # Strip status/resolution conditions from base — they're in the fragments
-        scope = re.match(r"project\s+in\s*\([^)]+\)", base, re.IGNORECASE)
-        base_scope = scope.group(0) if scope else base
-    else:
-        base_scope = None
+    base_scope = rf_mod.base_jql(_RICH_FILTER_PATH)
 
     def _compose(fragment: str, extra: str = "") -> str:
-        parts = []
-        if base_scope:
-            parts.append(base_scope)
-        parts.append('fixVersion = "{{RELEASE_VERSION}}"')
-        # Rich Filter fragments can contain top-level OR expressions. Group
-        # them so every branch remains scoped by project and fixVersion.
-        parts.append(f"({fragment})")
-        if extra:
-            parts.append(extra)
-        return " AND ".join(parts)
+        return compose_fragment(
+            fragment,
+            version="{{RELEASE_VERSION}}",
+            extra=extra,
+            base_scope=base_scope,
+        )
 
     ff_jql = rf_mod.static_filter("Feature Freeze", _RICH_FILTER_PATH)
     if ff_jql:
@@ -110,11 +99,57 @@ def _apply_rich_filter_overlay(templates: dict[str, str]) -> dict[str, str]:
         result["code_freeze_issues"] = _compose(cf_jql)
         result["code_freeze_issues_by_team"] = _compose(cf_jql, '"Team[Team]" = "{{CLOUD_ID}}"')
 
-    rn_jql = rf_mod.rich_queue("RNs Unclassified", _RICH_FILTER_PATH)
-    if rn_jql:
-        result["release_notes"] = _compose(rn_jql)
+    static_templates = {
+        "feature_demos": "demo",
+        "test_day_features": "Test Day",
+        "post_code_freeze_issues": "Post Code Freeze",
+    }
+    for template_name, filter_name in static_templates.items():
+        fragment = rf_mod.static_filter(filter_name, _RICH_FILTER_PATH)
+        if fragment:
+            result[template_name] = _compose(fragment)
+
+    queue_templates = {
+        "release_notes": "RNs Unclassified",
+        "release_notes_proposed": "RNs Proposed",
+        "release_notes_done": "RNs Done",
+        "release_notes_with_text": "Has RN Text",
+    }
+    for template_name, queue_name in queue_templates.items():
+        fragment = rf_mod.rich_queue(queue_name, _RICH_FILTER_PATH)
+        if fragment:
+            result[template_name] = _compose(fragment)
 
     return result
+
+
+def compose_fragment(
+    fragment: str,
+    *,
+    version: str | None = None,
+    extra: str | None = None,
+    base_scope: str | None = None,
+) -> str:
+    """Compose an exported JQL fragment with project and release scope."""
+    if base_scope is None:
+        import rich_filter as rf_mod
+
+        base = rf_mod.base_jql(_RICH_FILTER_PATH)
+        if base:
+            base_scope = base
+
+    parts = []
+    if base_scope:
+        # The base can contain a top-level OR, so group it before adding scope.
+        parts.append(f"({base_scope})")
+    if version is not None:
+        parts.append(f'fixVersion = "{version}"')
+    # Exported fragments can contain top-level OR expressions. Group them so
+    # every branch remains constrained by the preceding scope.
+    parts.append(f"({fragment})")
+    if extra:
+        parts.append(extra)
+    return " AND ".join(parts)
 
 
 def load_templates(path: Path | None = None) -> dict[str, str]:

--- a/skills/rhdh-release/scripts/jql.py
+++ b/skills/rhdh-release/scripts/jql.py
@@ -1,8 +1,13 @@
-"""Parse JQL templates from references/jql-release.md.
+"""Parse JQL templates from references/jql-release.md and Rich Filter JSON.
 
 Reads the markdown file at runtime so the CLI and agent share one source of truth.
 Supports placeholder rendering ({{RELEASE_VERSION}}, {{ISSUE_TYPE}}) and
 URL-encoded Jira search links.
+
+Five templates are sourced exclusively from the Rich Filter JSON export:
+feature_freeze_issues, feature_freeze_issues_by_team, code_freeze_issues,
+code_freeze_issues_by_team, and release_notes. These templates are only
+available when the Rich Filter is configured.
 """
 
 from __future__ import annotations
@@ -17,6 +22,7 @@ _REFERENCES_DIR = Path(__file__).resolve().parent.parent / "references"
 _JQL_FILE = _REFERENCES_DIR / "jql-release.md"
 
 _TEMPLATE_CACHE: dict[str, str] | None = None
+_RICH_FILTER_PATH: Path | str | None = None
 
 
 def _parse_jql_file(path: Path | None = None) -> dict[str, str]:
@@ -49,13 +55,78 @@ def _parse_jql_file(path: Path | None = None) -> dict[str, str]:
     return templates
 
 
+def set_rich_filter_path(path: Path | str | None) -> None:
+    """Configure the Rich Filter JSON location.
+
+    Calling this invalidates the template cache so the next load_templates()
+    call will re-compose templates with (or without) Rich Filter data.
+    """
+    global _RICH_FILTER_PATH, _TEMPLATE_CACHE
+    _RICH_FILTER_PATH = path
+    _TEMPLATE_CACHE = None
+
+
+def _apply_rich_filter_overlay(templates: dict[str, str]) -> dict[str, str]:
+    """Override specific templates with Rich Filter-sourced queries.
+
+    The Rich Filter provides filter fragments (no project scope or fixVersion).
+    We compose the full query as: base_scope + fixVersion + fragment.
+    """
+    import rich_filter as rf_mod
+
+    rf = rf_mod.load(_RICH_FILTER_PATH)
+    if rf is None:
+        return templates
+
+    result = dict(templates)
+
+    base = rf_mod.base_jql(_RICH_FILTER_PATH)
+    if base:
+        # Strip status/resolution conditions from base — they're in the fragments
+        scope = re.match(r"project\s+in\s*\([^)]+\)", base, re.IGNORECASE)
+        base_scope = scope.group(0) if scope else base
+    else:
+        base_scope = None
+
+    def _compose(fragment: str, extra: str = "") -> str:
+        parts = []
+        if base_scope:
+            parts.append(base_scope)
+        parts.append('fixVersion = "{{RELEASE_VERSION}}"')
+        parts.append(fragment)
+        if extra:
+            parts.append(extra)
+        return " AND ".join(parts)
+
+    ff_jql = rf_mod.static_filter("Feature Freeze", _RICH_FILTER_PATH)
+    if ff_jql:
+        result["feature_freeze_issues"] = _compose(ff_jql)
+        result["feature_freeze_issues_by_team"] = _compose(ff_jql, '"Team[Team]" = "{{CLOUD_ID}}"')
+
+    cf_jql = rf_mod.static_filter("Code Freeze", _RICH_FILTER_PATH)
+    if cf_jql:
+        result["code_freeze_issues"] = _compose(cf_jql)
+        result["code_freeze_issues_by_team"] = _compose(cf_jql, '"Team[Team]" = "{{CLOUD_ID}}"')
+
+    rn_jql = rf_mod.rich_queue("RNs Unclassified", _RICH_FILTER_PATH)
+    if rn_jql:
+        result["release_notes"] = _compose(rn_jql)
+
+    return result
+
+
 def load_templates(path: Path | None = None) -> dict[str, str]:
-    """Load and cache JQL templates from jql-release.md."""
+    """Load and cache JQL templates from jql-release.md.
+
+    If a Rich Filter path is configured, overlays Rich Filter-sourced
+    queries onto the markdown templates for supported template names.
+    """
     global _TEMPLATE_CACHE
     if path is not None:
         return _parse_jql_file(path)
     if _TEMPLATE_CACHE is None:
-        _TEMPLATE_CACHE = _parse_jql_file()
+        templates = _parse_jql_file()
+        _TEMPLATE_CACHE = _apply_rich_filter_overlay(templates)
     return _TEMPLATE_CACHE
 
 

--- a/skills/rhdh-release/scripts/jql.py
+++ b/skills/rhdh-release/scripts/jql.py
@@ -93,7 +93,9 @@ def _apply_rich_filter_overlay(templates: dict[str, str]) -> dict[str, str]:
         if base_scope:
             parts.append(base_scope)
         parts.append('fixVersion = "{{RELEASE_VERSION}}"')
-        parts.append(fragment)
+        # Rich Filter fragments can contain top-level OR expressions. Group
+        # them so every branch remains scoped by project and fixVersion.
+        parts.append(f"({fragment})")
         if extra:
             parts.append(extra)
         return " AND ".join(parts)

--- a/skills/rhdh-release/scripts/release.py
+++ b/skills/rhdh-release/scripts/release.py
@@ -26,6 +26,7 @@ if str(_scripts_dir) not in sys.path:
     sys.path.insert(0, str(_scripts_dir))
 
 import jql as jql_mod  # noqa: E402
+import rich_filter as rf_mod  # noqa: E402
 import slack_templates as slack_mod  # noqa: E402
 from formatters import OutputFormatter  # noqa: E402
 
@@ -394,8 +395,19 @@ def _fetch_teams(category: str | None = None) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 
+def _init_rich_filter() -> Path | None:
+    """Attempt to locate and configure the Rich Filter JSON.
+
+    Returns the path if found, None otherwise.
+    """
+    rf_path = rf_mod.discover()
+    if rf_path:
+        jql_mod.set_rich_filter_path(rf_path)
+    return rf_path
+
+
 def cmd_check(_args: argparse.Namespace, fmt: OutputFormatter) -> None:
-    """Verify prerequisites: acli, .jira-token, gog, gog-auth."""
+    """Verify prerequisites: acli, .jira-token, gog, gog-auth, rich-filter."""
     checks = []
 
     acli_path = shutil.which("acli")
@@ -461,6 +473,17 @@ def cmd_check(_args: argparse.Namespace, fmt: OutputFormatter) -> None:
                 "message": "connected" if jira_ok else "acli cannot reach Jira",
             }
         )
+
+    rf_path = rf_mod.discover()
+    checks.append(
+        {
+            "name": "rich-filter",
+            "status": "pass" if rf_path else "warn",
+            "message": str(rf_path)
+            if rf_path
+            else "not found (optional — JQL falls back to markdown templates)",
+        }
+    )
 
     all_pass = all(c["status"] == "pass" for c in checks)
     has_fail = any(c["status"] == "fail" for c in checks)
@@ -1105,6 +1128,8 @@ def main(argv: list[str] | None = None) -> None:
     if not handler:
         parser.print_help()
         sys.exit(1)
+
+    _init_rich_filter()
 
     try:
         handler(args, fmt)

--- a/skills/rhdh-release/scripts/release.py
+++ b/skills/rhdh-release/scripts/release.py
@@ -484,7 +484,6 @@ def cmd_check(_args: argparse.Namespace, fmt: OutputFormatter) -> None:
             "message": acli_path or "not found on PATH",
         }
     )
-
     token_file = Path.home() / ".jira-token"
     checks.append(
         {
@@ -547,9 +546,20 @@ def cmd_check(_args: argparse.Namespace, fmt: OutputFormatter) -> None:
             "status": "pass" if rf_path else "warn",
             "message": str(rf_path)
             if rf_path
-            else "not found (required for freeze and release-notes JQL)",
+            else "not found (required for data-driven release JQL)",
         }
     )
+    if rf_path:
+        validation_errors = rf_mod.validate(rf_path)
+        checks.append(
+            {
+                "name": "rich-filter-contract",
+                "status": "fail" if validation_errors else "pass",
+                "message": "; ".join(validation_errors)
+                if validation_errors
+                else "all required filters and queues are available",
+            }
+        )
 
     all_pass = all(c["status"] == "pass" for c in checks)
     has_fail = any(c["status"] == "fail" for c in checks)
@@ -819,25 +829,73 @@ def cmd_cves(args: argparse.Namespace, fmt: OutputFormatter) -> None:
 
 
 def cmd_notes(args: argparse.Namespace, fmt: OutputFormatter) -> None:
-    """Count issues missing Release Note Type."""
+    """Report release-note lifecycle counts."""
     version = args.version
-    jql, url = jql_mod.render_with_url("release_notes", version=version)
-    count = _acli_count(jql, fmt)
+    lifecycle_templates = {
+        "unclassified": "release_notes",
+        "proposed": "release_notes_proposed",
+        "done": "release_notes_done",
+        "with_text": "release_notes_with_text",
+    }
+    lifecycle = {}
+    for stage, template_name in lifecycle_templates.items():
+        jql, url = jql_mod.render_with_url(template_name, version=version)
+        lifecycle[stage] = {"count": _acli_count(jql, fmt), "jira_url": url}
 
     dashboard_url = "https://issues.redhat.com/secure/Dashboard.jspa?selectPageId=12382090"
 
     fmt.header(f"RHDH {version} — Release Notes")
-    fmt.log_info(f"Outstanding: {count} issues missing Release Note Type")
+    for stage, data in lifecycle.items():
+        fmt.log_info(f"{stage.replace('_', ' ').title()}: {data['count']}")
     fmt.log_info(f"Dashboard: {dashboard_url}")
 
     fmt.success(
         {
             "version": version,
-            "outstanding_count": count,
-            "jira_url": url,
+            "outstanding_count": lifecycle["unclassified"]["count"],
+            "jira_url": lifecycle["unclassified"]["jira_url"],
+            "lifecycle": lifecycle,
             "dashboard_url": dashboard_url,
         }
     )
+
+
+def cmd_post_freeze(args: argparse.Namespace, fmt: OutputFormatter) -> None:
+    """Count release-scoped work matching the Post Code Freeze filter."""
+    version = args.version
+    jql, url = jql_mod.render_with_url("post_code_freeze_issues", version=version)
+    count = _acli_count(jql, fmt)
+    fmt.header(f"RHDH {version} — Post Code Freeze")
+    fmt.log_info(f"Issues requiring post-freeze attention: {count}")
+    fmt.success({"version": version, "count": count, "jira_url": url})
+
+
+def cmd_rich_filter_inventory(_args: argparse.Namespace, fmt: OutputFormatter) -> None:
+    """List all query-bearing entries and presentation metadata."""
+    data = rf_mod.inventory()
+    if data is None:
+        raise RuntimeError("Rich Filter export not found")
+    fmt.header(data.get("name", "Rich Filter"))
+    fmt.success(data)
+
+
+def cmd_rich_filter_query(args: argparse.Namespace, fmt: OutputFormatter) -> None:
+    """Compose any exported Rich Filter query with optional release scope."""
+    fragment = rf_mod.fragment(args.kind, args.name, group=args.group)
+    jql = jql_mod.compose_fragment(fragment, version=args.version)
+    url = jql_mod.jira_url(jql)
+    data = {
+        "kind": args.kind,
+        "group": args.group,
+        "name": args.name,
+        "version": args.version,
+        "jql": jql,
+        "jira_url": url,
+    }
+    if args.count:
+        data["count"] = _acli_count(jql, fmt)
+    fmt.header(f"Rich Filter {args.kind}: {args.name}")
+    fmt.success(data)
 
 
 # ---------------------------------------------------------------------------
@@ -1114,6 +1172,29 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("notes", help="Missing release notes count")
     p.add_argument("version", help="Release version (e.g. 1.9.0)")
 
+    p = sub.add_parser("post-freeze", help="Post Code Freeze issue count")
+    p.add_argument("version", help="Release version (e.g. 1.9.0)")
+
+    rich_filter_parser = sub.add_parser("rich-filter", help="Rich Filter catalog and queries")
+    rich_filter_sub = rich_filter_parser.add_subparsers(dest="rich_filter_command")
+    rich_filter_sub.add_parser("inventory", help="List all exported filter data")
+    p = rich_filter_sub.add_parser("query", help="Compose any exported query")
+    p.add_argument(
+        "kind",
+        choices=[
+            "static",
+            "smart",
+            "queue",
+            "time-series",
+            "ratio-numerator",
+            "ratio-denominator",
+        ],
+    )
+    p.add_argument("name", help="Exported entry name")
+    p.add_argument("--group", help="Smart filter group name (required for kind=smart)")
+    p.add_argument("--version", help="Optional release version scope")
+    p.add_argument("--count", action="store_true", help="Run the composed query with acli")
+
     slack_parser = sub.add_parser("slack", help="Slack announcement templates")
     slack_sub = slack_parser.add_subparsers(dest="slack_command")
 
@@ -1143,6 +1224,7 @@ COMMANDS = {
     "epics": cmd_epics,
     "cves": cmd_cves,
     "notes": cmd_notes,
+    "post-freeze": cmd_post_freeze,
 }
 
 SLACK_COMMANDS = {
@@ -1150,6 +1232,11 @@ SLACK_COMMANDS = {
     "feature-freeze": cmd_slack_feature_freeze,
     "code-freeze-update": cmd_slack_code_freeze_update,
     "code-freeze": cmd_slack_code_freeze,
+}
+
+RICH_FILTER_COMMANDS = {
+    "inventory": cmd_rich_filter_inventory,
+    "query": cmd_rich_filter_query,
 }
 
 
@@ -1177,6 +1264,14 @@ def main(argv: list[str] | None = None) -> None:
             )
             sys.exit(1)
         handler = SLACK_COMMANDS.get(args.slack_command)
+    elif args.command == "rich-filter":
+        if not args.rich_filter_command:
+            fmt.error(
+                "MISSING_SUBCOMMAND",
+                "rich-filter requires a subcommand: " + ", ".join(sorted(RICH_FILTER_COMMANDS)),
+            )
+            sys.exit(1)
+        handler = RICH_FILTER_COMMANDS.get(args.rich_filter_command)
     else:
         handler = COMMANDS.get(args.command)
 

--- a/skills/rhdh-release/scripts/release.py
+++ b/skills/rhdh-release/scripts/release.py
@@ -489,6 +489,7 @@ def cmd_check(_args: argparse.Namespace, fmt: OutputFormatter) -> None:
         {
             "name": ".jira-token",
             "status": "pass" if token_file.exists() else "warn",
+            "optional": True,
             "message": str(token_file)
             if token_file.exists()
             else "missing (optional — acli may authenticate via other methods)",
@@ -561,8 +562,14 @@ def cmd_check(_args: argparse.Namespace, fmt: OutputFormatter) -> None:
             }
         )
 
-    all_pass = all(c["status"] == "pass" for c in checks)
+    all_pass = all(
+        c["status"] == "pass" or (c["status"] == "warn" and c.get("optional", False))
+        for c in checks
+    )
     has_fail = any(c["status"] == "fail" for c in checks)
+    has_actionable_warning = any(
+        c["status"] == "warn" and not c.get("optional", False) for c in checks
+    )
 
     for c in checks:
         if c["status"] == "pass":
@@ -575,7 +582,7 @@ def cmd_check(_args: argparse.Namespace, fmt: OutputFormatter) -> None:
     next_steps = []
     if has_fail:
         next_steps.append("Fix failing checks before running other commands")
-    if not all_pass:
+    if has_actionable_warning:
         next_steps.append("See: references/config.md for setup instructions")
 
     fmt.success({"checks": checks, "all_pass": all_pass}, next_steps=next_steps or None)
@@ -784,7 +791,23 @@ def cmd_epics(args: argparse.Namespace, fmt: OutputFormatter) -> None:
     """List outstanding Engineering EPICs for a release."""
     version = args.version
     jql, url = jql_mod.render_with_url("epics", version=version)
-    issues = _acli_json_enriched(jql, select="key,summary,status,assignee")
+    result = _run(["acli", "jira", "workitem", "search", "--jql", jql, "--limit", "1000", "--json"])
+    raw_issues = json.loads(result.stdout)
+    issues = []
+    for raw_issue in raw_issues:
+        fields = raw_issue.get("fields", {})
+        status = fields.get("status") or {}
+        assignee = fields.get("assignee") or {}
+        issues.append(
+            {
+                "key": raw_issue.get("key", ""),
+                "summary": fields.get("summary", ""),
+                "status": status.get("name", "") if isinstance(status, dict) else str(status),
+                "assignee": assignee.get("displayName", "Unassigned")
+                if isinstance(assignee, dict)
+                else str(assignee),
+            }
+        )
     count = len(issues)
 
     fmt.header(f"RHDH {version} — Outstanding EPICs")

--- a/skills/rhdh-release/scripts/release.py
+++ b/skills/rhdh-release/scripts/release.py
@@ -18,7 +18,7 @@ import re
 import shutil
 import subprocess
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 _scripts_dir = Path(__file__).resolve().parent
@@ -190,6 +190,59 @@ def _parse_date(raw: str) -> str | None:
         except ValueError:
             continue
     return None
+
+
+_MILESTONE_LABELS = {
+    "feature_freeze": r"\bFeature Freeze\b",
+    "code_freeze": r"\bCode Freeze\b",
+    "doc_freeze": r"\bDocs? Freeze\b",
+    "go_no_go": r"\bGo/No Go\b",
+    "ga_announce": r"\bGA Announce\b",
+}
+
+
+def _adf_text(node: dict) -> str:
+    """Render the text and date values from an Atlassian Document Format node."""
+    if node.get("type") == "text":
+        return node.get("text", "")
+    if node.get("type") == "date":
+        try:
+            timestamp = int(node.get("attrs", {}).get("timestamp"))
+            return datetime.fromtimestamp(timestamp / 1000, timezone.utc).date().isoformat()
+        except (TypeError, ValueError, OverflowError):
+            return ""
+    return " ".join(filter(None, (_adf_text(child) for child in node.get("content", []))))
+
+
+def _adf_table_rows(node: dict) -> list[str]:
+    """Return rendered rows from an ADF document's tables."""
+    rows = []
+    if node.get("type") == "tableRow":
+        rows.append(" | ".join(_adf_text(cell).strip() for cell in node.get("content", [])))
+    for child in node.get("content", []):
+        rows.extend(_adf_table_rows(child))
+    return rows
+
+
+def _extract_milestone_dates(description: dict | str | None) -> dict[str, str]:
+    """Extract release milestone dates from ADF table rows or legacy plain text."""
+    dates = {key: "TBD" for key in _MILESTONE_LABELS}
+    if isinstance(description, dict):
+        lines = _adf_table_rows(description)
+    elif isinstance(description, str):
+        lines = description.splitlines()
+    else:
+        return dates
+
+    for line in lines:
+        parsed_date = re.search(r"\b\d{4}-\d{2}-\d{2}\b", line)
+        if not parsed_date:
+            continue
+        for key, label_pattern in _MILESTONE_LABELS.items():
+            if re.search(label_pattern, line, re.IGNORECASE):
+                dates[key] = parsed_date.group(0)
+                break
+    return dates
 
 
 def _row_date(cells: list[str]) -> str | None:
@@ -532,17 +585,8 @@ def cmd_dates(_args: argparse.Namespace, fmt: OutputFormatter) -> None:
         summary = issue.get("fields", {}).get("summary", "")
 
         detail = _acli_view_json(key)
-        desc = ""
         desc_field = detail.get("fields", {}).get("description", {})
-        if isinstance(desc_field, dict):
-            desc = json.dumps(desc_field)
-        elif isinstance(desc_field, str):
-            desc = desc_field
-
-        dates = {}
-        for label in ["Feature Freeze", "Code Freeze", "Doc Freeze", "Go/No Go", "GA Announce"]:
-            m = re.search(rf"{re.escape(label)}[:\s]*(\d{{4}}-\d{{2}}-\d{{2}})", desc)
-            dates[label.lower().replace(" ", "_").replace("/", "_")] = m.group(1) if m else "TBD"
+        dates = _extract_milestone_dates(desc_field)
 
         version_m = re.search(r"(\d+\.\d+(?:\.\d+)?)", summary)
         if not version_m:
@@ -812,10 +856,8 @@ def _get_freeze_date(version: str, date_key: str) -> str:
         if version in summary:
             detail = _acli_view_json(issue["key"])
             desc_field = detail.get("fields", {}).get("description", {})
-            desc = json.dumps(desc_field) if isinstance(desc_field, dict) else str(desc_field or "")
-            m = re.search(rf"{re.escape(date_key)}[:\s]*(\d{{4}}-\d{{2}}-\d{{2}})", desc)
-            if m:
-                return m.group(1)
+            key = date_key.lower().replace(" ", "_").replace("/", "_")
+            return _extract_milestone_dates(desc_field).get(key, "TBD")
     return "TBD"
 
 

--- a/skills/rhdh-release/scripts/release.py
+++ b/skills/rhdh-release/scripts/release.py
@@ -383,11 +383,24 @@ def _acli_view_json(issue_key: str) -> dict:
 
 
 def _fetch_teams(category: str | None = None) -> list[dict]:
-    """Fetch team mapping from Google Sheets via gog."""
+    """Fetch team metadata and overlay Rich Filter Cloud IDs when available."""
     rows = _gog_sheets_get(TEAM_SHEET_ID, "Team")
     if not rows:
         raise RuntimeError("Team sheet is empty")
-    return _parse_teams(rows, category_filter=category)
+    teams = _parse_teams(rows, category_filter=category)
+
+    rich_filter_teams = rf_mod.scrum_teams() or []
+    cloud_ids = {
+        _normalize_team_name(team.get("name", "")): team.get("cloud_id", "")
+        for team in rich_filter_teams
+        if team.get("cloud_id")
+    }
+    for team in teams:
+        cloud_id = cloud_ids.get(_normalize_team_name(team["team_name"]))
+        if cloud_id:
+            team["cloud_id"] = cloud_id
+
+    return teams
 
 
 # ---------------------------------------------------------------------------
@@ -481,7 +494,7 @@ def cmd_check(_args: argparse.Namespace, fmt: OutputFormatter) -> None:
             "status": "pass" if rf_path else "warn",
             "message": str(rf_path)
             if rf_path
-            else "not found (optional — JQL falls back to markdown templates)",
+            else "not found (required for freeze and release-notes JQL)",
         }
     )
 
@@ -1129,9 +1142,8 @@ def main(argv: list[str] | None = None) -> None:
         parser.print_help()
         sys.exit(1)
 
-    _init_rich_filter()
-
     try:
+        _init_rich_filter()
         handler(args, fmt)
     except subprocess.CalledProcessError as e:
         fmt.error(
@@ -1142,6 +1154,16 @@ def main(argv: list[str] | None = None) -> None:
         sys.exit(1)
     except RuntimeError as e:
         fmt.error("RUNTIME_ERROR", str(e), next_steps=["Run: python scripts/release.py check"])
+        sys.exit(1)
+    except (KeyError, ValueError) as e:
+        fmt.error(
+            "CONFIGURATION_ERROR",
+            str(e),
+            next_steps=[
+                "Run: python scripts/release.py check",
+                "See: references/config.md",
+            ],
+        )
         sys.exit(1)
 
 

--- a/skills/rhdh-release/scripts/rich_filter.py
+++ b/skills/rhdh-release/scripts/rich_filter.py
@@ -1,0 +1,243 @@
+"""Parse Jira Rich Filter JSON exports for release JQL queries.
+
+Reads the "RHIDP Operational" Rich Filter export at runtime, providing
+accessor functions for static filters, smart filters, rich queues, and
+the base JQL scope. Falls back gracefully when the file is not available.
+
+The JSON structure (top-level):
+    {
+      "richFilter": {
+        "jiraFilter": { "jql": "..." },
+        "staticFilters": [{ "name": "...", "jql": "..." }, ...],
+        "smartFilters": [{ "name": "...", "clauses": [{ "name": "...", "jql": "..." }, ...] }, ...],
+        "richQueues": [{ "name": "...", "jql": "..." }, ...]
+      }
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+
+_RICH_FILTER_FILENAME = "rhidp-operational-rich-filter.json"
+_RICH_FILTER_SUBPATH = Path("jira-rich-filter") / _RICH_FILTER_FILENAME
+
+_cache: dict | None = None
+_cache_path: str | None = None
+
+
+def _candidate_paths() -> list[Path]:
+    """Return candidate paths for the Rich Filter JSON, in priority order."""
+    candidates = []
+
+    env_path = os.environ.get("RHDH_RICH_FILTER_PATH")
+    if env_path:
+        candidates.append(Path(env_path))
+
+    scripts_dir = Path(__file__).resolve().parent
+    sibling = scripts_dir.parent.parent.parent / "rhdh-skill-private-data" / _RICH_FILTER_SUBPATH
+    candidates.append(sibling)
+
+    skill_root = scripts_dir.parent
+    sibling2 = skill_root.parent.parent / "rhdh-skill-private-data" / _RICH_FILTER_SUBPATH
+    if sibling2 != sibling:
+        candidates.append(sibling2)
+
+    installed = Path.home() / ".claude/skills/rhdh-skill-private-data" / _RICH_FILTER_SUBPATH
+    candidates.append(installed)
+
+    return candidates
+
+
+def discover() -> Path | None:
+    """Find the Rich Filter JSON file. Returns the path or None."""
+    for p in _candidate_paths():
+        if p.is_file():
+            return p
+    return None
+
+
+def load(path: Path | str | None = None) -> dict | None:
+    """Load and cache the Rich Filter JSON.
+
+    Args:
+        path: Explicit path to the JSON file. If None, auto-discovers.
+
+    Returns:
+        The parsed richFilter dict, or None if the file is not found.
+
+    Raises:
+        ValueError: If the file exists but has an unexpected structure.
+    """
+    global _cache, _cache_path
+
+    if path is not None:
+        resolved = str(Path(path).resolve())
+    else:
+        found = discover()
+        if found is None:
+            return None
+        resolved = str(found)
+
+    if _cache is not None and _cache_path == resolved:
+        return _cache
+
+    p = Path(resolved)
+    if not p.is_file():
+        return None
+
+    data = json.loads(p.read_text())
+
+    rf = data.get("richFilter")
+    if rf is None:
+        raise ValueError(f"Rich Filter JSON at {resolved} missing top-level 'richFilter' key")
+
+    _cache = rf
+    _cache_path = resolved
+    return rf
+
+
+def base_jql(path: Path | str | None = None) -> str | None:
+    """Extract the base JQL from richFilter.jiraFilter.jql."""
+    rf = load(path)
+    if rf is None:
+        return None
+    jira_filter = rf.get("jiraFilter", {})
+    jql = jira_filter.get("jql")
+    if not jql:
+        return None
+    # Strip ORDER BY and trailing clauses — we only want the project scope
+    m = re.match(r"(.+?)\s+ORDER\s+BY\s+", jql, re.IGNORECASE)
+    if m:
+        return m.group(1).strip()
+    return jql.strip()
+
+
+def _find_by_name(items: list[dict], name: str) -> dict | None:
+    """Find an item in a list by its 'name' field (case-insensitive)."""
+    name_lower = name.lower()
+    for item in items:
+        if item.get("name", "").lower() == name_lower:
+            return item
+    return None
+
+
+def static_filter(name: str, path: Path | str | None = None) -> str | None:
+    """Get a static filter's JQL by name.
+
+    Args:
+        name: Filter name (e.g. "Feature Freeze", "Code Freeze", "CVE")
+        path: Optional explicit path to the JSON file.
+
+    Returns:
+        The JQL string, or None if not found.
+    """
+    rf = load(path)
+    if rf is None:
+        return None
+    filters = rf.get("staticFilters", [])
+    item = _find_by_name(filters, name)
+    return item["jql"] if item else None
+
+
+def smart_filter_clause(
+    group_name: str, clause_name: str, path: Path | str | None = None
+) -> str | None:
+    """Get a smart filter clause's JQL.
+
+    Args:
+        group_name: Smart filter group (e.g. "Scrum Team")
+        clause_name: Clause within the group (e.g. "AI", "Cope")
+        path: Optional explicit path.
+
+    Returns:
+        The JQL string, or None if not found.
+    """
+    rf = load(path)
+    if rf is None:
+        return None
+    groups = rf.get("smartFilters", [])
+    group = _find_by_name(groups, group_name)
+    if group is None:
+        return None
+    clause = _find_by_name(group.get("clauses", []), clause_name)
+    return clause["jql"] if clause else None
+
+
+def rich_queue(name: str, path: Path | str | None = None) -> str | None:
+    """Get a rich queue's JQL by name.
+
+    Args:
+        name: Queue name (e.g. "RNs Unclassified")
+        path: Optional explicit path.
+
+    Returns:
+        The JQL string, or None if not found.
+    """
+    rf = load(path)
+    if rf is None:
+        return None
+    queues = rf.get("richQueues", [])
+    item = _find_by_name(queues, name)
+    return item["jql"] if item else None
+
+
+def scrum_teams(path: Path | str | None = None) -> list[dict] | None:
+    """Extract team name -> Cloud ID mapping from the 'Scrum Team' smart filter.
+
+    Returns:
+        List of dicts with 'name' and 'cloud_id' keys, or None if unavailable.
+        The cloud_id is extracted from the JQL pattern: "Team[Team]" = <cloud_id>
+    """
+    rf = load(path)
+    if rf is None:
+        return None
+    groups = rf.get("smartFilters", [])
+    group = _find_by_name(groups, "Scrum Team")
+    if group is None:
+        return None
+
+    teams = []
+    for clause in group.get("clauses", []):
+        name = clause.get("name", "")
+        jql = clause.get("jql", "")
+        # Extract cloud ID from: "Team[Team]" = <cloud_id>
+        m = re.search(r'"Team\[Team\]"\s*=\s*(\S+)', jql)
+        cloud_id = m.group(1) if m else ""
+        teams.append({"name": name, "cloud_id": cloud_id})
+
+    return teams
+
+
+def list_static_filters(path: Path | str | None = None) -> list[str] | None:
+    """List available static filter names."""
+    rf = load(path)
+    if rf is None:
+        return None
+    return [f.get("name", "") for f in rf.get("staticFilters", [])]
+
+
+def list_smart_filters(path: Path | str | None = None) -> list[str] | None:
+    """List available smart filter group names."""
+    rf = load(path)
+    if rf is None:
+        return None
+    return [f.get("name", "") for f in rf.get("smartFilters", [])]
+
+
+def list_rich_queues(path: Path | str | None = None) -> list[str] | None:
+    """List available rich queue names."""
+    rf = load(path)
+    if rf is None:
+        return None
+    return [q.get("name", "") for q in rf.get("richQueues", [])]
+
+
+def reset_cache() -> None:
+    """Clear the cached Rich Filter data. Useful for testing."""
+    global _cache, _cache_path
+    _cache = None
+    _cache_path = None

--- a/skills/rhdh-release/scripts/rich_filter.py
+++ b/skills/rhdh-release/scripts/rich_filter.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import sys
 from pathlib import Path
 
 _RICH_FILTER_FILENAME = "rhidp-operational-rich-filter.json"
@@ -28,35 +29,33 @@ _RICH_FILTER_SUBPATH = Path("jira-rich-filter") / _RICH_FILTER_FILENAME
 _cache: dict | None = None
 _cache_path: str | None = None
 
-
-def _candidate_paths() -> list[Path]:
-    """Return candidate paths for the Rich Filter JSON, in priority order."""
-    candidates = []
-
-    env_path = os.environ.get("RHDH_RICH_FILTER_PATH")
-    if env_path:
-        candidates.append(Path(env_path))
-
-    scripts_dir = Path(__file__).resolve().parent
-    sibling = scripts_dir.parent.parent.parent / "rhdh-skill-private-data" / _RICH_FILTER_SUBPATH
-    candidates.append(sibling)
-
-    skill_root = scripts_dir.parent
-    sibling2 = skill_root.parent.parent / "rhdh-skill-private-data" / _RICH_FILTER_SUBPATH
-    if sibling2 != sibling:
-        candidates.append(sibling2)
-
-    installed = Path.home() / ".claude/skills/rhdh-skill-private-data" / _RICH_FILTER_SUBPATH
-    candidates.append(installed)
-
-    return candidates
+# Ensure rhdh skill package is importable (sibling skill in the same repo)
+_rhdh_skill_dir = str(Path(__file__).resolve().parent.parent.parent / "rhdh")
+if _rhdh_skill_dir not in sys.path:
+    sys.path.insert(0, _rhdh_skill_dir)
 
 
 def discover() -> Path | None:
-    """Find the Rich Filter JSON file. Returns the path or None."""
-    for p in _candidate_paths():
+    """Find the Rich Filter JSON file via rhdh config system.
+
+    Discovery order:
+    1. RHDH_RICH_FILTER_PATH env var (explicit file path override)
+    2. rhdh.config.get_repo("private-data") + subpath
+    """
+    env_path = os.environ.get("RHDH_RICH_FILTER_PATH")
+    if env_path:
+        p = Path(env_path)
         if p.is_file():
             return p
+
+    from rhdh.config import get_repo
+
+    repo_path = get_repo("private-data")
+    if repo_path:
+        p = repo_path / _RICH_FILTER_SUBPATH
+        if p.is_file():
+            return p
+
     return None
 
 

--- a/skills/rhdh-release/scripts/rich_filter.py
+++ b/skills/rhdh-release/scripts/rich_filter.py
@@ -29,6 +29,16 @@ _RICH_FILTER_SUBPATH = Path("jira-rich-filter") / _RICH_FILTER_FILENAME
 _cache: dict | None = None
 _cache_path: str | None = None
 
+_REQUIRED_STATIC_FILTERS = [
+    "Feature Freeze",
+    "Code Freeze",
+    "Post Code Freeze",
+    "demo",
+    "Test Day",
+]
+_REQUIRED_SMART_FILTERS = ["Scrum Team"]
+_REQUIRED_RICH_QUEUES = ["RNs Unclassified", "RNs Proposed", "RNs Done", "Has RN Text"]
+
 
 def _configured_repo() -> Path | None:
     """Read the private-data repo from the shared RHDH configuration.
@@ -220,6 +230,173 @@ def rich_queue(name: str, path: Path | str | None = None) -> str | None:
     queues = rf.get("richQueues", [])
     item = _find_by_name(queues, name)
     return item["jql"] if item else None
+
+
+def time_series(name: str, path: Path | str | None = None) -> str | None:
+    """Get a time series JQL fragment by name."""
+    rf = load(path)
+    if rf is None:
+        return None
+    item = _find_by_name(rf.get("timeSeries", []), name)
+    return item.get("jql") if item else None
+
+
+def custom_ratio(name: str, component: str, path: Path | str | None = None) -> str | None:
+    """Get a custom ratio numerator or denominator JQL fragment."""
+    rf = load(path)
+    if rf is None:
+        return None
+    item = _find_by_name(rf.get("customRatios", []), name)
+    if item is None:
+        return None
+    key = "numJql" if component == "numerator" else "denJql"
+    return item.get(key)
+
+
+def fragment(
+    kind: str,
+    name: str,
+    *,
+    group: str | None = None,
+    path: Path | str | None = None,
+) -> str:
+    """Return any query-bearing Rich Filter fragment by kind and name."""
+    if kind == "static":
+        value = static_filter(name, path)
+    elif kind == "queue":
+        value = rich_queue(name, path)
+    elif kind == "smart":
+        if not group:
+            raise ValueError("Smart filter queries require --group")
+        value = smart_filter_clause(group, name, path)
+    elif kind == "time-series":
+        value = time_series(name, path)
+    elif kind == "ratio-numerator":
+        value = custom_ratio(name, "numerator", path)
+    elif kind == "ratio-denominator":
+        value = custom_ratio(name, "denominator", path)
+    else:
+        raise ValueError(
+            "Rich Filter kind must be one of: static, smart, queue, time-series, "
+            "ratio-numerator, ratio-denominator"
+        )
+
+    if value is None:
+        label = f"{group} / {name}" if group else name
+        raise ValueError(f"Rich Filter {kind} query not found: {label}")
+    return value
+
+
+def inventory(path: Path | str | None = None) -> dict | None:
+    """Return a query catalog and presentation-metadata summary."""
+    rf = load(path)
+    if rf is None:
+        return None
+
+    def _handler_clauses(item: dict) -> list[str]:
+        handlers = item.get("handler", {})
+        if isinstance(handlers, dict):
+            handlers = [handlers]
+        if not isinstance(handlers, list):
+            return []
+        return [handler.get("clauseName", "") for handler in handlers if isinstance(handler, dict)]
+
+    return {
+        "name": rf.get("name", ""),
+        "static_filters": [item.get("name", "") for item in rf.get("staticFilters", [])],
+        "smart_filters": [
+            {
+                "name": group.get("name", ""),
+                "clauses": [clause.get("name", "") for clause in group.get("clauses", [])],
+            }
+            for group in rf.get("smartFilters", [])
+        ],
+        "rich_queues": [item.get("name", "") for item in rf.get("richQueues", [])],
+        "time_series": [item.get("name", "") for item in rf.get("timeSeries", [])],
+        "custom_ratios": [item.get("name", "") for item in rf.get("customRatios", [])],
+        "presentation_metadata": {
+            "dynamic_filter_fields": [
+                {
+                    "label": item.get("label", ""),
+                    "value": item.get("value", ""),
+                    "clauses": _handler_clauses(item),
+                }
+                for item in rf.get("dynamicFilters", [])
+            ],
+            "rich_views": [
+                {
+                    "name": item.get("name", ""),
+                    "columns": [
+                        {
+                            "label": column.get("label", ""),
+                            "value": column.get("value", ""),
+                        }
+                        for column in item.get("columns", [])
+                    ],
+                }
+                for item in rf.get("richViews", [])
+            ],
+        },
+    }
+
+
+def validate(path: Path | str | None = None) -> list[str]:
+    """Validate the export structure and required release-management entries."""
+    rf = load(path)
+    if rf is None:
+        return ["Rich Filter export not found"]
+
+    errors = []
+    if not rf.get("jiraFilter", {}).get("jql"):
+        errors.append("jiraFilter.jql is missing")
+
+    sections = [
+        ("static filter", rf.get("staticFilters", [])),
+        ("rich queue", rf.get("richQueues", [])),
+    ]
+    for label, items in sections:
+        for index, item in enumerate(items):
+            if not item.get("name"):
+                errors.append(f"{label} at index {index} has no name")
+            if not item.get("jql"):
+                errors.append(f"{label} '{item.get('name', index)}' has no JQL")
+
+    for group_index, group in enumerate(rf.get("smartFilters", [])):
+        group_name = group.get("name", "")
+        if not group_name:
+            errors.append(f"smart filter at index {group_index} has no name")
+        for clause_index, clause in enumerate(group.get("clauses", [])):
+            if not clause.get("name"):
+                errors.append(f"smart filter '{group_name}' clause {clause_index} has no name")
+            if not clause.get("jql"):
+                errors.append(
+                    f"smart filter '{group_name}' clause "
+                    f"'{clause.get('name', clause_index)}' has no JQL"
+                )
+
+    for index, item in enumerate(rf.get("timeSeries", [])):
+        if not item.get("name"):
+            errors.append(f"time series at index {index} has no name")
+        if not item.get("jql"):
+            errors.append(f"time series '{item.get('name', index)}' has no JQL")
+
+    for index, item in enumerate(rf.get("customRatios", [])):
+        if not item.get("name"):
+            errors.append(f"custom ratio at index {index} has no name")
+        for key in ("numJql", "denJql"):
+            if not item.get(key):
+                errors.append(f"custom ratio '{item.get('name', index)}' has no {key}")
+
+    for name in _REQUIRED_STATIC_FILTERS:
+        if static_filter(name, path) is None:
+            errors.append(f"required static filter missing: {name}")
+    for name in _REQUIRED_SMART_FILTERS:
+        if _find_by_name(rf.get("smartFilters", []), name) is None:
+            errors.append(f"required smart filter missing: {name}")
+    for name in _REQUIRED_RICH_QUEUES:
+        if rich_queue(name, path) is None:
+            errors.append(f"required rich queue missing: {name}")
+    return errors
 
 
 def scrum_teams(path: Path | str | None = None) -> list[dict] | None:

--- a/skills/rhdh-release/scripts/rich_filter.py
+++ b/skills/rhdh-release/scripts/rich_filter.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import subprocess
 from pathlib import Path
 
 _RICH_FILTER_FILENAME = "rhidp-operational-rich-filter.json"
@@ -27,6 +28,44 @@ _RICH_FILTER_SUBPATH = Path("jira-rich-filter") / _RICH_FILTER_FILENAME
 
 _cache: dict | None = None
 _cache_path: str | None = None
+
+
+def _configured_repo() -> Path | None:
+    """Read the private-data repo from the shared RHDH configuration.
+
+    The release scripts are also run directly, where the ``rhdh`` Python
+    package is not necessarily importable. In that case, read the same
+    project and user config files used by ``rhdh.config``.
+    """
+    env_path = os.environ.get("RHDH_PRIVATE_DATA_REPO")
+    if env_path and Path(env_path).is_dir():
+        return Path(env_path).resolve()
+
+    config_paths = [Path.home() / ".config" / "rhdh-skill" / "config.json"]
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        config_paths.append(Path(result.stdout.strip()) / ".rhdh" / "config.json")
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        pass
+
+    repo_path = None
+    for config_path in config_paths:
+        try:
+            data = json.loads(config_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        configured = data.get("repos", {}).get("private-data")
+        if configured:
+            repo_path = Path(configured).expanduser()
+
+    if repo_path and repo_path.is_dir():
+        return repo_path.resolve()
+    return None
 
 
 def discover() -> Path | None:
@@ -47,12 +86,13 @@ def discover() -> Path | None:
         from rhdh.config import get_repo
 
         repo_path = get_repo("private-data")
-        if repo_path:
-            p = repo_path / _RICH_FILTER_SUBPATH
-            if p.is_file():
-                return p
     except ImportError:
-        pass
+        repo_path = _configured_repo()
+
+    if repo_path:
+        p = repo_path / _RICH_FILTER_SUBPATH
+        if p.is_file():
+            return p
 
     return None
 
@@ -201,9 +241,9 @@ def scrum_teams(path: Path | str | None = None) -> list[dict] | None:
     for clause in group.get("clauses", []):
         name = clause.get("name", "")
         jql = clause.get("jql", "")
-        # Extract cloud ID from: "Team[Team]" = <cloud_id>
-        m = re.search(r'"Team\[Team\]"\s*=\s*(\S+)', jql)
-        cloud_id = m.group(1) if m else ""
+        # Extract a bare or quoted value from: "Team[Team]" = <cloud_id>
+        m = re.search(r""""Team\[Team\]"\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s)]+))""", jql)
+        cloud_id = next((value for value in m.groups() if value), "") if m else ""
         teams.append({"name": name, "cloud_id": cloud_id})
 
     return teams

--- a/skills/rhdh-release/scripts/rich_filter.py
+++ b/skills/rhdh-release/scripts/rich_filter.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import json
 import os
 import re
-import sys
 from pathlib import Path
 
 _RICH_FILTER_FILENAME = "rhidp-operational-rich-filter.json"
@@ -29,18 +28,14 @@ _RICH_FILTER_SUBPATH = Path("jira-rich-filter") / _RICH_FILTER_FILENAME
 _cache: dict | None = None
 _cache_path: str | None = None
 
-# Ensure rhdh skill package is importable (sibling skill in the same repo)
-_rhdh_skill_dir = str(Path(__file__).resolve().parent.parent.parent / "rhdh")
-if _rhdh_skill_dir not in sys.path:
-    sys.path.insert(0, _rhdh_skill_dir)
-
 
 def discover() -> Path | None:
-    """Find the Rich Filter JSON file via rhdh config system.
+    """Find the Rich Filter JSON file.
 
     Discovery order:
     1. RHDH_RICH_FILTER_PATH env var (explicit file path override)
-    2. rhdh.config.get_repo("private-data") + subpath
+    2. rhdh.config.get_repo("private-data") — defers to the rhdh skill's
+       config system (env var, config JSON, filesystem auto-detect)
     """
     env_path = os.environ.get("RHDH_RICH_FILTER_PATH")
     if env_path:
@@ -48,13 +43,16 @@ def discover() -> Path | None:
         if p.is_file():
             return p
 
-    from rhdh.config import get_repo
+    try:
+        from rhdh.config import get_repo
 
-    repo_path = get_repo("private-data")
-    if repo_path:
-        p = repo_path / _RICH_FILTER_SUBPATH
-        if p.is_file():
-            return p
+        repo_path = get_repo("private-data")
+        if repo_path:
+            p = repo_path / _RICH_FILTER_SUBPATH
+            if p.is_file():
+                return p
+    except ImportError:
+        pass
 
     return None
 

--- a/skills/rhdh-release/tests/check-jira.md
+++ b/skills/rhdh-release/tests/check-jira.md
@@ -24,7 +24,10 @@ If this fails, stop — Jira access is not configured.
 
 ### 1. JQL syntax validation
 
-Read `skills/rhdh-release/references/jql-release.md`. For each of the 12 query templates, substitute a real release version (discover it from check 2 below) and run with `--count` to verify the JQL parses without error.
+Run `python scripts/release.py --json check` and confirm the Rich Filter check
+passes. Load the 16 composed templates through `scripts/jql.py`; substitute a
+real release version (discover it from check 2 below) and run each with
+`--count` to verify the JQL parses without error.
 
 Use the `active_release` query first (no placeholders) to discover the current release version:
 
@@ -47,6 +50,9 @@ Then for each remaining query, substitute `{{RELEASE_VERSION}}` with the discove
 - [ ] `release_notes` — returns count
 - [ ] `feature_freeze_issues` — returns count
 - [ ] `code_freeze_issues` — returns count
+- [ ] `open_issues_by_team` — substitute `{{CLOUD_ID}}` with a Rich Filter Scrum Team Cloud ID, returns count
+- [ ] `feature_freeze_issues_by_team` — substitute `{{CLOUD_ID}}`, returns count
+- [ ] `code_freeze_issues_by_team` — substitute `{{CLOUD_ID}}`, returns count
 
 ### 2. parse_issues.py integration
 

--- a/skills/rhdh-release/tests/check-jira.md
+++ b/skills/rhdh-release/tests/check-jira.md
@@ -25,7 +25,7 @@ If this fails, stop — Jira access is not configured.
 ### 1. JQL syntax validation
 
 Run `python scripts/release.py --json check` and confirm the Rich Filter check
-passes. Load the 16 composed templates through `scripts/jql.py`; substitute a
+passes. Load the 20 composed templates through `scripts/jql.py`; substitute a
 real release version (discover it from check 2 below) and run each with
 `--count` to verify the JQL parses without error.
 
@@ -48,8 +48,12 @@ Then for each remaining query, substitute `{{RELEASE_VERSION}}` with the discove
 - [ ] `test_day_features` — returns count
 - [ ] `features_added_to_release` — returns count
 - [ ] `release_notes` — returns count
+- [ ] `release_notes_proposed` — returns count
+- [ ] `release_notes_done` — returns count
+- [ ] `release_notes_with_text` — returns count
 - [ ] `feature_freeze_issues` — returns count
 - [ ] `code_freeze_issues` — returns count
+- [ ] `post_code_freeze_issues` — returns count
 - [ ] `open_issues_by_team` — substitute `{{CLOUD_ID}}` with a Rich Filter Scrum Team Cloud ID, returns count
 - [ ] `feature_freeze_issues_by_team` — substitute `{{CLOUD_ID}}`, returns count
 - [ ] `code_freeze_issues_by_team` — substitute `{{CLOUD_ID}}`, returns count
@@ -81,7 +85,7 @@ acli jira workitem search --jql 'project IN (RHIDP, RHDHBugs, RHDHPLAN, RHDHSUPP
 ```
 Jira Smoke Checks — rhdh-release
 ==================================
- 1. JQL syntax validation:    PASS/FAIL (N/16 queries valid)
+ 1. JQL syntax validation:    PASS/FAIL (N/20 queries valid)
  2. parse_issues.py:          PASS/FAIL (details)
  3. Team enrichment:          PASS/FAIL (details)
 

--- a/skills/rhdh-release/tests/check-jira.md
+++ b/skills/rhdh-release/tests/check-jira.md
@@ -81,7 +81,7 @@ acli jira workitem search --jql 'project IN (RHIDP, RHDHBugs, RHDHPLAN, RHDHSUPP
 ```
 Jira Smoke Checks — rhdh-release
 ==================================
- 1. JQL syntax validation:    PASS/FAIL (N/12 queries valid)
+ 1. JQL syntax validation:    PASS/FAIL (N/16 queries valid)
  2. parse_issues.py:          PASS/FAIL (details)
  3. Team enrichment:          PASS/FAIL (details)
 

--- a/skills/rhdh-release/tests/check-structural.md
+++ b/skills/rhdh-release/tests/check-structural.md
@@ -50,7 +50,7 @@ List any files missing required sections.
 
 Read `skills/rhdh-release/references/jql-release.md`. Extract all `## <query_name>` headings.
 
-- [ ] Exactly 13 query templates exist
+- [ ] Exactly 11 query templates exist (5 more are sourced from Rich Filter at runtime)
 
 Then grep all workflow files for references to each query name. Verify:
 
@@ -95,7 +95,7 @@ Read `skills/rhdh-release/references/config.md`:
 
 - [ ] `scripts/formatters.py` exists and is a regular file (not a symlink)
 - [ ] No symlinks remain in `scripts/` (`find scripts/ -type l` returns empty)
-- [ ] Exactly 4 Python scripts: `release.py`, `formatters.py`, `jql.py`, `slack_templates.py`
+- [ ] Exactly 5 Python scripts: `release.py`, `formatters.py`, `jql.py`, `rich_filter.py`, `slack_templates.py`
 
 ### 10. Release CLI existence
 

--- a/skills/rhdh-release/tests/check-structural.md
+++ b/skills/rhdh-release/tests/check-structural.md
@@ -19,7 +19,7 @@ Read `skills/rhdh-release/SKILL.md` and verify:
 - [ ] YAML frontmatter has `name: rhdh-release`
 - [ ] YAML frontmatter has `description` (length > 20 chars)
 - [ ] Contains `<essential_principles>` ... `</essential_principles>`
-- [ ] Contains `<intake>` ... `</intake>` with numbered options 1–13
+- [ ] Contains `<intake>` ... `</intake>` with numbered options 1–15
 - [ ] Contains `<routing>` ... `</routing>` with a markdown table
 - [ ] Contains `<reference_index>` ... `</reference_index>`
 - [ ] Contains `<prerequisites>` ... `</prerequisites>`
@@ -44,13 +44,13 @@ List any files missing required sections.
 
 ### 4. Workflow count
 
-- [ ] Exactly 13 workflow files exist in `skills/rhdh-release/workflows/`
+- [ ] Exactly 15 workflow files exist in `skills/rhdh-release/workflows/`
 
 ### 5. JQL template coverage
 
 Read `skills/rhdh-release/references/jql-release.md`. Extract all `## <query_name>` headings.
 
-- [ ] Exactly 16 query template sections exist (11 with inline JQL, 5 sourced from Rich Filter at runtime)
+- [ ] Exactly 20 query template sections exist (9 with inline JQL, 11 sourced from Rich Filter at runtime)
 
 Then grep all workflow files for references to each query name. Verify:
 
@@ -78,6 +78,7 @@ Verify all local files listed in `<reference_index>` exist:
 - [ ] `references/jql-release.md`
 - [ ] `references/slack-templates.md`
 - [ ] `references/config.md`
+- [ ] `references/rich-filter-coverage.md`
 
 Note: The release process reference uses `gog docs cat` (live Google Doc) — no local file to check.
 
@@ -118,7 +119,7 @@ Structural Checks — rhdh-release
  1. SKILL.md structure:          PASS/FAIL (details)
  2. Routing → workflow:          PASS/FAIL (details)
  3. Workflow file structure:     PASS/FAIL (details)
- 4. Workflow count:              PASS/FAIL (N/13)
+ 4. Workflow count:              PASS/FAIL (N/15)
  5. JQL template coverage:       PASS/FAIL (details)
  6. Slack template coverage:     PASS/FAIL (details)
  7. Reference file existence:    PASS/FAIL (details)

--- a/skills/rhdh-release/tests/check-structural.md
+++ b/skills/rhdh-release/tests/check-structural.md
@@ -50,7 +50,7 @@ List any files missing required sections.
 
 Read `skills/rhdh-release/references/jql-release.md`. Extract all `## <query_name>` headings.
 
-- [ ] Exactly 11 query templates exist (5 more are sourced from Rich Filter at runtime)
+- [ ] Exactly 16 query template sections exist (11 with inline JQL, 5 sourced from Rich Filter at runtime)
 
 Then grep all workflow files for references to each query name. Verify:
 

--- a/skills/rhdh-release/tests/demo-release-cli.md
+++ b/skills/rhdh-release/tests/demo-release-cli.md
@@ -94,9 +94,9 @@ options:
 
 ## JQL template parsing
 
-Verify that jql.py parses 11 inline templates from `references/jql-release.md`.
-When the Rich Filter is configured, five runtime templates are added for a
-total of 16.
+Verify that jql.py parses 9 inline templates from `references/jql-release.md`.
+When the Rich Filter is configured, eleven runtime templates are added for a
+total of 20.
 
 ```python3
 import sys; sys.path.insert(0, 'scripts')
@@ -199,7 +199,7 @@ uv run pytest ../../tests/unit/test_release_cli.py --tb=short -q 2>&1
 
 ## Workflow CLI integration
 
-Verify all 13 workflows have been updated with CLI-first Step 1.
+Verify all 15 workflows have CLI-first instructions.
 
 ```bash
 total=$(ls workflows/*.md | wc -l | tr -d ' '); with_cli=$(grep -l 'Step 1: Run CLI' workflows/*.md | wc -l | tr -d ' '); echo "Workflows with CLI step: $with_cli/$total"

--- a/skills/rhdh-release/tests/demo-release-cli.md
+++ b/skills/rhdh-release/tests/demo-release-cli.md
@@ -94,7 +94,9 @@ options:
 
 ## JQL template parsing
 
-Verify that jql.py parses all 13 templates from `references/jql-release.md` and renders them with placeholders.
+Verify that jql.py parses 11 inline templates from `references/jql-release.md`.
+When the Rich Filter is configured, five runtime templates are added for a
+total of 16.
 
 ```python3
 import sys; sys.path.insert(0, 'scripts')
@@ -107,19 +109,17 @@ for name in templates:
 ```
 
 ```output
-Templates loaded: 13
+Templates loaded: 11
   active_release
   blockers
-  code_freeze_issues
   cves
   epics
   feature_demos
-  feature_freeze_issues
   feature_subtasks
   features_added_to_release
   open_issues
+  open_issues_by_team
   open_issues_by_type
-  release_notes
   test_day_features
 ```
 

--- a/skills/rhdh-release/workflows/announce-code-freeze-update.md
+++ b/skills/rhdh-release/workflows/announce-code-freeze-update.md
@@ -19,76 +19,17 @@ Generate a Slack message announcing Code Freeze status update.
 python scripts/release.py --json slack code-freeze-update {{RELEASE_VERSION}}
 ```
 
-If the CLI succeeds, use its `slack_message` field directly (it's the filled template). If it fails, follow the manual steps below.
-
-## Step 2 (fallback): Get Code Freeze date
-
-Run the `release-dates` workflow or fetch directly:
-
-```bash
-acli jira workitem search --jql "project=rhdhplan AND issuetype=feature AND component=release AND status != closed" --limit 500 --json
-```
-
-Then for the matching release issue:
-
-```bash
-acli jira workitem view {{RELEASE_ISSUE_KEY}} --json
-```
-
-Extract the Code Freeze date from the description.
-
-## Step 3 (fallback): Get active engineering teams
-
-```bash
-gog sheets get 1vQXfvID72qwqvLb17eyGOvnZXrZG7NBzTGv6RP9wvyM Team --json --results-only
-```
-
-Filter to category "Engineering" and status "Active".
-
-## Step 4 (fallback): Get outstanding release notes count
-
-```bash
-acli jira workitem search --jql 'project in (RHIDP, "Red Hat Developer Hub Bugs", "RHDH Support", rhdhplan) and issuetype in (Feature, bug) and "Release Note Type" is EMPTY and fixVersion = "{{RELEASE_VERSION}}"' --count
-```
-
-## Step 5 (fallback): Get feature subtasks count
-
-Use the `feature_subtasks` JQL from `references/jql-release.md`:
-
-```bash
-acli jira workitem search --jql 'project in (RHDHPlan) AND issuetype = sub-task AND fixVersion = "{{RELEASE_VERSION}}" AND status != closed' --count
-```
-
-## Step 6 (fallback): Get per-team issue counts
-
-Use the `code_freeze_issues` JQL (all open issues), then filter by team:
-
-```bash
-acli jira workitem search --jql 'project IN (RHIDP, RHDHBugs, RHDHPLAN, RHDHSUPP) AND fixVersion = "{{RELEASE_VERSION}}" AND status != closed' --limit 500 --json | python ~/.claude/skills/rhdh-jira/scripts/parse_issues.py --enrich -s key,summary,status,team
-```
-
-Group results by team and count per team.
-
-## Step 7 (fallback): Fill template and output
-
-Load the **Code Freeze Update** template from `references/slack-templates.md`.
-
-Fill all placeholders:
-
-- `{{RELEASE_VERSION}}` — the release version
-- `{{CODE_FREEZE_DATE}}` — from Step 1
-- `{{TEAM_NAME}}`, `{{TEAM_ISSUE_COUNT}}`, `{{JIRA_LINK}}`, `{{LEAD_SLACK}}` — repeated per team from Steps 2 and 5
-- `{{OUTSTANDING_RELEASE_NOTES_ISSUE_COUNT}}` — from Step 3
-- `{{FEATURE_SUBTASK_ISSUE_COUNT}}` — from Step 4
-
-**Output the filled template in a triple-backtick code block** for copy-paste into Slack.
+Use its `slack_message` field directly. This workflow depends on the Rich
+Filter for release-note and Code Freeze JQL. If either template is unavailable,
+run `python scripts/release.py --json check`, configure the Rich Filter as shown
+in `references/config.md`, and retry. Do not substitute hardcoded queries.
 
 </process>
 
 <gotchas>
 
-- Always use `parse_issues.py --enrich` for team counts — never count manually.
-- The Code Freeze Update uses ALL open issues for team breakdown (unlike Feature Freeze Update which excludes infra/ops).
+- Team counts and Jira links come from the CLI's Cloud ID-scoped Rich Filter queries.
+- Code Freeze scope is defined by the Rich Filter; do not replace it with `status != closed`.
 
 </gotchas>
 

--- a/skills/rhdh-release/workflows/announce-code-freeze.md
+++ b/skills/rhdh-release/workflows/announce-code-freeze.md
@@ -30,18 +30,18 @@ acli jira workitem search --jql 'project IN (RHIDP, RHDHBugs, RHDHPLAN, RHDHSUPP
 
 ## Step 3 (fallback): Get feature demos count
 
-Use the `feature_demos` JQL from `references/jql-release.md`:
+Use the `feature_demos` template composed from the Rich Filter `demo` entry:
 
 ```bash
-acli jira workitem search --jql 'project in (RHDHPlan, RHIDP) AND issuetype = feature AND labels = demo AND fixVersion = "{{RELEASE_VERSION}}" AND status != closed' --count
+python scripts/release.py --json rich-filter query static demo --version "{{RELEASE_VERSION}}" --count
 ```
 
 ## Step 4 (fallback): Get test day features count
 
-Use the `test_day_features` JQL:
+Use the `test_day_features` template composed from the Rich Filter `Test Day` entry:
 
 ```bash
-acli jira workitem search --jql 'Project in (RHDHPlan, rhidp) AND issuetype = feature AND labels = rhdh-testday AND fixVersion = "{{RELEASE_VERSION}}" AND status != closed' --count
+python scripts/release.py --json rich-filter query static "Test Day" --version "{{RELEASE_VERSION}}" --count
 ```
 
 ## Step 5 (fallback): Get total open issues count

--- a/skills/rhdh-release/workflows/announce-feature-freeze-update.md
+++ b/skills/rhdh-release/workflows/announce-feature-freeze-update.md
@@ -19,69 +19,17 @@ Generate a Slack message announcing Feature Freeze status update.
 python scripts/release.py --json slack feature-freeze-update {{RELEASE_VERSION}}
 ```
 
-If the CLI succeeds, use its `slack_message` field directly (it's the filled template). If it fails, follow the manual steps below.
-
-## Step 2 (fallback): Get Feature Freeze date
-
-Run the `release-dates` workflow or fetch directly:
-
-```bash
-acli jira workitem search --jql "project=rhdhplan AND issuetype=feature AND component=release AND status != closed" --limit 500 --json
-```
-
-Then for the matching release issue:
-
-```bash
-acli jira workitem view {{RELEASE_ISSUE_KEY}} --json
-```
-
-Extract the Feature Freeze date from the description.
-
-## Step 3 (fallback): Get active engineering teams
-
-```bash
-gog sheets get 1vQXfvID72qwqvLb17eyGOvnZXrZG7NBzTGv6RP9wvyM Team --json --results-only
-```
-
-Filter to category "Engineering" and status "Active".
-
-## Step 4 (fallback): Get outstanding release notes count
-
-Use the `release_notes` JQL:
-
-```bash
-acli jira workitem search --jql 'project in (RHIDP, "Red Hat Developer Hub Bugs", "RHDH Support", rhdhplan) and issuetype in (Feature, bug) and "Release Note Type" is EMPTY and fixVersion = "{{RELEASE_VERSION}}"' --count
-```
-
-## Step 5 (fallback): Get per-team issue counts
-
-Use the `feature_freeze_issues` JQL as the base, then filter by team using `parse_issues.py`:
-
-```bash
-acli jira workitem search --jql 'project IN (RHIDP, RHDHBugs, RHDHPLAN, RHDHSUPP) AND fixVersion = "{{RELEASE_VERSION}}" and resolution is EMPTY AND component not in (AI, Build, Certification, "Continuous Improvement", Documentation, Knowledge, Performance, Quality, Quickstart, Release, "RHDH Local", Security, Segment, Serviceability, Support, "Team Operations", "Test Framework", "Test Infrastructure", "Upstream & Community", UX) AND Type not in (Bug, Vulnerability, sub-task) AND status not in ("Dev Complete", "Release Pending", Done, Closed) AND (labels is EMPTY OR labels != stretch-goal)' --limit 500 --json | python ~/.claude/skills/rhdh-jira/scripts/parse_issues.py --enrich -s key,summary,status,team
-```
-
-Group results by team and count per team.
-
-## Step 6 (fallback): Fill template and output
-
-Load the **Feature Freeze Update** template from `references/slack-templates.md`.
-
-Fill all placeholders:
-
-- `{{RELEASE_VERSION}}` — the release version
-- `{{FEATURE_FREEZE_DATE}}` — from Step 1
-- `{{TEAM_NAME}}`, `{{ISSUE_COUNT}}`, `{{JIRA_LINK}}`, `{{LEAD_SLACK}}` — repeated per team from Steps 2 and 4
-- `{{OUTSTANDING_RELEASE_NOTES_ISSUE_COUNT}}` — from Step 3
-
-**Output the filled template in a triple-backtick code block** for copy-paste into Slack.
+Use its `slack_message` field directly. This workflow depends on the
+Rich Filter for both release-note and Feature Freeze JQL. If either template is
+unavailable, run `python scripts/release.py --json check`, configure the Rich
+Filter as shown in `references/config.md`, and retry. Do not use the
+hardcoded queries as substitutes.
 
 </process>
 
 <gotchas>
 
-- Always use `parse_issues.py --enrich` for team counts — never count manually.
-- Build Jira search links by URL-encoding the JQL scoped to each team.
+- Team counts and Jira links come from the CLI's Cloud ID-scoped Rich Filter queries.
 - The `feature_freeze_issues` JQL excludes infrastructure/ops components and bugs — this is intentional for Feature Freeze tracking.
 
 </gotchas>

--- a/skills/rhdh-release/workflows/announce-feature-freeze.md
+++ b/skills/rhdh-release/workflows/announce-feature-freeze.md
@@ -18,45 +18,10 @@ Generate a Slack message announcing that Feature Freeze milestone has been reach
 python scripts/release.py --json slack feature-freeze {{RELEASE_VERSION}}
 ```
 
-If the CLI succeeds, use its `slack_message` field directly (it's the filled template). If it fails, follow the manual steps below.
-
-## Step 2 (fallback): Get open EPICs count
-
-Use the `epics` JQL from `references/jql-release.md`:
-
-```bash
-acli jira workitem search --jql 'project IN (RHIDP) AND fixVersion = "{{RELEASE_VERSION}}" and issuetype = epic and status not in (closed, "Release Pending", "Dev Complete")' --count
-```
-
-## Step 3 (fallback): Get CVE count
-
-Use the `cves` JQL:
-
-```bash
-acli jira workitem search --jql 'project IN (RHIDP, rhdhbugs) AND fixVersion = "{{RELEASE_VERSION}}" and issuetype in (weakness, Vulnerability, bug) and summary ~ "CVE*"' --count
-```
-
-## Step 4 (fallback): Get outstanding release notes count
-
-Use the `release_notes` JQL:
-
-```bash
-acli jira workitem search --jql 'project in (RHIDP, "Red Hat Developer Hub Bugs", "RHDH Support", rhdhplan) and issuetype in (Feature, bug) and "Release Note Type" is EMPTY and fixVersion = "{{RELEASE_VERSION}}"' --count
-```
-
-## Step 5 (fallback): Fill template and output
-
-Load the **Feature Freeze Announcement** template from `references/slack-templates.md`.
-
-Fill all placeholders:
-
-- `{{RELEASE_VERSION}}` — the release version
-- `{{EPIC_ISSUE_COUNT}}` — from Step 1
-- `{{CVE_ISSUE_COUNT}}` — from Step 2
-- `{{OUTSTANDING_RELEASE_NOTES_ISSUE_COUNT}}` — from Step 3
-- `{{JIRA_LINK}}` — URL-encoded Jira search link for each count
-
-**Output the filled template in a triple-backtick code block** for copy-paste into Slack.
+Use its `slack_message` field directly. If it reports that `release_notes` is
+unavailable, run `python scripts/release.py --json check`, configure the Rich
+Filter as shown in `references/config.md`, and retry. Do not use a hardcoded
+release-notes query because the Rich Filter is the source of truth.
 
 </process>
 

--- a/skills/rhdh-release/workflows/post-code-freeze.md
+++ b/skills/rhdh-release/workflows/post-code-freeze.md
@@ -1,0 +1,27 @@
+# Workflow: Review Post Code Freeze Work
+
+Identify release-scoped issues selected by the operational Post Code Freeze filter.
+
+<prerequisites>
+
+Run `python scripts/release.py --json check` and require the Rich Filter contract check to pass.
+
+</prerequisites>
+
+<process>
+
+```bash
+python scripts/release.py --json post-freeze {{RELEASE_VERSION}}
+```
+
+Use the returned count and Jira link. The query is composed from the exported
+`Post Code Freeze` static filter; do not reproduce its JQL locally.
+
+</process>
+
+<success_criteria>
+
+- [ ] Post Code Freeze count is reported
+- [ ] A release-scoped Jira search link is included
+
+</success_criteria>

--- a/skills/rhdh-release/workflows/release-notes.md
+++ b/skills/rhdh-release/workflows/release-notes.md
@@ -1,6 +1,6 @@
-# Workflow: Retrieve Outstanding Release Notes
+# Workflow: Review Release Note Lifecycle
 
-Compile features and bugs missing Release Note Type field.
+Report unclassified, proposed, done, and populated release-note work.
 
 <prerequisites>
 
@@ -25,6 +25,10 @@ Rich Filter is the source of truth for release-note classification.
 
 Also include the Release Notes Dashboard returned by the CLI.
 
+The lifecycle keys map to `release_notes`, `release_notes_proposed`,
+`release_notes_done`, and `release_notes_with_text` in
+`references/jql-release.md`.
+
 </process>
 
 <gotchas>
@@ -36,8 +40,8 @@ Also include the Release Notes Dashboard returned by the CLI.
 
 <success_criteria>
 
-- [ ] Count of issues missing Release Note Type
-- [ ] Jira search link to the outstanding items
+- [ ] Counts for unclassified, proposed, done, and issues with release-note text
+- [ ] Jira search link for every lifecycle stage
 - [ ] Link to Release Notes Dashboard
 
 </success_criteria>

--- a/skills/rhdh-release/workflows/release-notes.md
+++ b/skills/rhdh-release/workflows/release-notes.md
@@ -18,27 +18,12 @@ Compile features and bugs missing Release Note Type field.
 python scripts/release.py --json notes {{RELEASE_VERSION}}
 ```
 
-If the CLI succeeds, use its output directly. If it fails, follow the manual steps below.
+Use the CLI output directly. If it reports that `release_notes` is unavailable,
+run `python scripts/release.py --json check`, configure the Rich Filter as shown
+in `references/config.md`, and retry. Do not substitute a hardcoded query: the
+Rich Filter is the source of truth for release-note classification.
 
-## Step 2 (fallback): Count issues missing Release Note Type
-
-Use the `release_notes` JQL from `references/jql-release.md`:
-
-```bash
-acli jira workitem search --jql 'project in (RHIDP, "Red Hat Developer Hub Bugs", "RHDH Support", rhdhplan) and issuetype in (Feature, bug) and "Release Note Type" is EMPTY and fixVersion = "{{RELEASE_VERSION}}"' --count
-```
-
-## Step 3 (fallback): Get details (if needed)
-
-```bash
-acli jira workitem search --jql 'project in (RHIDP, "Red Hat Developer Hub Bugs", "RHDH Support", rhdhplan) and issuetype in (Feature, bug) and "Release Note Type" is EMPTY and fixVersion = "{{RELEASE_VERSION}}"' --limit 500 --json | python ~/.claude/skills/rhdh-jira/scripts/parse_issues.py --enrich -s key,summary,status,issuetype
-```
-
-## Step 4 (fallback): Format output
-
-**{{COUNT}} issues missing Release Note Type** — [View in Jira](https://issues.redhat.com/issues/?jql=...)
-
-Also link to the [Release Notes Dashboard](https://issues.redhat.com/secure/Dashboard.jspa?selectPageId=12382090) for full details.
+Also include the Release Notes Dashboard returned by the CLI.
 
 </process>
 

--- a/skills/rhdh-release/workflows/rich-filter-catalog.md
+++ b/skills/rhdh-release/workflows/rich-filter-catalog.md
@@ -1,0 +1,42 @@
+# Workflow: Inspect or Query the Rich Filter Catalog
+
+Expose every query-bearing entry in the configured Rich Filter export.
+
+<prerequisites>
+
+Run `python scripts/release.py --json check` and require the Rich Filter contract check to pass.
+
+</prerequisites>
+
+<process>
+
+First list the catalog:
+
+```bash
+python scripts/release.py --json rich-filter inventory
+```
+
+Then query an entry by kind. Smart-filter clauses require their group name;
+`--version` adds release scope and `--count` executes the composed JQL.
+
+```bash
+python scripts/release.py --json rich-filter query static demo --version {{RELEASE_VERSION}} --count
+python scripts/release.py --json rich-filter query smart AI --group "Scrum Team" --version {{RELEASE_VERSION}} --count
+python scripts/release.py --json rich-filter query queue "RNs Proposed" --version {{RELEASE_VERSION}} --count
+python scripts/release.py --json rich-filter query time-series "Last week" --version {{RELEASE_VERSION}} --count
+python scripts/release.py --json rich-filter query ratio-numerator "1.10 Plan to Commit" --count
+python scripts/release.py --json rich-filter query ratio-denominator "1.10 Plan to Commit" --count
+```
+
+Inventory output also lists dynamic fields and view columns as presentation
+metadata. Time-series JQL and both custom-ratio JQL sides are executable.
+
+</process>
+
+<success_criteria>
+
+- [ ] The requested catalog entry is identified unambiguously
+- [ ] Composed JQL and a Jira search link are returned
+- [ ] A live count is included when requested
+
+</success_criteria>

--- a/skills/rhdh/SKILL.md
+++ b/skills/rhdh/SKILL.md
@@ -239,7 +239,8 @@ $RHDH config set cli /path         # Set rhdh-cli location
 $RHDH config set plugins /path     # Set rhdh-plugins location
 $RHDH config set operator /path    # Set rhdh-operator location
 $RHDH config set chart /path       # Set rhdh-chart location
-$RHDH config set catalog /path     # Set rhdh-plugin-catalog location
+$RHDH config set catalog /path       # Set rhdh-plugin-catalog location
+$RHDH config set private-data /path  # Set rhdh-skill-private-data location
 ```
 
 **Workspace operations:**
@@ -334,6 +335,7 @@ Todos must be **self-contained**—a new session should understand the task with
 **GitHub CLI (PRs, CI, workflows):** references/github-reference.md
 **Version Matrix:** references/versions.md — RHDH/Backstage version compatibility, create-app versions
 **Slack Notifications:** references/slack-notification.md — Slack ping templates, handle mapping, channel routing
+**Private Data:** references/private-data.md — private data repo setup and sync (Rich Filter exports)
 </reference_index>
 
 <skills_index>

--- a/skills/rhdh/references/private-data.md
+++ b/skills/rhdh/references/private-data.md
@@ -15,17 +15,11 @@ Repository for Jira Rich Filter exports and other operational data used by RHDH 
 
 ## Setup
 
-**Clone** (sibling to `rhdh-skill`):
+**Clone** and **register:**
 
 ```bash
-cd "$(dirname /path/to/rhdh-skill)"
 git clone git@gitlab.cee.redhat.com:rhidp/rhdh-skill-private-data.git
-```
-
-**Configure** (if cloned elsewhere):
-
-```bash
-$RHDH config set private-data /path/to/rhdh-skill-private-data
+rhdh config set private-data /path/to/rhdh-skill-private-data
 ```
 
 **Update** (pull latest Rich Filter export):

--- a/skills/rhdh/references/private-data.md
+++ b/skills/rhdh/references/private-data.md
@@ -1,0 +1,40 @@
+# Private Data Repository
+
+Internal repository containing Jira Rich Filter exports and other private operational data that cannot be checked into the public `rhdh-skill` repo.
+
+## Repository
+
+- **URL:** `git@gitlab.cee.redhat.com:rhidp/rhdh-skill-private-data.git`
+- **Access:** Requires Red Hat VPN / internal network
+- **Maintainers:** Matt Reid, Jasper Chui (Rich Filter owners)
+
+## Contents
+
+| Path | Description |
+|------|-------------|
+| `jira-rich-filter/rhidp-operational-rich-filter.json` | Exported "RHIDP Operational" Rich Filter — project-scoped JQL, component exclusion lists, team Cloud ID mappings, queue definitions |
+
+## Setup
+
+**Clone** (sibling to `rhdh-skill`):
+
+```bash
+cd "$(dirname /path/to/rhdh-skill)"
+git clone git@gitlab.cee.redhat.com:rhidp/rhdh-skill-private-data.git
+```
+
+**Configure** (if cloned elsewhere):
+
+```bash
+$RHDH config set private-data /path/to/rhdh-skill-private-data
+```
+
+**Update** (pull latest Rich Filter export):
+
+```bash
+cd /path/to/rhdh-skill-private-data && git pull
+```
+
+## How It's Used
+
+The `rhdh-release` skill's `rich_filter.py` module reads the Rich Filter JSON at runtime to source JQL queries. When the file is available, it overlays the hardcoded JQL templates in `jql-release.md` with queries composed from the Rich Filter. When the file is missing, the skill falls back to the markdown templates.

--- a/skills/rhdh/references/private-data.md
+++ b/skills/rhdh/references/private-data.md
@@ -1,11 +1,10 @@
 # Private Data Repository
 
-Internal repository containing Jira Rich Filter exports and other private operational data that cannot be checked into the public `rhdh-skill` repo.
+Repository for Jira Rich Filter exports and other operational data used by RHDH skills. Clone it alongside the other RHDH repos and register it via `rhdh config set private-data /path`.
 
 ## Repository
 
 - **URL:** `git@gitlab.cee.redhat.com:rhidp/rhdh-skill-private-data.git`
-- **Access:** Requires Red Hat VPN / internal network
 - **Maintainers:** Matt Reid, Jasper Chui (Rich Filter owners)
 
 ## Contents
@@ -37,4 +36,4 @@ cd /path/to/rhdh-skill-private-data && git pull
 
 ## How It's Used
 
-The `rhdh-release` skill's `rich_filter.py` module reads the Rich Filter JSON at runtime to source JQL queries. When the file is available, it overlays the hardcoded JQL templates in `jql-release.md` with queries composed from the Rich Filter. When the file is missing, the skill falls back to the markdown templates.
+The `rhdh-release` skill discovers this repo via `rhdh.config.get_repo("private-data")` and reads the Rich Filter JSON at runtime to source JQL queries. When the file is available, it overlays the markdown JQL templates with queries composed from the Rich Filter. When the repo is not configured, freeze commands error with a clear message listing available templates.

--- a/skills/rhdh/references/rhdh-repos.md
+++ b/skills/rhdh/references/rhdh-repos.md
@@ -159,11 +159,10 @@ Reference of all RHDH-related repositories, what each one is used for, and how t
 ### rhdh-skill-private-data
 
 - **Upstream:** <https://gitlab.cee.redhat.com/rhidp/rhdh-skill-private-data>
-- **Description:** Internal repository for Jira Rich Filter exports and other private operational data used by RHDH skills. Contains exported Rich Filter JSON from the "RHIDP Operational" Jira Rich Filter managed by Matt Reid and Jasper Chui.
-- **Note:** Requires Red Hat VPN / internal network access.
+- **Description:** Jira Rich Filter exports and operational data used by RHDH skills. Contains exported Rich Filter JSON from the "RHIDP Operational" Jira Rich Filter managed by Matt Reid and Jasper Chui.
 - **Key concepts:**
   - **Rich Filter exports:** JSON exports from Jira Rich Filters that define project-scoped queries, component exclusion lists, team Cloud ID mappings, and queue definitions. Used by the `rhdh-release` skill to source JQL queries at runtime instead of hardcoding them.
-  - **Expected location:** Sibling to `rhdh-skill` checkout (i.e. `../rhdh-skill-private-data`), or configured via `$RHDH config set private-data /path`.
+  - **Discovery:** Located via `rhdh.config.get_repo("private-data")` — configure with `rhdh config set private-data /path`.
 - **Key paths:** `jira-rich-filter/rhidp-operational-rich-filter.json` (Rich Filter export)
 
 ### backstage

--- a/skills/rhdh/references/rhdh-repos.md
+++ b/skills/rhdh/references/rhdh-repos.md
@@ -156,6 +156,16 @@ Reference of all RHDH-related repositories, what each one is used for, and how t
   - **Used by overlay workflows:** `rhdh-plugin-export-overlays` can use the factory container for local plugin builds.
 - **Key paths:** `Containerfile` (image definition)
 
+### rhdh-skill-private-data
+
+- **Upstream:** <https://gitlab.cee.redhat.com/rhidp/rhdh-skill-private-data>
+- **Description:** Internal repository for Jira Rich Filter exports and other private operational data used by RHDH skills. Contains exported Rich Filter JSON from the "RHIDP Operational" Jira Rich Filter managed by Matt Reid and Jasper Chui.
+- **Note:** Requires Red Hat VPN / internal network access.
+- **Key concepts:**
+  - **Rich Filter exports:** JSON exports from Jira Rich Filters that define project-scoped queries, component exclusion lists, team Cloud ID mappings, and queue definitions. Used by the `rhdh-release` skill to source JQL queries at runtime instead of hardcoding them.
+  - **Expected location:** Sibling to `rhdh-skill` checkout (i.e. `../rhdh-skill-private-data`), or configured via `$RHDH config set private-data /path`.
+- **Key paths:** `jira-rich-filter/rhidp-operational-rich-filter.json` (Rich Filter export)
+
 ### backstage
 
 - **Upstream:** <https://github.com/backstage/backstage>

--- a/skills/rhdh/rhdh/config.py
+++ b/skills/rhdh/rhdh/config.py
@@ -113,7 +113,7 @@ SUBMODULE_REPOS: dict[str, dict] = {
         "has_fork": False,
         "required": False,
         "config_key": "private-data",
-        "description": "Internal repo for Jira Rich Filter exports and operational data",
+        "description": "Jira Rich Filter exports and operational data for RHDH skills",
         "upstream_host": "gitlab.cee.redhat.com",
         "upstream_path": "rhidp/rhdh-skill-private-data",
     },

--- a/skills/rhdh/rhdh/config.py
+++ b/skills/rhdh/rhdh/config.py
@@ -109,6 +109,14 @@ SUBMODULE_REPOS: dict[str, dict] = {
         "description": "Upstream Backstage framework",
         "upstream_org": "backstage",
     },
+    "rhdh-skill-private-data": {
+        "has_fork": False,
+        "required": False,
+        "config_key": "private-data",
+        "description": "Internal repo for Jira Rich Filter exports and operational data",
+        "upstream_host": "gitlab.cee.redhat.com",
+        "upstream_path": "rhidp/rhdh-skill-private-data",
+    },
 }
 
 # GitHub organization for upstream repos

--- a/tests/unit/test_release_cli.py
+++ b/tests/unit/test_release_cli.py
@@ -1,6 +1,8 @@
 """Unit tests for skills/rhdh-release/scripts/ — jql.py, slack_templates.py, release.py, rich_filter.py."""
 
 import json
+import os
+import subprocess
 import sys
 from pathlib import Path
 from urllib.parse import quote
@@ -280,6 +282,36 @@ class TestParseAcliCount:
             assert False, "Expected ValueError"
         except ValueError:
             pass
+
+
+class TestFetchTeams:
+    ROWS = [
+        ["Category", "Team Name", "Status", "Leads", "Slack Handles", "Cloud ID"],
+        ["Engineering", "RHDH AI", "Active", "Ada", "@ada", "sheet-ai"],
+        ["Engineering", "Cope", "Active", "Grace", "@grace", "sheet-cope"],
+    ]
+
+    def test_rich_filter_cloud_ids_override_spreadsheet(self, monkeypatch):
+        monkeypatch.setattr(release, "_gog_sheets_get", lambda *_args: self.ROWS)
+        monkeypatch.setattr(
+            release.rf_mod,
+            "scrum_teams",
+            lambda: [{"name": "AI", "cloud_id": "rich-filter-ai"}],
+        )
+
+        teams = release._fetch_teams(category="Engineering")
+
+        assert teams[0]["cloud_id"] == "rich-filter-ai"
+        assert teams[0]["slack_handles"] == ["@ada"]
+        assert teams[1]["cloud_id"] == "sheet-cope"
+
+    def test_spreadsheet_cloud_ids_are_fallback(self, monkeypatch):
+        monkeypatch.setattr(release, "_gog_sheets_get", lambda *_args: self.ROWS)
+        monkeypatch.setattr(release.rf_mod, "scrum_teams", lambda: None)
+
+        teams = release._fetch_teams(category="Engineering")
+
+        assert [team["cloud_id"] for team in teams] == ["sheet-ai", "sheet-cope"]
 
 
 class TestCommandMapping:
@@ -586,6 +618,19 @@ class TestRichFilterParser:
         assert "ec74d716" in teams[0]["cloud_id"]
         assert teams[1]["name"] == "Cope"
 
+    def test_scrum_teams_removes_jql_value_quotes(self, tmp_path):
+        data = json.loads(json.dumps(SAMPLE_RICH_FILTER))
+        data["richFilter"]["smartFilters"][0]["clauses"][0]["jql"] = (
+            '"Team[Team]" = "quoted-cloud-id"'
+        )
+        rf_path = tmp_path / "rf.json"
+        rf_path.write_text(json.dumps(data))
+
+        teams = rich_filter.scrum_teams(rf_path)
+
+        assert teams is not None
+        assert teams[0]["cloud_id"] == "quoted-cloud-id"
+
     def test_list_static_filters(self, tmp_path):
         rf_path = _write_sample_rf(tmp_path)
         names = rich_filter.list_static_filters(rf_path)
@@ -656,6 +701,17 @@ class TestJqlRichFilterIntegration:
         cf = templates["code_freeze_issues"]
         assert "issuetype in (bug, Story, task, Vulnerability)" in cf
         assert "fixVersion" in cf
+
+    def test_groups_rich_filter_fragment_to_preserve_scope(self, tmp_path):
+        data = json.loads(json.dumps(SAMPLE_RICH_FILTER))
+        data["richFilter"]["staticFilters"][2]["jql"] = "status = Open OR status = Reopened"
+        rf_path = tmp_path / "rf.json"
+        rf_path.write_text(json.dumps(data))
+        jql.set_rich_filter_path(rf_path)
+
+        rendered = jql.render("code_freeze_issues", version="2.1.0")
+
+        assert 'fixVersion = "2.1.0" AND (status = Open OR status = Reopened)' in rendered
 
     def test_adds_release_notes_from_rich_filter(self, tmp_path):
         rf_path = _write_sample_rf(tmp_path)
@@ -731,3 +787,51 @@ class TestJqlWithoutRichFilter:
             assert False, "Expected KeyError"
         except KeyError as e:
             assert "feature_freeze_issues" in str(e)
+
+
+class TestRichFilterCliIntegration:
+    def test_direct_script_discovers_project_config(self, tmp_path):
+        private_data = tmp_path / "private-data"
+        rf_path = private_data / "jira-rich-filter" / "rhidp-operational-rich-filter.json"
+        rf_path.parent.mkdir(parents=True)
+        rf_path.write_text(json.dumps(SAMPLE_RICH_FILTER))
+
+        project = tmp_path / "project"
+        config_dir = project / ".rhdh"
+        config_dir.mkdir(parents=True)
+        (config_dir / "config.json").write_text(
+            json.dumps({"repos": {"private-data": str(private_data)}})
+        )
+        subprocess.run(["git", "init"], cwd=project, check=True, capture_output=True)
+
+        code = (
+            "import sys; "
+            f"sys.path.insert(0, {str(_RELEASE_SCRIPTS)!r}); "
+            "import rich_filter; print(rich_filter.discover())"
+        )
+        env = {**os.environ, "HOME": str(tmp_path / "home")}
+        env.pop("PYTHONPATH", None)
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            cwd=project,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+
+        assert result.stdout.strip() == str(rf_path)
+
+    def test_missing_rich_filter_is_reported_without_traceback(self, monkeypatch, capsys):
+        jql.set_rich_filter_path(None)
+        monkeypatch.setattr(release, "_init_rich_filter", lambda: None)
+
+        try:
+            release.main(["--json", "notes", "2.1.0"])
+            assert False, "Expected SystemExit"
+        except SystemExit as e:
+            assert e.code == 1
+
+        output = json.loads(capsys.readouterr().out)
+        assert output["error"]["code"] == "CONFIGURATION_ERROR"
+        assert "release_notes" in output["error"]["message"]

--- a/tests/unit/test_release_cli.py
+++ b/tests/unit/test_release_cli.py
@@ -1,5 +1,6 @@
-"""Unit tests for skills/rhdh-release/scripts/ — jql.py, slack_templates.py, release.py."""
+"""Unit tests for skills/rhdh-release/scripts/ — jql.py, slack_templates.py, release.py, rich_filter.py."""
 
+import json
 import sys
 from pathlib import Path
 from urllib.parse import quote
@@ -11,6 +12,7 @@ if str(_RELEASE_SCRIPTS) not in sys.path:
 
 import jql  # noqa: E402
 import release  # noqa: E402
+import rich_filter  # noqa: E402
 import slack_templates  # noqa: E402
 
 # =========================================================================
@@ -19,11 +21,21 @@ import slack_templates  # noqa: E402
 
 
 class TestJqlLoadTemplates:
-    def test_loads_16_templates(self):
-        templates = jql.load_templates()
-        assert len(templates) == 16
+    def setup_method(self):
+        jql._TEMPLATE_CACHE = None
+        jql._RICH_FILTER_PATH = None
+        rich_filter.reset_cache()
 
-    def test_known_template_names(self):
+    def teardown_method(self):
+        jql._TEMPLATE_CACHE = None
+        jql._RICH_FILTER_PATH = None
+        rich_filter.reset_cache()
+
+    def test_loads_11_markdown_templates(self):
+        templates = jql.load_templates()
+        assert len(templates) == 11
+
+    def test_known_markdown_template_names(self):
         names = jql.list_templates()
         assert "active_release" in names
         assert "open_issues" in names
@@ -34,13 +46,16 @@ class TestJqlLoadTemplates:
         assert "feature_subtasks" in names
         assert "test_day_features" in names
         assert "features_added_to_release" in names
-        assert "release_notes" in names
         assert "blockers" in names
-        assert "feature_freeze_issues" in names
-        assert "code_freeze_issues" in names
         assert "open_issues_by_team" in names
-        assert "feature_freeze_issues_by_team" in names
-        assert "code_freeze_issues_by_team" in names
+
+    def test_rich_filter_templates_not_in_markdown(self):
+        names = jql.list_templates()
+        assert "feature_freeze_issues" not in names
+        assert "feature_freeze_issues_by_team" not in names
+        assert "code_freeze_issues" not in names
+        assert "code_freeze_issues_by_team" not in names
+        assert "release_notes" not in names
 
 
 class TestJqlGetTemplate:
@@ -403,3 +418,316 @@ class TestFindMilestones:
             ["2025-06-01", "GA Announce RHDH 1.8"],
         ]
         assert release._find_milestones(rows, "2.0") == {}
+
+
+# =========================================================================
+# rich_filter.py
+# =========================================================================
+
+SAMPLE_RICH_FILTER = {
+    "richFilter": {
+        "status": "active",
+        "name": "RHIDP Operational",
+        "jiraFilter": {
+            "id": "27716",
+            "name": "RHIDP Operational",
+            "jql": "project in (rhidp, rhdhplan, rhdhsupp, rhdhbugs) and (resolutiondate >= -365d or status != Closed) ORDER BY priority DESC",
+        },
+        "staticFilters": [
+            {
+                "key": "k1",
+                "name": "CVE",
+                "jql": 'summary ~ "CVE-*"',
+            },
+            {
+                "key": "k2",
+                "name": "Feature Freeze",
+                "jql": 'resolution is EMPTY AND component not in ("AEM Migration", AI) AND Type not in (Bug, Vulnerability, sub-task) AND status not in ("Dev Complete", "Release Pending", Done, Closed)',
+            },
+            {
+                "key": "k3",
+                "name": "Code Freeze",
+                "jql": 'issuetype in (bug, Story, task, Vulnerability) AND status not in ("Release Pending", Closed) AND component not in ("AEM Migration", AI)',
+            },
+            {
+                "key": "k4",
+                "name": "demo",
+                "jql": "labels in (demo)",
+            },
+        ],
+        "smartFilters": [
+            {
+                "key": "sf1",
+                "name": "Scrum Team",
+                "andEnabled": False,
+                "clauses": [
+                    {
+                        "key": "c1",
+                        "name": "AI",
+                        "jql": '"Team[Team]" = ec74d716-af36-4b3c-950f-f79213d08f71-1087',
+                    },
+                    {
+                        "key": "c2",
+                        "name": "Cope",
+                        "jql": '"Team[Team]" = ec74d716-af36-4b3c-950f-f79213d08f71-4403',
+                    },
+                ],
+            },
+            {
+                "key": "sf2",
+                "name": "Delivery Team",
+                "andEnabled": False,
+                "clauses": [
+                    {
+                        "key": "c3",
+                        "name": "Engineering",
+                        "jql": "Team in (ec74d716-af36-4b3c-950f-f79213d08f71-1087)",
+                    },
+                ],
+            },
+        ],
+        "richQueues": [
+            {
+                "key": "rq1",
+                "name": "RNs Unclassified",
+                "jql": '("Release Note Type" not in ("Release Note Not Required") OR "release note type" is EMPTY) AND summary !~ "CVE-*"',
+            },
+            {
+                "key": "rq2",
+                "name": "RNs Proposed",
+                "jql": '"Release Note Status" in (Proposed)',
+            },
+        ],
+    }
+}
+
+
+def _write_sample_rf(tmpdir: Path) -> Path:
+    """Write sample Rich Filter JSON and return the file path."""
+    rf_path = tmpdir / "rf.json"
+    rf_path.write_text(json.dumps(SAMPLE_RICH_FILTER))
+    return rf_path
+
+
+class TestRichFilterParser:
+    def setup_method(self):
+        rich_filter.reset_cache()
+
+    def test_load_returns_rich_filter_dict(self, tmp_path):
+        rf_path = _write_sample_rf(tmp_path)
+        rf = rich_filter.load(rf_path)
+        assert rf is not None
+        assert rf["name"] == "RHIDP Operational"
+
+    def test_load_missing_file_returns_none(self, tmp_path):
+        rf = rich_filter.load(tmp_path / "nonexistent.json")
+        assert rf is None
+
+    def test_load_bad_structure_raises(self, tmp_path):
+        bad = tmp_path / "bad.json"
+        bad.write_text('{"not_richFilter": {}}')
+        try:
+            rich_filter.load(bad)
+            assert False, "Expected ValueError"
+        except ValueError as e:
+            assert "richFilter" in str(e)
+
+    def test_base_jql_strips_order_by(self, tmp_path):
+        rf_path = _write_sample_rf(tmp_path)
+        base = rich_filter.base_jql(rf_path)
+        assert base is not None
+        assert "ORDER BY" not in base
+        assert "project in" in base.lower()
+
+    def test_static_filter_by_name(self, tmp_path):
+        rf_path = _write_sample_rf(tmp_path)
+        ff = rich_filter.static_filter("Feature Freeze", rf_path)
+        assert ff is not None
+        assert "resolution is EMPTY" in ff
+
+    def test_static_filter_case_insensitive(self, tmp_path):
+        rf_path = _write_sample_rf(tmp_path)
+        ff = rich_filter.static_filter("feature freeze", rf_path)
+        assert ff is not None
+
+    def test_static_filter_not_found(self, tmp_path):
+        rf_path = _write_sample_rf(tmp_path)
+        result = rich_filter.static_filter("Nonexistent", rf_path)
+        assert result is None
+
+    def test_smart_filter_clause(self, tmp_path):
+        rf_path = _write_sample_rf(tmp_path)
+        jql_str = rich_filter.smart_filter_clause("Scrum Team", "AI", rf_path)
+        assert jql_str is not None
+        assert "ec74d716" in jql_str
+
+    def test_smart_filter_clause_not_found(self, tmp_path):
+        rf_path = _write_sample_rf(tmp_path)
+        result = rich_filter.smart_filter_clause("Scrum Team", "Missing", rf_path)
+        assert result is None
+
+    def test_rich_queue(self, tmp_path):
+        rf_path = _write_sample_rf(tmp_path)
+        rn = rich_filter.rich_queue("RNs Unclassified", rf_path)
+        assert rn is not None
+        assert "Release Note Type" in rn
+
+    def test_rich_queue_not_found(self, tmp_path):
+        rf_path = _write_sample_rf(tmp_path)
+        result = rich_filter.rich_queue("Missing Queue", rf_path)
+        assert result is None
+
+    def test_scrum_teams(self, tmp_path):
+        rf_path = _write_sample_rf(tmp_path)
+        teams = rich_filter.scrum_teams(rf_path)
+        assert teams is not None
+        assert len(teams) == 2
+        assert teams[0]["name"] == "AI"
+        assert "ec74d716" in teams[0]["cloud_id"]
+        assert teams[1]["name"] == "Cope"
+
+    def test_list_static_filters(self, tmp_path):
+        rf_path = _write_sample_rf(tmp_path)
+        names = rich_filter.list_static_filters(rf_path)
+        assert names is not None
+        assert "Feature Freeze" in names
+        assert "CVE" in names
+
+    def test_list_smart_filters(self, tmp_path):
+        rf_path = _write_sample_rf(tmp_path)
+        names = rich_filter.list_smart_filters(rf_path)
+        assert names is not None
+        assert "Scrum Team" in names
+        assert "Delivery Team" in names
+
+    def test_list_rich_queues(self, tmp_path):
+        rf_path = _write_sample_rf(tmp_path)
+        names = rich_filter.list_rich_queues(rf_path)
+        assert names is not None
+        assert "RNs Unclassified" in names
+
+    def test_caching(self, tmp_path):
+        rf_path = _write_sample_rf(tmp_path)
+        rf1 = rich_filter.load(rf_path)
+        rf2 = rich_filter.load(rf_path)
+        assert rf1 is rf2
+
+    def test_reset_cache(self, tmp_path):
+        rf_path = _write_sample_rf(tmp_path)
+        rf1 = rich_filter.load(rf_path)
+        rich_filter.reset_cache()
+        rf2 = rich_filter.load(rf_path)
+        assert rf1 is not rf2
+
+    def test_load_none_without_file_returns_none(self):
+        result = rich_filter.load()
+        # Will return None if no file is discoverable in the default paths
+        assert result is None or isinstance(result, dict)
+
+
+# =========================================================================
+# jql.py — Rich Filter integration
+# =========================================================================
+
+
+class TestJqlRichFilterIntegration:
+    def setup_method(self):
+        jql._TEMPLATE_CACHE = None
+        rich_filter.reset_cache()
+
+    def teardown_method(self):
+        jql._TEMPLATE_CACHE = None
+        jql._RICH_FILTER_PATH = None
+        rich_filter.reset_cache()
+
+    def test_adds_feature_freeze_from_rich_filter(self, tmp_path):
+        rf_path = _write_sample_rf(tmp_path)
+        jql.set_rich_filter_path(rf_path)
+        templates = jql.load_templates()
+        ff = templates["feature_freeze_issues"]
+        assert "resolution is EMPTY" in ff
+        assert "fixVersion" in ff
+        assert "project in" in ff.lower()
+
+    def test_adds_code_freeze_from_rich_filter(self, tmp_path):
+        rf_path = _write_sample_rf(tmp_path)
+        jql.set_rich_filter_path(rf_path)
+        templates = jql.load_templates()
+        cf = templates["code_freeze_issues"]
+        assert "issuetype in (bug, Story, task, Vulnerability)" in cf
+        assert "fixVersion" in cf
+
+    def test_adds_release_notes_from_rich_filter(self, tmp_path):
+        rf_path = _write_sample_rf(tmp_path)
+        jql.set_rich_filter_path(rf_path)
+        templates = jql.load_templates()
+        rn = templates["release_notes"]
+        assert "Release Note Type" in rn
+        assert "fixVersion" in rn
+
+    def test_adds_team_filter_from_rich_filter(self, tmp_path):
+        rf_path = _write_sample_rf(tmp_path)
+        jql.set_rich_filter_path(rf_path)
+        templates = jql.load_templates()
+        ff_team = templates["feature_freeze_issues_by_team"]
+        assert "{{CLOUD_ID}}" in ff_team
+        assert "Team[Team]" in ff_team
+
+    def test_preserves_markdown_templates(self, tmp_path):
+        rf_path = _write_sample_rf(tmp_path)
+        jql.set_rich_filter_path(rf_path)
+        templates = jql.load_templates()
+        assert "active_release" in templates
+        assert "blockers" in templates
+        assert "epics" in templates
+        assert "rhdhplan" in templates["active_release"].lower()
+
+    def test_total_16_with_rich_filter(self, tmp_path):
+        rf_path = _write_sample_rf(tmp_path)
+        jql.set_rich_filter_path(rf_path)
+        templates = jql.load_templates()
+        assert len(templates) == 16
+
+    def test_render_with_rich_filter(self, tmp_path):
+        rf_path = _write_sample_rf(tmp_path)
+        jql.set_rich_filter_path(rf_path)
+        rendered = jql.render("feature_freeze_issues", version="2.1.0")
+        assert '"2.1.0"' in rendered
+        assert "{{RELEASE_VERSION}}" not in rendered
+
+
+class TestJqlWithoutRichFilter:
+    def setup_method(self):
+        jql._TEMPLATE_CACHE = None
+        jql._RICH_FILTER_PATH = None
+        rich_filter.reset_cache()
+
+    def teardown_method(self):
+        jql._TEMPLATE_CACHE = None
+        jql._RICH_FILTER_PATH = None
+        rich_filter.reset_cache()
+
+    def test_only_11_templates_without_rich_filter(self):
+        jql.set_rich_filter_path(None)
+        templates = jql.load_templates()
+        assert len(templates) == 11
+
+    def test_only_11_when_path_missing(self, tmp_path):
+        jql.set_rich_filter_path(tmp_path / "nonexistent.json")
+        templates = jql.load_templates()
+        assert len(templates) == 11
+
+    def test_freeze_templates_missing_without_rich_filter(self):
+        jql.set_rich_filter_path(None)
+        templates = jql.load_templates()
+        assert "feature_freeze_issues" not in templates
+        assert "code_freeze_issues" not in templates
+        assert "release_notes" not in templates
+
+    def test_freeze_template_raises_keyerror(self):
+        jql.set_rich_filter_path(None)
+        try:
+            jql.get_template("feature_freeze_issues")
+            assert False, "Expected KeyError"
+        except KeyError as e:
+            assert "feature_freeze_issues" in str(e)

--- a/tests/unit/test_release_cli.py
+++ b/tests/unit/test_release_cli.py
@@ -34,9 +34,9 @@ class TestJqlLoadTemplates:
         jql._RICH_FILTER_PATH = None
         rich_filter.reset_cache()
 
-    def test_loads_11_markdown_templates(self):
+    def test_loads_9_markdown_templates(self):
         templates = jql.load_templates()
-        assert len(templates) == 11
+        assert len(templates) == 9
 
     def test_known_markdown_template_names(self):
         names = jql.list_templates()
@@ -45,9 +45,7 @@ class TestJqlLoadTemplates:
         assert "open_issues_by_type" in names
         assert "epics" in names
         assert "cves" in names
-        assert "feature_demos" in names
         assert "feature_subtasks" in names
-        assert "test_day_features" in names
         assert "features_added_to_release" in names
         assert "blockers" in names
         assert "open_issues_by_team" in names
@@ -59,6 +57,12 @@ class TestJqlLoadTemplates:
         assert "code_freeze_issues" not in names
         assert "code_freeze_issues_by_team" not in names
         assert "release_notes" not in names
+        assert "feature_demos" not in names
+        assert "test_day_features" not in names
+        assert "post_code_freeze_issues" not in names
+        assert "release_notes_proposed" not in names
+        assert "release_notes_done" not in names
+        assert "release_notes_with_text" not in names
 
 
 class TestJqlGetTemplate:
@@ -247,11 +251,33 @@ class TestReleaseParser:
             "epics",
             "cves",
             "notes",
+            "post-freeze",
         ]:
             args = parser.parse_args([cmd, "1.0.0"])
             assert args.command == cmd
         args = parser.parse_args(["teams"])
         assert args.command == "teams"
+
+    def test_rich_filter_subcommands_parse(self):
+        parser = release.build_parser()
+        args = parser.parse_args(["rich-filter", "inventory"])
+        assert args.rich_filter_command == "inventory"
+        args = parser.parse_args(
+            [
+                "rich-filter",
+                "query",
+                "smart",
+                "AI",
+                "--group",
+                "Scrum Team",
+                "--version",
+                "2.1.0",
+                "--count",
+            ]
+        )
+        assert args.rich_filter_command == "query"
+        assert args.group == "Scrum Team"
+        assert args.count is True
 
     def test_all_slack_subcommands_parse(self):
         parser = release.build_parser()
@@ -328,6 +354,7 @@ class TestCommandMapping:
             "epics",
             "cves",
             "notes",
+            "post-freeze",
         }
         assert expected_commands == set(release.COMMANDS.keys())
 
@@ -339,6 +366,9 @@ class TestCommandMapping:
             "code-freeze",
         }
         assert expected == set(release.SLACK_COMMANDS.keys())
+
+    def test_all_rich_filter_commands_mapped(self):
+        assert {"inventory", "query"} == set(release.RICH_FILTER_COMMANDS)
 
 
 # =========================================================================
@@ -541,6 +571,16 @@ SAMPLE_RICH_FILTER = {
                 "name": "demo",
                 "jql": "labels in (demo)",
             },
+            {
+                "key": "k5",
+                "name": "Test Day",
+                "jql": "labels in (rhdh-testday)",
+            },
+            {
+                "key": "k6",
+                "name": "Post Code Freeze",
+                "jql": "component not in (release, quality)",
+            },
         ],
         "smartFilters": [
             {
@@ -584,6 +624,37 @@ SAMPLE_RICH_FILTER = {
                 "name": "RNs Proposed",
                 "jql": '"Release Note Status" in (Proposed)',
             },
+            {
+                "key": "rq3",
+                "name": "RNs Done",
+                "jql": '"Release Note Status" = Done',
+            },
+            {
+                "key": "rq4",
+                "name": "Has RN Text",
+                "jql": '"Release Note Text" is not EMPTY',
+            },
+        ],
+        "dynamicFilters": [
+            {
+                "label": "Status",
+                "value": "status",
+                "handler": {"clauseName": "status"},
+            }
+        ],
+        "richViews": [
+            {
+                "name": "Release Notes",
+                "columns": [{"label": "Key", "value": "issuekey"}],
+            }
+        ],
+        "timeSeries": [{"name": "Last week", "jql": "created >= -7d"}],
+        "customRatios": [
+            {
+                "name": "Plan to Commit",
+                "numJql": "labels = planned",
+                "denJql": "labels = candidate",
+            }
         ],
     }
 }
@@ -663,6 +734,54 @@ class TestRichFilterParser:
         rf_path = _write_sample_rf(tmp_path)
         result = rich_filter.rich_queue("Missing Queue", rf_path)
         assert result is None
+
+    def test_gets_any_fragment_kind(self, tmp_path):
+        rf_path = _write_sample_rf(tmp_path)
+        assert "demo" in rich_filter.fragment("static", "demo", path=rf_path)
+        assert "Proposed" in rich_filter.fragment("queue", "RNs Proposed", path=rf_path)
+        assert "Team[Team]" in rich_filter.fragment("smart", "AI", group="Scrum Team", path=rf_path)
+        assert "created >= -7d" == rich_filter.fragment("time-series", "Last week", path=rf_path)
+        assert "labels = planned" == rich_filter.fragment(
+            "ratio-numerator", "Plan to Commit", path=rf_path
+        )
+        assert "labels = candidate" == rich_filter.fragment(
+            "ratio-denominator", "Plan to Commit", path=rf_path
+        )
+
+    def test_smart_fragment_requires_group(self, tmp_path):
+        rf_path = _write_sample_rf(tmp_path)
+        try:
+            rich_filter.fragment("smart", "AI", path=rf_path)
+            assert False, "Expected ValueError"
+        except ValueError as e:
+            assert "--group" in str(e)
+
+    def test_inventory_covers_queries_and_presentation_metadata(self, tmp_path):
+        inventory = rich_filter.inventory(_write_sample_rf(tmp_path))
+        assert inventory is not None
+        assert "demo" in inventory["static_filters"]
+        assert inventory["smart_filters"][0]["name"] == "Scrum Team"
+        assert "RNs Done" in inventory["rich_queues"]
+        assert inventory["time_series"] == ["Last week"]
+        assert inventory["custom_ratios"] == ["Plan to Commit"]
+        assert inventory["presentation_metadata"]["dynamic_filter_fields"] == [
+            {"label": "Status", "value": "status", "clauses": ["status"]}
+        ]
+        assert inventory["presentation_metadata"]["rich_views"][0]["columns"] == [
+            {"label": "Key", "value": "issuekey"}
+        ]
+
+    def test_validate_complete_contract(self, tmp_path):
+        assert rich_filter.validate(_write_sample_rf(tmp_path)) == []
+
+    def test_validate_reports_missing_required_entry(self, tmp_path):
+        data = json.loads(json.dumps(SAMPLE_RICH_FILTER))
+        data["richFilter"]["staticFilters"] = [
+            item for item in data["richFilter"]["staticFilters"] if item["name"] != "Test Day"
+        ]
+        rf_path = tmp_path / "rf.json"
+        rf_path.write_text(json.dumps(data))
+        assert "required static filter missing: Test Day" in rich_filter.validate(rf_path)
 
     def test_scrum_teams(self, tmp_path):
         rf_path = _write_sample_rf(tmp_path)
@@ -746,6 +865,7 @@ class TestJqlRichFilterIntegration:
         templates = jql.load_templates()
         ff = templates["feature_freeze_issues"]
         assert "resolution is EMPTY" in ff
+        assert "resolutiondate >= -365d or status != Closed" in ff
         assert "fixVersion" in ff
         assert "project in" in ff.lower()
 
@@ -766,6 +886,7 @@ class TestJqlRichFilterIntegration:
 
         rendered = jql.render("code_freeze_issues", version="2.1.0")
 
+        assert rendered.startswith("(project in")
         assert 'fixVersion = "2.1.0" AND (status = Open OR status = Reopened)' in rendered
 
     def test_adds_release_notes_from_rich_filter(self, tmp_path):
@@ -793,11 +914,21 @@ class TestJqlRichFilterIntegration:
         assert "epics" in templates
         assert "rhdhplan" in templates["active_release"].lower()
 
-    def test_total_16_with_rich_filter(self, tmp_path):
+    def test_total_20_with_rich_filter(self, tmp_path):
         rf_path = _write_sample_rf(tmp_path)
         jql.set_rich_filter_path(rf_path)
         templates = jql.load_templates()
-        assert len(templates) == 16
+        assert len(templates) == 20
+
+    def test_adds_all_release_note_lifecycle_and_post_freeze_templates(self, tmp_path):
+        jql.set_rich_filter_path(_write_sample_rf(tmp_path))
+        templates = jql.load_templates()
+        assert "Proposed" in templates["release_notes_proposed"]
+        assert "Done" in templates["release_notes_done"]
+        assert "Release Note Text" in templates["release_notes_with_text"]
+        assert "component not in" in templates["post_code_freeze_issues"]
+        assert "labels in (demo)" in templates["feature_demos"]
+        assert "labels in (rhdh-testday)" in templates["test_day_features"]
 
     def test_render_with_rich_filter(self, tmp_path):
         rf_path = _write_sample_rf(tmp_path)
@@ -818,15 +949,15 @@ class TestJqlWithoutRichFilter:
         jql._RICH_FILTER_PATH = None
         rich_filter.reset_cache()
 
-    def test_only_11_templates_without_rich_filter(self):
+    def test_only_9_templates_without_rich_filter(self):
         jql.set_rich_filter_path(_NO_RICH_FILTER)
         templates = jql.load_templates()
-        assert len(templates) == 11
+        assert len(templates) == 9
 
-    def test_only_11_when_path_missing(self, tmp_path):
+    def test_only_9_when_path_missing(self, tmp_path):
         jql.set_rich_filter_path(tmp_path / "nonexistent.json")
         templates = jql.load_templates()
-        assert len(templates) == 11
+        assert len(templates) == 9
 
     def test_freeze_templates_missing_without_rich_filter(self):
         jql.set_rich_filter_path(_NO_RICH_FILTER)
@@ -845,6 +976,120 @@ class TestJqlWithoutRichFilter:
 
 
 class TestRichFilterCliIntegration:
+    def test_check_reports_partial_export_contract(self, tmp_path, monkeypatch, capsys):
+        data = json.loads(json.dumps(SAMPLE_RICH_FILTER))
+        data["richFilter"]["richQueues"] = [
+            queue for queue in data["richFilter"]["richQueues"] if queue["name"] != "RNs Done"
+        ]
+        rf_path = tmp_path / "partial.json"
+        rf_path.write_text(json.dumps(data))
+        monkeypatch.setattr(release.rf_mod, "discover", lambda: rf_path)
+        monkeypatch.setattr(release.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(
+            release,
+            "_run",
+            lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0, "1", ""),
+        )
+
+        try:
+            release.main(["--json", "check"])
+            assert False, "Expected SystemExit"
+        except SystemExit as error:
+            assert error.code == 1
+
+        output = json.loads(capsys.readouterr().out)
+        contract = next(
+            check for check in output["data"]["checks"] if check["name"] == "rich-filter-contract"
+        )
+        assert contract["status"] == "fail"
+        assert "RNs Done" in contract["message"]
+
+    def test_inventory_command_exposes_catalog(self, monkeypatch, capsys):
+        catalog = {
+            "name": "RHIDP Operational",
+            "static_filters": ["demo"],
+            "smart_filters": [{"name": "Scrum Team", "clauses": ["AI"]}],
+            "rich_queues": ["RNs Proposed"],
+            "presentation_metadata": {"rich_views": ["Default"]},
+        }
+        monkeypatch.setattr(release, "_init_rich_filter", lambda: None)
+        monkeypatch.setattr(release.rf_mod, "inventory", lambda: catalog)
+
+        release.main(["--json", "rich-filter", "inventory"])
+
+        output = json.loads(capsys.readouterr().out)
+        assert output["data"] == catalog
+
+    def test_query_command_composes_and_counts_fragment(self, monkeypatch, capsys):
+        monkeypatch.setattr(release, "_init_rich_filter", lambda: None)
+        monkeypatch.setattr(
+            release.rf_mod,
+            "fragment",
+            lambda kind, name, group=None: 'labels in ("demo")',
+        )
+        monkeypatch.setattr(release, "_acli_count", lambda jql_value, fmt: 7)
+
+        release.main(
+            [
+                "--json",
+                "rich-filter",
+                "query",
+                "static",
+                "demo",
+                "--version",
+                "2.1.0",
+                "--count",
+            ]
+        )
+
+        data = json.loads(capsys.readouterr().out)["data"]
+        assert 'fixVersion = "2.1.0"' in data["jql"]
+        assert 'labels in ("demo")' in data["jql"]
+        assert data["count"] == 7
+
+    def test_notes_command_reports_all_lifecycle_stages(self, monkeypatch, capsys):
+        counts = {
+            "release_notes": 8,
+            "release_notes_proposed": 5,
+            "release_notes_done": 3,
+            "release_notes_with_text": 2,
+        }
+        monkeypatch.setattr(release, "_init_rich_filter", lambda: None)
+        monkeypatch.setattr(
+            release.jql_mod,
+            "render_with_url",
+            lambda name, version=None: (name, f"https://jira/{name}"),
+        )
+        monkeypatch.setattr(release, "_acli_count", lambda query, fmt: counts[query])
+
+        release.main(["--json", "notes", "2.1.0"])
+
+        data = json.loads(capsys.readouterr().out)["data"]
+        assert data["outstanding_count"] == 8
+        assert {name: item["count"] for name, item in data["lifecycle"].items()} == {
+            "unclassified": 8,
+            "proposed": 5,
+            "done": 3,
+            "with_text": 2,
+        }
+
+    def test_post_freeze_command_returns_count_and_link(self, monkeypatch, capsys):
+        monkeypatch.setattr(release, "_init_rich_filter", lambda: None)
+        monkeypatch.setattr(
+            release.jql_mod,
+            "render_with_url",
+            lambda name, version=None: (name, "https://jira/post-freeze"),
+        )
+        monkeypatch.setattr(release, "_acli_count", lambda query, fmt: 4)
+
+        release.main(["--json", "post-freeze", "2.1.0"])
+
+        assert json.loads(capsys.readouterr().out)["data"] == {
+            "version": "2.1.0",
+            "count": 4,
+            "jira_url": "https://jira/post-freeze",
+        }
+
     def test_direct_script_discovers_project_config(self, tmp_path):
         private_data = tmp_path / "private-data"
         rf_path = private_data / "jira-rich-filter" / "rhidp-operational-rich-filter.json"

--- a/tests/unit/test_release_cli.py
+++ b/tests/unit/test_release_cli.py
@@ -976,6 +976,82 @@ class TestJqlWithoutRichFilter:
 
 
 class TestRichFilterCliIntegration:
+    def test_check_ignores_optional_token_warning_for_all_pass(self, tmp_path, monkeypatch, capsys):
+        rf_path = _write_sample_rf(tmp_path)
+        monkeypatch.setattr(release.Path, "home", lambda: tmp_path / "home")
+        monkeypatch.setattr(release.rf_mod, "discover", lambda: rf_path)
+        monkeypatch.setattr(release.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(
+            release,
+            "_run",
+            lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0, "1", ""),
+        )
+
+        release.main(["--json", "check"])
+
+        output = json.loads(capsys.readouterr().out)
+        token_check = next(
+            check for check in output["data"]["checks"] if check["name"] == ".jira-token"
+        )
+        assert token_check["status"] == "warn"
+        assert token_check["optional"] is True
+        assert output["data"]["all_pass"] is True
+        assert "next_steps" not in output
+
+    def test_epics_uses_search_payload_without_enrichment(self, monkeypatch, capsys):
+        raw_issues = [
+            {
+                "key": "RHIDP-1",
+                "fields": {
+                    "summary": "An epic",
+                    "status": {"name": "In Progress"},
+                    "assignee": {"displayName": "Ada"},
+                },
+            },
+            {
+                "key": "RHIDP-2",
+                "fields": {
+                    "summary": "Unassigned epic",
+                    "status": {"name": "New"},
+                    "assignee": None,
+                },
+            },
+        ]
+        monkeypatch.setattr(release, "_init_rich_filter", lambda: None)
+        monkeypatch.setattr(
+            release,
+            "_run",
+            lambda *args, **kwargs: subprocess.CompletedProcess(
+                args[0], 0, json.dumps(raw_issues), ""
+            ),
+        )
+        monkeypatch.setattr(
+            release,
+            "_acli_json_enriched",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("EPICs must not use per-issue enrichment")
+            ),
+        )
+
+        release.main(["--json", "epics", "2.1.0"])
+
+        data = json.loads(capsys.readouterr().out)["data"]
+        assert data["count"] == 2
+        assert data["epics"] == [
+            {
+                "key": "RHIDP-1",
+                "summary": "An epic",
+                "status": "In Progress",
+                "assignee": "Ada",
+            },
+            {
+                "key": "RHIDP-2",
+                "summary": "Unassigned epic",
+                "status": "New",
+                "assignee": "Unassigned",
+            },
+        ]
+
     def test_check_reports_partial_export_contract(self, tmp_path, monkeypatch, capsys):
         data = json.loads(json.dumps(SAMPLE_RICH_FILTER))
         data["richFilter"]["richQueues"] = [

--- a/tests/unit/test_release_cli.py
+++ b/tests/unit/test_release_cli.py
@@ -9,6 +9,7 @@ from urllib.parse import quote
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 _RELEASE_SCRIPTS = PROJECT_ROOT / "skills" / "rhdh-release" / "scripts"
+_NO_RICH_FILTER = PROJECT_ROOT / ".test-no-rich-filter.json"
 if str(_RELEASE_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_RELEASE_SCRIPTS))
 
@@ -25,7 +26,7 @@ import slack_templates  # noqa: E402
 class TestJqlLoadTemplates:
     def setup_method(self):
         jql._TEMPLATE_CACHE = None
-        jql._RICH_FILTER_PATH = None
+        jql._RICH_FILTER_PATH = _NO_RICH_FILTER
         rich_filter.reset_cache()
 
     def teardown_method(self):
@@ -414,6 +415,60 @@ class TestParseDate:
         assert release._parse_date("not a date") is None
 
 
+class TestExtractMilestoneDates:
+    @staticmethod
+    def _row(label, value):
+        value_node = (
+            {"type": "date", "attrs": {"timestamp": value}}
+            if value != "TBD"
+            else {"type": "text", "text": value}
+        )
+        return {
+            "type": "tableRow",
+            "content": [
+                {"type": "tableCell", "content": [{"type": "text", "text": label}]},
+                {"type": "tableCell", "content": [value_node]},
+            ],
+        }
+
+    def test_extracts_adf_date_nodes_by_milestone_row(self):
+        description = {
+            "type": "doc",
+            "content": [
+                {
+                    "type": "table",
+                    "content": [
+                        self._row("Feature Freeze", "1790035200000"),
+                        self._row("Code Freeze", "1791849600000"),
+                        self._row("Docs Input Freeze", "TBD"),
+                        self._row("Docs Freeze", "TBD"),
+                        self._row("RHDH 1.10 Go/No Go & Push", "1792972800000"),
+                        self._row("RHDH 1.10 GA announce", "1793145600000"),
+                    ],
+                }
+            ],
+        }
+
+        dates = release._extract_milestone_dates(description)
+
+        assert dates == {
+            "feature_freeze": "2026-09-22",
+            "code_freeze": "2026-10-13",
+            "doc_freeze": "TBD",
+            "go_no_go": "2026-10-26",
+            "ga_announce": "2026-10-28",
+        }
+
+    def test_supports_legacy_plain_text_descriptions(self):
+        dates = release._extract_milestone_dates(
+            "Feature Freeze: 2025-05-01\nCode Freeze 2025-05-15"
+        )
+
+        assert dates["feature_freeze"] == "2025-05-01"
+        assert dates["code_freeze"] == "2025-05-15"
+        assert dates["ga_announce"] == "TBD"
+
+
 class TestFindScheduleTab:
     def test_finds_current_year(self):
         from datetime import datetime
@@ -764,7 +819,7 @@ class TestJqlWithoutRichFilter:
         rich_filter.reset_cache()
 
     def test_only_11_templates_without_rich_filter(self):
-        jql.set_rich_filter_path(None)
+        jql.set_rich_filter_path(_NO_RICH_FILTER)
         templates = jql.load_templates()
         assert len(templates) == 11
 
@@ -774,14 +829,14 @@ class TestJqlWithoutRichFilter:
         assert len(templates) == 11
 
     def test_freeze_templates_missing_without_rich_filter(self):
-        jql.set_rich_filter_path(None)
+        jql.set_rich_filter_path(_NO_RICH_FILTER)
         templates = jql.load_templates()
         assert "feature_freeze_issues" not in templates
         assert "code_freeze_issues" not in templates
         assert "release_notes" not in templates
 
     def test_freeze_template_raises_keyerror(self):
-        jql.set_rich_filter_path(None)
+        jql.set_rich_filter_path(_NO_RICH_FILTER)
         try:
             jql.get_template("feature_freeze_issues")
             assert False, "Expected KeyError"
@@ -823,7 +878,7 @@ class TestRichFilterCliIntegration:
         assert result.stdout.strip() == str(rf_path)
 
     def test_missing_rich_filter_is_reported_without_traceback(self, monkeypatch, capsys):
-        jql.set_rich_filter_path(None)
+        jql.set_rich_filter_path(_NO_RICH_FILTER)
         monkeypatch.setattr(release, "_init_rich_filter", lambda: None)
 
         try:

--- a/tests/unit/test_skill_structure.py
+++ b/tests/unit/test_skill_structure.py
@@ -277,6 +277,7 @@ class TestReferenceStructure:
             "jira-reference.md",
             "jira-structure.md",
             "github-tips.md",
+            "private-data.md",
             "rhdh-repos.md",
             "versions.md",
         }


### PR DESCRIPTION
## Why

The release skill duplicated operational Jira logic in local Markdown JQL. That logic drifted from the **RHIDP Operational** Rich Filter used by release managers. This PR makes the exported Rich Filter the runtime source of truth wherever it has an authoritative equivalent, while keeping release versions dynamic and preserving clearly documented local queries where no equivalent exists.

## What changed

### Rich Filter integration

- discover the private-data repository through shared RHDH configuration, with `RHDH_RICH_FILTER_PATH` as an explicit override
- parse and validate the complete exported base filter, static filters, smart-filter clauses, rich queues, time series, custom ratios, dynamic fields, and Rich Views
- compose exported JQL with release/team scope using parentheses around the base filter and exported OR expressions
- fail with actionable diagnostics when a required named release filter or queue is renamed or missing; no copied-JQL fallback is used

### First-class release mappings

The release CLI now sources these behaviors from the export:

- Feature Freeze and Code Freeze, including Cloud ID-scoped team variants
- Post Code Freeze
- feature demos and Test Day
- Scrum Team Cloud IDs
- release-note lifecycle: unclassified, proposed, done, and text present
- complete operational base scope (excluding only `ORDER BY`)

The CLI retains local JQL for active-release discovery, generic open-work counts, blockers, EPICs, CVEs, feature subtasks, and recently added features because the export has no semantically equivalent named entry. The rationale is documented in `references/rich-filter-coverage.md`.

### New CLI behavior

```bash
python scripts/release.py --json check
python scripts/release.py --json notes 2.1.0
python scripts/release.py --json post-freeze 2.1.0
python scripts/release.py --json rich-filter inventory
python scripts/release.py --json rich-filter query static demo --version 2.1.0 --count
python scripts/release.py --json rich-filter query smart AI --group "Scrum Team" --version 2.1.0 --count
python scripts/release.py --json rich-filter query queue "RNs Proposed" --version 2.1.0 --count
python scripts/release.py --json rich-filter query time-series "Last week" --version 2.1.0 --count
python scripts/release.py --json rich-filter query ratio-numerator "1.10 Plan to Commit" --count
```

`rich-filter inventory` exposes all query-bearing entries and reports dynamic field/Rich View metadata without treating presentation configuration as executable JQL.

### Robustness and performance fixes

- `check` validates the required Rich Filter contract
- an absent `.jira-token` remains visible as an optional warning but no longer makes `all_pass` false when Jira connectivity succeeds
- missing `gog`, authentication, Rich Filter data, or required contract entries remain actionable warnings/failures
- milestone dates parse Jira ADF date nodes, timestamps, and legacy plain text
- EPIC reporting uses the fields already present in one `acli --json` search instead of making one enrichment request per issue
- workflow docs no longer recommend stale hardcoded fallback JQL for Rich Filter-owned behavior

## Intentional behavior change

The exported operational filters are broader than the old demo/Test Day templates. A live comparison for `2.1.0` on 2026-07-15 showed:

| Query | Old local JQL | Rich Filter composition |
|---|---:|---:|
| Feature demos | 31 | 34 |
| Test Day | 27 | 52 |

These differences are expected: the export is now authoritative rather than preserving the narrower `RHDHPlan/RHIDP + Feature + open` scope.

## Battle-test results

Tested end-to-end against live Jira, Google Sheets/Docs, and the configured private-data export:

- all 15 routed release workflows complete successfully
- all 20 composed release templates parse in live Jira for `2.1.0`
- all four freeze Slack commands generate complete messages with live dates, counts, Jira links, team Cloud IDs, leads, and release-note data
- dates and future schedule agree for the 2.1.0 milestones
- static, smart, queue, time-series, ratio-numerator, and ratio-denominator queries execute successfully
- inventory reads 24 static filters, 23 smart-filter groups / 93 clauses, 4 queues, 16 dynamic fields, 19 views, 5 time series, and 6 ratios
- the 382-issue EPIC workflow now completes with one Jira search in about 11 seconds instead of hundreds of enrichment calls
- `check` returns `all_pass: true` with the optional token warning preserved and no misleading setup steps

## Test plan

- [x] `uv run pytest` — 393 passed
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] complete, partial/renamed, and absent export fixtures
- [x] optional-warning readiness regression test
- [x] regression test proving EPIC reporting does not call enrichment
- [x] live Jira syntax/count checks for every release template and every exported query kind
- [x] all 15 routed workflows exercised with live data
