### PR TITLE
chore: improves the logic when generating...

### DIFF
--- a/skills/compute-plugin-package-overlay-cve-list/SKILL.md
+++ b/skills/compute-plugin-package-overlay-cve-list/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: compute-plugin-package-overlay-cve-list
 description: >-
-  Builds a deduped RHDH CVE Management CSV from GA plugin workspace changes in
+  Builds an RHDH CVE Management CSV from GA plugin workspace changes in
   rhdh-plugin-export-overlays since a version tag (patches, source.json, plugins-list).
-  Use for "CVE CSV", "workspace CVEs since tag", "collect overlay CVEs", "CVE management CSV",
+  One row per CVE × plugins-list package (multi-workspace CVEs expand). Use for "CVE CSV",
+  "workspace CVEs since tag", "collect overlay CVEs", "CVE management CSV",
   orchestrator/lightspeed CVE review, or plugin package overlay CVE list.
 ---
 
@@ -91,6 +92,7 @@ Never invent CVSS — only use the leading score from `customfield_10859` (or an
 - Overlays may lack version tags — `--since X.Y.Z` uses the tip-most branch commit mentioning that version (release message **or** `resolve X.Y.Z CVEs`), not an earlier release-message alone
 - CVE tracking is **GA-only** (`spec.support: generally-available`)
 - Skip test-only commits (`e2e-tests/`, `smoke-tests/`)
+- One CSV row per **CVE × plugins-list package** (Container = GA `dynamicArtifact` or `workspaces/<ws>/<pluginPath>`); multi-workspace CVEs expand
 - Enrich via Atlassian MCP after extract (`--apply-enrich`)
 - If no JIRA for a CVE, **JIRA Issue** column gets the overlays commit URL
 - Unchanged / prior-release backport CVEs → Resolution `Done <since>`, Status `Closed <since>` (e.g. `Done 1.10.2` / `Closed 1.10.2`); JIRA from introduce commit PR

--- a/skills/compute-plugin-package-overlay-cve-list/references/csv-format.md
+++ b/skills/compute-plugin-package-overlay-cve-list/references/csv-format.md
@@ -6,10 +6,10 @@ Header (exact):
 JIRA Issue,CVE,CVSS,Package Name,Container,Due Date,Resolution,Status
 ```
 
-- **One row per unique CVE ID**
+- **One row per CVE × affected plugin package** (not one row per CVE globally). If the same CVE lands in both `lightspeed` and `orchestrator`, emit separate rows for each workspace’s packages.
 - **JIRA Issue** may list multiple keys space-separated (e.g. `RHIDP-15801 RHIDP-15535`). If no JIRA is known for the CVE, put the overlays **commit URL** instead (`https://github.com/redhat-developer/rhdh-plugin-export-overlays/commit/<sha>`).
 - CVEs only listed in `cve-backports.yaml` context (not added in the commit), or landed in a `--since X.Y.Z` “resolve X.Y.Z CVEs” commit, are treated as **already fixed in that version**: Resolution=`Done X.Y.Z`, Status=`Closed X.Y.Z` (ignore when reviewing the nextz CVE list). JIRA/commit from blame/`git log -S` introduce history.
-- **Container**: prefer package container / `dynamicArtifact` image when known; else `workspaces/<name>/patches` (or `source.json` path when that was the hit)
+- **Container**: for each key in `workspaces/<ws>/plugins-list.yaml`, prefer that package’s GA `dynamicArtifact` image normalized to `quay.io/rhdh/<name>` (`rhdh/…` and `redhat-developer/rhdh-plugin-export-overlays/…` remapped); else `workspaces/<ws>/<pluginPath>`. If `plugins-list.yaml` is missing, fall back to `workspaces/<name>/patches` (or `source.json` / workspace root)
 - After extract (CLI): CVSS, Due Date, Resolution, Status empty until MCP enrich
 - With `--no-metadata`: skip agent MCP enrich; leave those columns empty
 - After `--apply-enrich`: fill from Atlassian MCP; CVSS = leading score from ProdSec `customfield_10859` (e.g. `7.5` from `7.5 CVSS:3.1/...`); do not invent scores

--- a/skills/compute-plugin-package-overlay-cve-list/references/sources.md
+++ b/skills/compute-plugin-package-overlay-cve-list/references/sources.md
@@ -33,7 +33,8 @@ Under each selected workspace:
 
 - 1 CVE + N JIRAs → all JIRAs on that CVE row
 - N CVEs + N JIRAs → index pair; agent may refine via MCP issue summaries; if ambiguous → both-to-both
-- Dedupe by CVE; merge JIRA lists
+- Dedupe by **CVE + Container**; merge JIRA lists for the same pair
+- Expand each workspace CVE hit across `plugins-list.yaml` package paths (Container column)
 
 ## `--since` resolution
 

--- a/skills/compute-plugin-package-overlay-cve-list/scripts/compute-plugin-package-overlay-cve-list.mjs
+++ b/skills/compute-plugin-package-overlay-cve-list/scripts/compute-plugin-package-overlay-cve-list.mjs
@@ -316,17 +316,26 @@ export function priorFixedLabels(since) {
   return { resolution: 'Done', status: 'Closed' };
 }
 
+/** Merge key: one CSV row per CVE × Container (workspace package path). */
+export function cveRowKey(row) {
+  const cve = String(row.cve || '').toUpperCase();
+  const container = String(row.container || '').trim();
+  const workspace = String(row.workspace || '').trim();
+  return `${cve}\0${container || workspace || '_'}`;
+}
+
 export function mergeCveRows(rows) {
   const map = new Map();
   for (const row of rows) {
-    const key = row.cve.toUpperCase();
+    const key = cveRowKey(row);
+    const cve = String(row.cve || '').toUpperCase();
     const existing = map.get(key);
     const priorFixed = Boolean(row.priorFixed);
     const priorIn = row.priorFixedIn || '';
     if (!existing) {
       const labels = priorFixed ? priorFixedLabels(priorIn) : null;
       map.set(key, {
-        cve: key,
+        cve,
         jiras: [...new Set(row.jiras || [])],
         package: row.package || '',
         container: row.container || '',
@@ -335,6 +344,7 @@ export function mergeCveRows(rows) {
         resolution: priorFixed ? labels.resolution : row.resolution || '',
         status: priorFixed ? labels.status : row.status || '',
         workspace: row.workspace || '',
+        pluginPath: row.pluginPath || '',
         pr: row.pr || null,
         commitSha: row.commitSha || '',
         priorFixed,
@@ -372,8 +382,13 @@ export function mergeCveRows(rows) {
     if (!existing.pr && row.pr) existing.pr = row.pr;
     if (!existing.commitSha && row.commitSha) existing.commitSha = row.commitSha;
     if (!existing.workspace && row.workspace) existing.workspace = row.workspace;
+    if (!existing.pluginPath && row.pluginPath) existing.pluginPath = row.pluginPath;
   }
-  return [...map.values()].sort((a, b) => a.cve.localeCompare(b.cve));
+  return [...map.values()].sort((a, b) => {
+    const c = a.cve.localeCompare(b.cve);
+    if (c !== 0) return c;
+    return String(a.container || '').localeCompare(String(b.container || ''));
+  });
 }
 
 export function csvEscape(val) {
@@ -400,7 +415,7 @@ export function rowsToCsv(rows) {
         csvEscape(r.cve),
         csvEscape(r.cvss || ''),
         csvEscape(r.package || ''),
-        csvEscape(r.container || ''),
+        csvEscape(normalizeContainerRef(r.container || '')),
         csvEscape(r.dueDate || ''),
         csvEscape(r.resolution || ''),
         csvEscape(r.status || ''),
@@ -685,12 +700,130 @@ export function containerFromMetadata(repoRoot, workspace) {
     if (!/\.ya?ml$/.test(f)) continue;
     const text = fs.readFileSync(path.join(metaDir, f), 'utf8');
     if (!/support:\s*generally-available\b/.test(text)) continue;
-    const m = text.match(
-      /dynamicArtifact:\s*["']?oci:\/\/(?:registry\.access\.redhat\.com|quay\.io)\/([^\s"'@]+)/,
-    );
-    if (m) return m[1].replace(/@sha256:.*/, '');
+    const img = normalizeContainerRef(parseDynamicArtifactImage(text));
+    if (img) return img;
   }
   return '';
+}
+
+/** Plugin package paths from workspaces/<ws>/plugins-list.yaml keys. */
+export function parsePluginsListYaml(text) {
+  const paths = [];
+  for (const line of String(text || '').split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const m = trimmed.match(/^([^:]+):\s*(.*)$/);
+    if (!m) continue;
+    const p = m[1].trim().replace(/\/$/, '');
+    if (!p || p.includes(' ')) continue;
+    paths.push(p);
+  }
+  return paths;
+}
+
+/** Strip oci://host/path:tag@digest!suffix → path without host. */
+export function parseDynamicArtifactImage(text) {
+  const m = String(text || '').match(/dynamicArtifact:\s*["']?oci:\/\/([^\s"']+)/i);
+  if (!m) return '';
+  let ref = m[1];
+  ref = ref.replace(/!.*$/, '');
+  ref = ref.replace(/@sha256:[a-f0-9]+$/i, '');
+  // Drop image tag (last :segment that is not a port-only host quirk — path tags)
+  const slash = ref.indexOf('/');
+  if (slash < 0) return ref;
+  const host = ref.slice(0, slash);
+  let imgPath = ref.slice(slash + 1);
+  imgPath = imgPath.replace(/:[^/]+$/, '');
+  return imgPath || host;
+}
+
+/**
+ * Normalize Container refs for CVE management CSV:
+ *   redhat-developer/rhdh-plugin-export-overlays/X → quay.io/rhdh/X
+ *   rhdh/X → quay.io/rhdh/X
+ * Leaves workspaces/... paths and already-qualified quay.io/rhdh/ refs alone.
+ */
+export function normalizeContainerRef(container) {
+  const s = String(container || '').trim();
+  if (!s) return '';
+  const overlaysPrefix = 'redhat-developer/rhdh-plugin-export-overlays/';
+  if (s.startsWith(overlaysPrefix)) {
+    return `quay.io/rhdh/${s.slice(overlaysPrefix.length)}`;
+  }
+  if (s.startsWith('rhdh/') && !s.startsWith('rhdh/rhdh/')) {
+    return `quay.io/${s}`;
+  }
+  return s;
+}
+
+function escapeRegExp(s) {
+  return String(s).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** True when metadata text refers to this exact plugins-list path (not a prefix sibling). */
+export function metadataMatchesPluginPath(text, workspace, pluginPath) {
+  const re = new RegExp(
+    `/workspaces/${escapeRegExp(workspace)}/${escapeRegExp(pluginPath)}(?:["'\\s?#]|$)`,
+  );
+  return re.test(String(text || ''));
+}
+
+/**
+ * Container hints for a workspace CVE hit: one entry per plugins-list package.
+ * Prefers GA dynamicArtifact image; else workspaces/<ws>/<pluginPath>;
+ * falls back to patches/source.json/workspace when plugins-list is missing.
+ */
+export function containerHintsForWorkspace(repoRoot, workspace, files = []) {
+  const listFile = path.join(repoRoot, 'workspaces', workspace, 'plugins-list.yaml');
+  let pluginPaths = [];
+  if (fs.existsSync(listFile)) {
+    pluginPaths = parsePluginsListYaml(fs.readFileSync(listFile, 'utf8'));
+  }
+  if (!pluginPaths.length) {
+    return [
+      {
+        container: normalizeContainerRef(
+          primaryContainerHint(repoRoot, workspace, files),
+        ),
+        pluginPath: '',
+      },
+    ];
+  }
+  const metaDir = path.join(repoRoot, 'workspaces', workspace, 'metadata');
+  const metaTexts = [];
+  if (fs.existsSync(metaDir)) {
+    for (const f of fs.readdirSync(metaDir)) {
+      if (!/\.ya?ml$/.test(f)) continue;
+      metaTexts.push(fs.readFileSync(path.join(metaDir, f), 'utf8'));
+    }
+  }
+  return pluginPaths.map((pluginPath) => {
+    let image = '';
+    for (const text of metaTexts) {
+      if (!metadataMatchesPluginPath(text, workspace, pluginPath)) continue;
+      if (!/support:\s*generally-available\b/.test(text)) continue;
+      image = parseDynamicArtifactImage(text);
+      if (image) break;
+    }
+    return {
+      container: normalizeContainerRef(
+        image || `workspaces/${workspace}/${pluginPath}`,
+      ),
+      pluginPath,
+    };
+  });
+}
+
+/** Expand a base CVE row into one row per workspace package Container. */
+export function expandRowAcrossContainers(repoRoot, baseRow, files = []) {
+  const ws = baseRow.workspace;
+  if (!ws) return [{ ...baseRow }];
+  const hints = containerHintsForWorkspace(repoRoot, ws, files);
+  return hints.map((h) => ({
+    ...baseRow,
+    container: normalizeContainerRef(h.container),
+    pluginPath: h.pluginPath || baseRow.pluginPath || '',
+  }));
 }
 
 function resolveBranch(args, repo) {
@@ -1066,42 +1199,45 @@ async function main() {
     const prMatch = commit.subject.match(PR_RE);
     const prNumber = prMatch ? Number(prMatch[1]) : null;
 
+    // CVEs newly added to backports in this commit, per workspace
+    const addedByWs = new Map();
     for (const ws of touchedWs) {
       const wsFiles = commit.files.filter((f) => f.startsWith(`workspaces/${ws}/`));
       if (isTestOnlyPaths(wsFiles, ws)) continue;
 
-      const container = primaryContainerHint(repo, ws, wsFiles);
-
-      // cve-backports.yaml: only CVEs added in this commit's diff (not unchanged context)
       const backportPath = `workspaces/${ws}/patches/cve-backports.yaml`;
-      if (wsFiles.some((f) => f === backportPath || f.endsWith('/cve-backports.yaml'))) {
-        const yamlText = showFileAt(repo, commit.sha, backportPath);
-        const added = cvesAddedInCommitDiff(diffFileAtCommit(repo, commit.sha, backportPath));
-        const priorReleaseBatch = isPriorReleaseCveCommit(commit.subject, args.since);
-        if (yamlText && added.size) {
-          const pkgByCve = new Map();
-          for (const entry of parseCveBackportsYaml(yamlText)) {
-            for (const cve of entry.cve_ids) {
-              pkgByCve.set(cve.toUpperCase(), entry.package);
-            }
-          }
-          for (const cve of added) {
-            let row = {
-              cve,
-              jiras: [],
-              package: pkgByCve.get(cve) || '',
-              container,
-              workspace: ws,
-              pr: prNumber,
-              commitSha: commit.sha,
-              priorFixed: false,
-            };
-            if (priorReleaseBatch) {
-              const jiras = jirasFromCommit(repo, commit.sha, args.jiraProjects);
-              row = markPriorFixed({ ...row, jiras }, args.since);
-            }
-            collected.push(row);
-          }
+      if (!wsFiles.some((f) => f === backportPath || f.endsWith('/cve-backports.yaml'))) {
+        continue;
+      }
+      const yamlText = showFileAt(repo, commit.sha, backportPath);
+      const added = cvesAddedInCommitDiff(diffFileAtCommit(repo, commit.sha, backportPath));
+      const priorReleaseBatch = isPriorReleaseCveCommit(commit.subject, args.since);
+      if (!yamlText || !added.size) continue;
+
+      addedByWs.set(ws, added);
+      const pkgByCve = new Map();
+      for (const entry of parseCveBackportsYaml(yamlText)) {
+        for (const cve of entry.cve_ids) {
+          pkgByCve.set(cve.toUpperCase(), entry.package);
+        }
+      }
+      for (const cve of added) {
+        let row = {
+          cve,
+          jiras: [],
+          package: pkgByCve.get(cve) || '',
+          container: '',
+          workspace: ws,
+          pr: prNumber,
+          commitSha: commit.sha,
+          priorFixed: false,
+        };
+        if (priorReleaseBatch) {
+          const jiras = jirasFromCommit(repo, commit.sha, args.jiraProjects);
+          row = markPriorFixed({ ...row, jiras }, args.since);
+        }
+        for (const expanded of expandRowAcrossContainers(repo, row, wsFiles)) {
+          collected.push(expanded);
         }
       }
     }
@@ -1116,61 +1252,57 @@ async function main() {
           pairLineAssociations(pr.title || '', args.jiraProjects),
         );
 
-        const ws =
-          [...touchedWs][0] ||
-          (pr.title.match(/\[([a-z0-9-]+)\]/i) || [])[1] ||
-          '';
-        const container = ws
-          ? primaryContainerHint(repo, ws, commit.files)
-          : '';
-
-        // CVEs newly added to backports in this commit (any touched workspace)
-        const addedHere = new Set();
-        for (const tws of touchedWs) {
-          const bp = `workspaces/${tws}/patches/cve-backports.yaml`;
-          if (commit.files.includes(bp)) {
-            for (const c of cvesAddedInCommitDiff(diffFileAtCommit(repo, commit.sha, bp))) {
-              addedHere.add(c);
-            }
-          }
-        }
+        const titleWs = (pr.title.match(/\[([a-z0-9-]+)\]/i) || [])[1] || '';
+        const assocWorkspaces = [...touchedWs].filter((ws) => {
+          const wsFiles = commit.files.filter((f) =>
+            f.startsWith(`workspaces/${ws}/`),
+          );
+          return !isTestOnlyPaths(wsFiles, ws);
+        });
+        if (!assocWorkspaces.length && titleWs) assocWorkspaces.push(titleWs);
 
         for (const a of assocs) {
           const cve = a.cve.toUpperCase();
-          let row = {
-            cve,
-            jiras: a.jiras || [],
-            package: a.package || '',
-            container,
-            workspace: ws,
-            pr: prNumber,
-            commitSha: commit.sha,
-            priorFixed: false,
-          };
-          // PR mentions CVE but backport entry was not added in this commit → prior fix
-          if (!addedHere.has(cve)) {
-            const bp = ws
-              ? `workspaces/${ws}/patches/cve-backports.yaml`
-              : null;
-            const intro = bp ? findCveIntroduceCommit(repo, cve, bp) : null;
-            if (intro && intro !== commit.sha) {
-              const jiras = [
-                ...new Set([
-                  ...(row.jiras || []),
-                  ...jirasFromCommit(repo, intro, args.jiraProjects),
-                ]),
-              ];
-              row = markPriorFixed(
-                {
-                  ...row,
-                  commitSha: intro,
-                  jiras,
-                },
-                args.since,
-              );
+          for (const ws of assocWorkspaces) {
+            const wsFiles = commit.files.filter((f) =>
+              f.startsWith(`workspaces/${ws}/`),
+            );
+            const addedHere = addedByWs.get(ws) || new Set();
+            let row = {
+              cve,
+              jiras: a.jiras || [],
+              package: a.package || '',
+              container: '',
+              workspace: ws,
+              pr: prNumber,
+              commitSha: commit.sha,
+              priorFixed: false,
+            };
+            // PR mentions CVE but backport entry was not added in this commit → prior fix
+            if (!addedHere.has(cve)) {
+              const bp = `workspaces/${ws}/patches/cve-backports.yaml`;
+              const intro = findCveIntroduceCommit(repo, cve, bp);
+              if (intro && intro !== commit.sha) {
+                const jiras = [
+                  ...new Set([
+                    ...(row.jiras || []),
+                    ...jirasFromCommit(repo, intro, args.jiraProjects),
+                  ]),
+                ];
+                row = markPriorFixed(
+                  {
+                    ...row,
+                    commitSha: intro,
+                    jiras,
+                  },
+                  args.since,
+                );
+              }
+            }
+            for (const expanded of expandRowAcrossContainers(repo, row, wsFiles)) {
+              collected.push(expanded);
             }
           }
-          collected.push(row);
         }
       }
     }

--- a/skills/compute-plugin-package-overlay-cve-list/tests/compute-plugin-package-overlay-cve-list.test.mjs
+++ b/skills/compute-plugin-package-overlay-cve-list/tests/compute-plugin-package-overlay-cve-list.test.mjs
@@ -28,6 +28,12 @@ import {
   jqlForMcpSearch,
   DEFAULT_JQL,
   workspaceHasGaSupport,
+  parsePluginsListYaml,
+  parseDynamicArtifactImage,
+  normalizeContainerRef,
+  metadataMatchesPluginPath,
+  containerHintsForWorkspace,
+  expandRowAcrossContainers,
 } from '../scripts/compute-plugin-package-overlay-cve-list.mjs';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -124,14 +130,141 @@ backports:
 });
 
 describe('mergeCveRows', () => {
-  it('dedupes CVE and merges jiras', () => {
+  it('dedupes same CVE+container and merges jiras', () => {
     const rows = mergeCveRows([
-      { cve: 'CVE-2026-1', jiras: ['RHIDP-1'], package: 'a' },
-      { cve: 'CVE-2026-1', jiras: ['RHIDP-2'], package: '' },
+      {
+        cve: 'CVE-2026-1',
+        jiras: ['RHIDP-1'],
+        package: 'a',
+        container: 'workspaces/orchestrator/plugins/orchestrator',
+        workspace: 'orchestrator',
+      },
+      {
+        cve: 'CVE-2026-1',
+        jiras: ['RHIDP-2'],
+        package: '',
+        container: 'workspaces/orchestrator/plugins/orchestrator',
+        workspace: 'orchestrator',
+      },
     ]);
     assert.equal(rows.length, 1);
     assert.deepEqual(rows[0].jiras, ['RHIDP-1', 'RHIDP-2']);
     assert.equal(rows[0].package, 'a');
+  });
+
+  it('keeps separate rows for the same CVE in different containers', () => {
+    const rows = mergeCveRows([
+      {
+        cve: 'CVE-2026-1',
+        jiras: ['RHIDP-1'],
+        container: 'workspaces/orchestrator/plugins/orchestrator',
+        workspace: 'orchestrator',
+      },
+      {
+        cve: 'CVE-2026-1',
+        jiras: ['RHIDP-1'],
+        container: 'workspaces/lightspeed/plugins/lightspeed',
+        workspace: 'lightspeed',
+      },
+    ]);
+    assert.equal(rows.length, 2);
+  });
+});
+
+describe('plugins-list / container mapping', () => {
+  it('parses plugins-list keys', () => {
+    const paths = parsePluginsListYaml(`
+plugins/orchestrator:
+plugins/orchestrator-backend: --embed-package @scope/common
+# comment
+`);
+    assert.deepEqual(paths, [
+      'plugins/orchestrator',
+      'plugins/orchestrator-backend',
+    ]);
+  });
+
+  it('parses dynamicArtifact across registries', () => {
+    assert.equal(
+      parseDynamicArtifactImage(
+        'dynamicArtifact: "oci://registry.access.redhat.com/rhdh/foo@sha256:abc"',
+      ),
+      'rhdh/foo',
+    );
+    assert.equal(
+      parseDynamicArtifactImage(
+        'dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed:bs_1.49.4__2.8.7!suffix',
+      ),
+      'redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed',
+    );
+  });
+
+  it('normalizes Container refs to quay.io/rhdh/', () => {
+    assert.equal(
+      normalizeContainerRef(
+        'redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed',
+      ),
+      'quay.io/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed',
+    );
+    assert.equal(
+      normalizeContainerRef('rhdh/red-hat-developer-hub-backstage-plugin-orchestrator'),
+      'quay.io/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator',
+    );
+    assert.equal(
+      normalizeContainerRef(
+        'quay.io/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator',
+      ),
+      'quay.io/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator',
+    );
+    assert.equal(
+      normalizeContainerRef('workspaces/orchestrator/plugins/orchestrator'),
+      'workspaces/orchestrator/plugins/orchestrator',
+    );
+  });
+
+  it('matches exact plugin path not prefix siblings', () => {
+    const orch =
+      'backstage.io/source-location: url:https://github.com/x/tree/main/workspaces/orchestrator/plugins/orchestrator\n';
+    const orchBackend =
+      'backstage.io/source-location: url:https://github.com/x/tree/main/workspaces/orchestrator/plugins/orchestrator-backend\n';
+    assert.equal(
+      metadataMatchesPluginPath(orch, 'orchestrator', 'plugins/orchestrator'),
+      true,
+    );
+    assert.equal(
+      metadataMatchesPluginPath(
+        orchBackend,
+        'orchestrator',
+        'plugins/orchestrator',
+      ),
+      false,
+    );
+  });
+
+  it('expands a row across plugins-list packages', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cve-ws-'));
+    const ws = path.join(dir, 'workspaces', 'demo');
+    fs.mkdirSync(path.join(ws, 'metadata'), { recursive: true });
+    fs.writeFileSync(
+      path.join(ws, 'plugins-list.yaml'),
+      'plugins/a:\nplugins/b:\n',
+    );
+    fs.writeFileSync(
+      path.join(ws, 'metadata', 'a.yaml'),
+      `spec:\n  support: generally-available\n` +
+        `  dynamicArtifact: oci://registry.access.redhat.com/rhdh/pkg-a@sha256:1\n` +
+        `annotations:\n  backstage.io/source-location: url:https://x/workspaces/demo/plugins/a\n`,
+    );
+    const expanded = expandRowAcrossContainers(dir, {
+      cve: 'CVE-2026-1',
+      workspace: 'demo',
+      package: 'brace-expansion',
+    });
+    assert.equal(expanded.length, 2);
+    assert.equal(expanded[0].container, 'quay.io/rhdh/pkg-a');
+    assert.equal(expanded[1].container, 'workspaces/demo/plugins/b');
+    const hints = containerHintsForWorkspace(dir, 'demo');
+    assert.equal(hints.length, 2);
   });
 });
 


### PR DESCRIPTION
### What does this PR do?

chore: improves the logic when generating the CSV list of CVEs such that for each affected package and CVE, we get a row in the table ([RHIDP-15396](https://redhat.atlassian.net/browse/RHIDP-15396), [RHIDP-15389](https://redhat.atlassian.net/browse/RHIDP-15389))

Generated-by: cursor

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
Fetch PR  sources, run the skill using the "--since 1.10.2" qualifier. See what it spits out.

Note that Kim had to manually cleanup the CSV results in https://docs.google.com/spreadsheets/d/1JZVTc03wirx-bTpjn3muWed8cGyFTRTNe6x3Gr02hys/edit?gid=256141912#gid=256141912 so this generation tool isn't QUITE perfect yet. 

Still need better logic for if/when the specific PACKAGES are affected by the CVE fix, by looking at source.json and seeing what changes were done in rhdh-plugins or bcp or b/b repos.

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.