### PR TITLE
feat(skill): add rhdh-deploy-local-plugin for testing dynamic plugins on cluster

### DIFF
--- a/skills/rhdh-deploy-local-plugin/SKILL.md
+++ b/skills/rhdh-deploy-local-plugin/SKILL.md
@@ -36,10 +36,18 @@ Always use `@red-hat-developer-hub/cli` for export and OCI packaging. The CLI ha
 - Dynamic plugin export (`plugin export` → creates `dist-dynamic/`)
 - OCI image creation with correct directory structure (`plugin package --tag`)
 - Automatic `io.backstage.dynamic-packages` annotation
-- Prints the `dynamic-plugins.yaml` entry to use on the cluster
 
 Do NOT manually create Containerfiles, generate annotations, or call `podman build` directly.
 Docs: https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.9/html/installing_and_viewing_plugins_in_red_hat_developer_hub/assembly-third-party-plugins
+</principle>
+
+<principle name="oci_uri_format">
+The `dynamic-plugins.yaml` entry format is a plain OCI URI **without** any `!plugin-name` suffix:
+
+**Correct:** `oci://ghcr.io/user/repo/red-hat-developer-hub-backstage-plugin-quickstart:tag`
+**Wrong:**  `oci://ghcr.io/user/repo/backstage-plugin-quickstart:tag!red-hat-developer-hub-backstage-plugin-quickstart`
+
+The `plugin package` CLI may print an example with the `!` fragment selector — **ignore it**. The current RHDH format does not use this suffix. The image name in the OCI path must match the official overlay naming convention: `<scope>-<package-name>` (e.g., `@red-hat-developer-hub/backstage-plugin-quickstart` → `red-hat-developer-hub-backstage-plugin-quickstart`).
 </principle>
 
 </essential_principles>
@@ -113,14 +121,15 @@ Identify what to deploy. Gather from user or infer from current working director
 | `GHCR_USER` | From `gh api user -q .login` |
 
 Derive from plugin's `package.json`:
-- `PLUGIN_SHORT` — package name without scope and `-dynamic` suffix
+- `PLUGIN_SHORT` — full image name matching overlay convention: `@scope/name` → `scope-name` (with `-dynamic` suffix stripped)
 - `VERSION` — from `version` field
 - `TAG` — pattern: `bs_<backstage-version>__<plugin-version>-test`
 
 ```bash
 GHCR_USER=$(gh api user -q .login)
 cd workspaces/${WORKSPACE}/plugins/${PLUGIN}
-PLUGIN_SHORT=$(node -p "require('./package.json').name.replace(/@[^/]+\//, '').replace(/-dynamic$/, '')")
+# Convert scoped name to overlay image name: @red-hat-developer-hub/backstage-plugin-foo → red-hat-developer-hub-backstage-plugin-foo
+PLUGIN_SHORT=$(node -p "require('./package.json').name.replace('@','').replace('/','-').replace(/-dynamic$/, '')")
 VERSION=$(node -p "require('./package.json').version")
 BS_VERSION=$(node -p "require('./package.json').backstage?.supportedVersions || require('../../../backstage.json')?.version || 'unknown'")
 TAG="bs_${BS_VERSION}__${VERSION}-test"
@@ -192,13 +201,37 @@ podman push ghcr.io/${GHCR_USER}/rhdh-plugin-export-overlays/${PLUGIN_SHORT}:${T
  Docs: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry
 ```
 
-**After successful push:**
+**After successful push — ensure GHCR package is public:**
+
+GHCR packages default to **private** on first push. A private image will cause `skopeo inspect` / `unauthorized` errors when the cluster tries to pull it. Make the package public via the GitHub API:
+
+```bash
+echo "  Ensuring GHCR package is public..."
+gh api --method PATCH /user/packages/container/rhdh-plugin-export-overlays%2F${PLUGIN_SHORT} \
+  -f visibility=public 2>&1
+
+if [ $? -eq 0 ]; then
+  echo " [PASS]  GHCR package is public"
+else
+  echo " [FAIL]  Could not set package visibility to public"
+  echo " Fix: Go to https://github.com/users/${GHCR_USER}/packages/container/package/rhdh-plugin-export-overlays%2F${PLUGIN_SHORT}"
+  echo "       → Package settings → Change visibility → Public"
+  echo " Then retry the deploy step."
+  exit 1
+fi
 ```
-echo ""
-echo " [WARN]  If this is the FIRST push for this package, make it PUBLIC:"
-echo "         https://github.com/users/${GHCR_USER}/packages/container/package/rhdh-plugin-export-overlays%2F${PLUGIN_SHORT}"
-echo "         → Package settings → Change visibility → Public"
-echo ""
+
+**Validation:** Verify the image is publicly accessible before proceeding to deploy:
+
+```bash
+podman pull ghcr.io/${GHCR_USER}/rhdh-plugin-export-overlays/${PLUGIN_SHORT}:${TAG}
+if [ $? -eq 0 ]; then
+  echo " [PASS]  Image is publicly pullable"
+else
+  echo " [FAIL]  Image pull failed — package may still be private"
+  echo " Fix: https://github.com/users/${GHCR_USER}/packages/container/package/rhdh-plugin-export-overlays%2F${PLUGIN_SHORT}"
+  exit 1
+fi
 ```
 
 ---

--- a/skills/rhdh-deploy-local-plugin/SKILL.md
+++ b/skills/rhdh-deploy-local-plugin/SKILL.md
@@ -2,9 +2,9 @@
 name: rhdh-deploy-local-plugin
 description: >-
   Build, package, and deploy a local RHDH/BCP plugin as an OCI image to an
-  OpenShift cluster for testing. Handles GHCR auth, OCI annotation generation,
-  image build, push, ConfigMap update, and pod rollout. Use when the user asks
-  to "test on cluster", "deploy plugin to cluster", "build OCI image",
+  OpenShift cluster for testing. Uses rhdh-cli for export and packaging,
+  handles GHCR auth, push, ConfigMap update, and pod rollout. Use when the
+  user asks to "test on cluster", "deploy plugin to cluster", "build OCI image",
   "push plugin to GHCR", "verify dynamic plugin on OpenShift",
   "test my changes on cluster", or "deploy local changes".
 ---
@@ -31,16 +31,15 @@ This applies to ALL steps including Step 0. Run the echo command in the terminal
 If any step fails validation, STOP immediately with a clear error message and documentation link. Do NOT proceed to the next step. The user must fix the issue before continuing.
 </principle>
 
-<principle name="directory_layout">
-The OCI image must contain an extracted directory — NOT a `.tgz` archive.
-Structure: `/<plugin-short-name>/package.json`, `/<plugin-short-name>/dist/`, etc.
-Violating this causes: `ENOENT: no such file or directory, open '.../package.json'`
-</principle>
+<principle name="use_rhdh_cli">
+Always use `@red-hat-developer-hub/cli` for export and OCI packaging. The CLI handles:
+- Dynamic plugin export (`plugin export` → creates `dist-dynamic/`)
+- OCI image creation with correct directory structure (`plugin package --tag`)
+- Automatic `io.backstage.dynamic-packages` annotation
+- Prints the `dynamic-plugins.yaml` entry to use on the cluster
 
-<principle name="annotation_mandatory">
-Every OCI image must carry the `io.backstage.dynamic-packages` annotation (base64-encoded JSON).
-Without it: `InstallException: No plugins found in OCI image`.
-Always use `--no-cache` to ensure the annotation is applied (podman caching can silently skip it).
+Do NOT manually create Containerfiles, generate annotations, or call `podman build` directly.
+Docs: https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.9/html/installing_and_viewing_plugins_in_red_hat_developer_hub/assembly-third-party-plugins
 </principle>
 
 </essential_principles>
@@ -61,7 +60,6 @@ Verify all tools are present. Print a status table using `[PASS]` / `[FAIL]` / `
 | `oc` | `oc version --client` | https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html |
 | `gh` | `gh --version` | https://cli.github.com/manual/installation |
 | `npx` | `npx --version` | https://nodejs.org/en/download |
-| `python3` | `python3 --version` | https://www.python.org/downloads/ |
 | `yarn` | `yarn --version` | https://yarnpkg.com/getting-started/install |
 
 ### Must-have auth checks
@@ -85,12 +83,11 @@ Verify all tools are present. Print a status table using `[PASS]` / `[FAIL]` / `
  [PASS]  oc — v4.17.0
  [PASS]  gh — v2.70.0
  [PASS]  npx — v10.9.4
- [PASS]  python3 — v3.14.3
  [PASS]  yarn — v4.9.1
  [PASS]  gh auth — authenticated as its-mitesh-kumar
  [PASS]  write:packages — scope present
  [PASS]  GHCR login — active
- [WARN]  oc cluster — not logged in (will need login in Step 6)
+ [WARN]  oc cluster — not logged in (will need login in Step 4)
 ```
 
 **If ANY must-have check fails:** Print the fix command, documentation link, and STOP.
@@ -113,12 +110,27 @@ Identify what to deploy. Gather from user or infer from current working director
 | `PLUGIN` | Directory name under `plugins/` (infer from cwd or ask) |
 | `NAMESPACE` | Namespace where RHDH runs on the cluster (ask user) |
 | `CLUSTER_API` | Cluster API URL (ask if `oc whoami` fails) |
+| `GHCR_USER` | From `gh api user -q .login` |
 
-Auto-derived variables (resolved later in Step 3):
-- `GHCR_USER` — from `gh api user -q .login`
-- `PLUGIN_SHORT` — from `dist-dynamic/package.json` (name without scope and `-dynamic`)
-- `VERSION` — from `dist-dynamic/package.json`
+Derive from plugin's `package.json`:
+- `PLUGIN_SHORT` — package name without scope and `-dynamic` suffix
+- `VERSION` — from `version` field
 - `TAG` — pattern: `bs_<backstage-version>__<plugin-version>-test`
+
+```bash
+GHCR_USER=$(gh api user -q .login)
+cd workspaces/${WORKSPACE}/plugins/${PLUGIN}
+PLUGIN_SHORT=$(node -p "require('./package.json').name.replace(/@[^/]+\//, '').replace(/-dynamic$/, '')")
+VERSION=$(node -p "require('./package.json').version")
+BS_VERSION=$(node -p "require('./package.json').backstage?.supportedVersions || require('../../../backstage.json')?.version || 'unknown'")
+TAG="bs_${BS_VERSION}__${VERSION}-test"
+
+echo "  Plugin: ${PLUGIN_SHORT}"
+echo "  Version: ${VERSION}"
+echo "  Tag: ${TAG}"
+echo "  GHCR user: ${GHCR_USER}"
+echo "  Image: ghcr.io/${GHCR_USER}/rhdh-plugin-export-overlays/${PLUGIN_SHORT}:${TAG}"
+```
 
 **Wait for user response if workspace/namespace are not clear.**
 
@@ -126,137 +138,44 @@ Auto-derived variables (resolved later in Step 3):
 
 ---
 
-## Step 2 — Build & Export
+## Step 2 — Build, Export & Package
 
 ```
-echo "================ Step 2 — Build & Export ==========="
+echo "================ Step 2 — Build, Export & Package ==========="
 ```
 
 ```bash
-cd workspaces/${WORKSPACE}
 echo "  Running yarn tsc..."
 yarn tsc
 
-cd plugins/${PLUGIN}
 echo "  Running yarn build..."
 yarn build
 
 echo "  Exporting as dynamic plugin..."
-npx @red-hat-developer-hub/cli plugin export
+npx @red-hat-developer-hub/cli@latest plugin export
+
+echo "  Packaging as OCI image..."
+npx @red-hat-developer-hub/cli@latest plugin package \
+  --tag ghcr.io/${GHCR_USER}/rhdh-plugin-export-overlays/${PLUGIN_SHORT}:${TAG}
 ```
 
-**Validation:** Check output for `detected backstage feature:` lines, e.g.:
-```
-detected backstage feature: ./alpha => @backstage/FrontendPlugin
-detected backstage feature: ./<name>-translations-module => @backstage/FrontendModule
-```
+**Validation:** The `plugin package` command should:
+1. Print `detected backstage feature:` lines (e.g., `./alpha => @backstage/FrontendPlugin`)
+2. Print the `dynamic-plugins.yaml` entry to use on the cluster
+3. Exit with code 0
 
-**If no features detected:** STOP — the plugin's `package.json` is missing `exports` entries or the plugin does not create Backstage features. See `references/oci-structure.md` for the expected package.json structure.
+**If `plugin export` fails:** Check `yarn build` output for TypeScript errors. Run `yarn tsc` separately to diagnose.
+
+**If `plugin package` fails:**
+- Container tool not found: add `--container-tool docker` or ensure `podman` is on PATH
+- Permission denied: check container runtime is running (`podman machine start` on macOS)
 
 ---
 
-## Step 3 — Generate OCI Annotation
+## Step 3 — Push to GHCR
 
 ```
-echo "================ Step 3 — Generate OCI Annotation ==========="
-```
-
-```bash
-cd dist-dynamic
-
-PLUGIN_SHORT=$(python3 -c "
-import json
-pkg = json.load(open('package.json'))
-print(pkg['name'].replace('@red-hat-developer-hub/', '').replace('@backstage-community/', '').replace('-dynamic', ''))
-")
-VERSION=$(python3 -c "import json; print(json.load(open('package.json'))['version'])")
-BS_VERSION=$(python3 -c "import json; print(json.load(open('package.json')).get('backstage',{}).get('supported-versions','unknown'))")
-TAG="bs_${BS_VERSION}__${VERSION}-test"
-GHCR_USER=$(gh api user -q .login)
-
-echo "  Plugin short name: ${PLUGIN_SHORT}"
-echo "  Version: ${VERSION}"
-echo "  Backstage version: ${BS_VERSION}"
-echo "  Tag: ${TAG}"
-echo "  GHCR user: ${GHCR_USER}"
-
-ANNOTATION=$(python3 -c "
-import json, base64
-pkg = json.load(open('package.json'))
-short_name = pkg['name'].replace('@red-hat-developer-hub/', '').replace('@backstage-community/', '').replace('-dynamic', '')
-annotation = [{short_name: {
-    'name': pkg['name'],
-    'version': pkg['version'],
-    'backstage': pkg.get('backstage', {}),
-    'repository': pkg.get('repository', {}),
-    'license': pkg.get('license', 'Apache-2.0')
-}}]
-print(base64.b64encode(json.dumps(annotation).encode()).decode())
-")
-
-echo "  Annotation generated (${#ANNOTATION} chars)"
-```
-
-**Validation:** `ANNOTATION` must be non-empty. If empty, the `package.json` is malformed — check `backstage.features` field exists.
-
----
-
-## Step 4 — Build OCI Image
-
-```
-echo "================ Step 4 — Build OCI Image ==========="
-```
-
-```bash
-echo -e "Containerfile\n.dockerignore" > .dockerignore
-
-cat <<EOF > Containerfile
-FROM scratch
-COPY --chmod=755 . /${PLUGIN_SHORT}/
-EOF
-
-echo "  Building image: ghcr.io/${GHCR_USER}/rhdh-plugin-export-overlays/${PLUGIN_SHORT}:${TAG}"
-
-podman build --no-cache --platform linux/amd64 \
-  --annotation "io.backstage.dynamic-packages=${ANNOTATION}" \
-  -t ghcr.io/${GHCR_USER}/rhdh-plugin-export-overlays/${PLUGIN_SHORT}:${TAG} \
-  -f Containerfile .
-```
-
-**Validation:** Exit code 0 and output contains `Successfully tagged`.
-
----
-
-## Step 5 — Verify Image
-
-```
-echo "================ Step 5 — Verify Image ==========="
-```
-
-```bash
-podman inspect ghcr.io/${GHCR_USER}/rhdh-plugin-export-overlays/${PLUGIN_SHORT}:${TAG} | \
-  python3 -c "
-import json, sys, base64
-d = json.load(sys.stdin)
-ann = d[0].get('Annotations', {}).get('io.backstage.dynamic-packages', '')
-if not ann:
-    print(' [FAIL]  io.backstage.dynamic-packages annotation MISSING')
-    sys.exit(1)
-decoded = json.loads(base64.b64decode(ann))
-features = list(decoded[0].values())[0].get('backstage', {}).get('features', {})
-print(' [PASS]  Annotation present')
-print(f' [PASS]  Features: {json.dumps(features)}')
-"
-```
-
-**Hard gate:** If annotation is missing, STOP. Rebuild with `--no-cache`.
-
----
-
-## Step 6 — Push to GHCR
-
-```
-echo "================ Step 6 — Push to GHCR ==========="
+echo "================ Step 3 — Push to GHCR ==========="
 ```
 
 ```bash
@@ -284,13 +203,13 @@ echo ""
 
 ---
 
-## Step 7 — Deploy to Cluster
+## Step 4 — Deploy to Cluster
 
 ```
-echo "================ Step 7 — Deploy to Cluster ==========="
+echo "================ Step 4 — Deploy to Cluster ==========="
 ```
 
-### 7.1 — Ensure cluster login
+### 4.1 — Ensure cluster login
 
 ```bash
 if ! oc whoami &>/dev/null; then
@@ -302,7 +221,7 @@ fi
 echo " [PASS]  Cluster: $(oc whoami --show-server)"
 ```
 
-### 7.2 — Update ConfigMap
+### 4.2 — Update ConfigMap
 
 ```bash
 oc get configmap dynamic-plugins -n ${NAMESPACE} \
@@ -318,7 +237,7 @@ oc create configmap dynamic-plugins \
 echo "  ConfigMap updated"
 ```
 
-### 7.3 — Restart pod
+### 4.3 — Restart pod
 
 ```bash
 oc delete pod -n ${NAMESPACE} -l app.kubernetes.io/instance=redhat-developer-hub
@@ -327,10 +246,10 @@ echo "  Pod deleted, waiting for new pod..."
 
 ---
 
-## Step 8 — Validate Deployment
+## Step 5 — Validate Deployment
 
 ```
-echo "================ Step 8 — Validate Deployment ==========="
+echo "================ Step 5 — Validate Deployment ==========="
 ```
 
 ```bash
@@ -347,7 +266,7 @@ if echo "$INSTALL_LOG" | grep -q "Installed"; then
 else
   echo " [FAIL]  Plugin NOT found in init logs"
   echo "  Detail: ${INSTALL_LOG}"
-  echo "  Fix: Check OCI annotation and image structure"
+  echo "  Fix: Check OCI image structure — see references/oci-structure.md"
   exit 1
 fi
 
@@ -403,7 +322,6 @@ echo " [PASS]  Rolled back to official image"
 
 ## When NOT to Use
 
-- **Backend-only plugins** — this skill is for frontend dynamic plugins. Backend plugins follow a different OCI structure.
 - **Plugins already in the overlay CI** — if the plugin is already published via `rhdh-plugin-export-overlays` CI and you just need to bump a version, use the `overlay` skill instead.
 - **Local dev testing** — if you only need to test locally with `yarn start`, use `rhdh-local` skill or `packages: all` in `app-config.yaml`.
 - **Helm chart changes** — this skill deploys plugin OCI images, not Helm value changes.
@@ -416,6 +334,6 @@ echo " [PASS]  Rolled back to official image"
 
 | Reference | Load when... |
 |-----------|-------------|
-| `references/oci-structure.md` | When debugging image build or annotation issues |
+| `references/oci-structure.md` | When debugging image build, annotation issues, or `plugin package` failures |
 
 </reference_index>

--- a/skills/rhdh-deploy-local-plugin/SKILL.md
+++ b/skills/rhdh-deploy-local-plugin/SKILL.md
@@ -1,0 +1,421 @@
+---
+name: rhdh-deploy-local-plugin
+description: >-
+  Build, package, and deploy a local RHDH/BCP plugin as an OCI image to an
+  OpenShift cluster for testing. Handles GHCR auth, OCI annotation generation,
+  image build, push, ConfigMap update, and pod rollout. Use when the user asks
+  to "test on cluster", "deploy plugin to cluster", "build OCI image",
+  "push plugin to GHCR", "verify dynamic plugin on OpenShift",
+  "test my changes on cluster", or "deploy local changes".
+---
+
+<essential_principles>
+
+<principle name="skill_entry_banner">
+As the very first action when the skill is invoked, echo a skill entry banner to the terminal:
+```
+echo "================ Using Deploy Local Plugin Skill ==========="
+```
+This must happen before any other work (reading references, gathering inputs, etc.).
+</principle>
+
+<principle name="step_echo_banners">
+Before executing each numbered Step, echo a clearly visible banner to the terminal so the user can track progress:
+```
+echo "================ Step N — <Step title> ==========="
+```
+This applies to ALL steps including Step 0. Run the echo command in the terminal before doing anything else for that step.
+</principle>
+
+<principle name="fail_fast">
+If any step fails validation, STOP immediately with a clear error message and documentation link. Do NOT proceed to the next step. The user must fix the issue before continuing.
+</principle>
+
+<principle name="directory_layout">
+The OCI image must contain an extracted directory — NOT a `.tgz` archive.
+Structure: `/<plugin-short-name>/package.json`, `/<plugin-short-name>/dist/`, etc.
+Violating this causes: `ENOENT: no such file or directory, open '.../package.json'`
+</principle>
+
+<principle name="annotation_mandatory">
+Every OCI image must carry the `io.backstage.dynamic-packages` annotation (base64-encoded JSON).
+Without it: `InstallException: No plugins found in OCI image`.
+Always use `--no-cache` to ensure the annotation is applied (podman caching can silently skip it).
+</principle>
+
+</essential_principles>
+
+## Step 0 — Readiness Check
+
+```
+echo "================ Step 0 — Readiness Check ==========="
+```
+
+Verify all tools are present. Print a status table using `[PASS]` / `[FAIL]` / `[WARN]` indicators. If any must-have check fails, STOP with install instructions.
+
+### Must-have tools
+
+| Tool | Check command | Install link |
+|------|--------------|--------------|
+| `podman` | `podman --version` | https://podman.io/docs/installation |
+| `oc` | `oc version --client` | https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html |
+| `gh` | `gh --version` | https://cli.github.com/manual/installation |
+| `npx` | `npx --version` | https://nodejs.org/en/download |
+| `python3` | `python3 --version` | https://www.python.org/downloads/ |
+| `yarn` | `yarn --version` | https://yarnpkg.com/getting-started/install |
+
+### Must-have auth checks
+
+| Check | Command | Fix |
+|-------|---------|-----|
+| gh authenticated | `gh auth status` | `gh auth login` — https://cli.github.com/manual/gh_auth_login |
+| `write:packages` scope | `gh auth status 2>&1 \| grep write:packages` | `gh auth refresh -h github.com -s write:packages` — https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic |
+| GHCR login | `podman login ghcr.io --get-login` | `gh auth token \| podman login ghcr.io -u $(gh api user -q .login) --password-stdin` |
+
+### Good-to-have (warn only)
+
+| Check | Condition | What it enables | Link |
+|-------|-----------|----------------|------|
+| Cluster login | `oc whoami` | Deploy directly without re-login | `oc login <url> --username <u> --password <p>` |
+
+### Output format
+
+```
+ [PASS]  podman — v5.4.0
+ [PASS]  oc — v4.17.0
+ [PASS]  gh — v2.70.0
+ [PASS]  npx — v10.9.4
+ [PASS]  python3 — v3.14.3
+ [PASS]  yarn — v4.9.1
+ [PASS]  gh auth — authenticated as its-mitesh-kumar
+ [PASS]  write:packages — scope present
+ [PASS]  GHCR login — active
+ [WARN]  oc cluster — not logged in (will need login in Step 6)
+```
+
+**If ANY must-have check fails:** Print the fix command, documentation link, and STOP.
+
+---
+
+<intake>
+
+## Step 1 — Gather Inputs
+
+```
+echo "================ Step 1 — Gather Inputs ==========="
+```
+
+Identify what to deploy. Gather from user or infer from current working directory:
+
+| Variable | How to resolve |
+|----------|----------------|
+| `WORKSPACE` | Directory name under `workspaces/` (infer from cwd or ask) |
+| `PLUGIN` | Directory name under `plugins/` (infer from cwd or ask) |
+| `NAMESPACE` | Namespace where RHDH runs on the cluster (ask user) |
+| `CLUSTER_API` | Cluster API URL (ask if `oc whoami` fails) |
+
+Auto-derived variables (resolved later in Step 3):
+- `GHCR_USER` — from `gh api user -q .login`
+- `PLUGIN_SHORT` — from `dist-dynamic/package.json` (name without scope and `-dynamic`)
+- `VERSION` — from `dist-dynamic/package.json`
+- `TAG` — pattern: `bs_<backstage-version>__<plugin-version>-test`
+
+**Wait for user response if workspace/namespace are not clear.**
+
+</intake>
+
+---
+
+## Step 2 — Build & Export
+
+```
+echo "================ Step 2 — Build & Export ==========="
+```
+
+```bash
+cd workspaces/${WORKSPACE}
+echo "  Running yarn tsc..."
+yarn tsc
+
+cd plugins/${PLUGIN}
+echo "  Running yarn build..."
+yarn build
+
+echo "  Exporting as dynamic plugin..."
+npx @red-hat-developer-hub/cli plugin export
+```
+
+**Validation:** Check output for `detected backstage feature:` lines, e.g.:
+```
+detected backstage feature: ./alpha => @backstage/FrontendPlugin
+detected backstage feature: ./<name>-translations-module => @backstage/FrontendModule
+```
+
+**If no features detected:** STOP — the plugin's `package.json` is missing `exports` entries or the plugin does not create Backstage features. See `references/oci-structure.md` for the expected package.json structure.
+
+---
+
+## Step 3 — Generate OCI Annotation
+
+```
+echo "================ Step 3 — Generate OCI Annotation ==========="
+```
+
+```bash
+cd dist-dynamic
+
+PLUGIN_SHORT=$(python3 -c "
+import json
+pkg = json.load(open('package.json'))
+print(pkg['name'].replace('@red-hat-developer-hub/', '').replace('@backstage-community/', '').replace('-dynamic', ''))
+")
+VERSION=$(python3 -c "import json; print(json.load(open('package.json'))['version'])")
+BS_VERSION=$(python3 -c "import json; print(json.load(open('package.json')).get('backstage',{}).get('supported-versions','unknown'))")
+TAG="bs_${BS_VERSION}__${VERSION}-test"
+GHCR_USER=$(gh api user -q .login)
+
+echo "  Plugin short name: ${PLUGIN_SHORT}"
+echo "  Version: ${VERSION}"
+echo "  Backstage version: ${BS_VERSION}"
+echo "  Tag: ${TAG}"
+echo "  GHCR user: ${GHCR_USER}"
+
+ANNOTATION=$(python3 -c "
+import json, base64
+pkg = json.load(open('package.json'))
+short_name = pkg['name'].replace('@red-hat-developer-hub/', '').replace('@backstage-community/', '').replace('-dynamic', '')
+annotation = [{short_name: {
+    'name': pkg['name'],
+    'version': pkg['version'],
+    'backstage': pkg.get('backstage', {}),
+    'repository': pkg.get('repository', {}),
+    'license': pkg.get('license', 'Apache-2.0')
+}}]
+print(base64.b64encode(json.dumps(annotation).encode()).decode())
+")
+
+echo "  Annotation generated (${#ANNOTATION} chars)"
+```
+
+**Validation:** `ANNOTATION` must be non-empty. If empty, the `package.json` is malformed — check `backstage.features` field exists.
+
+---
+
+## Step 4 — Build OCI Image
+
+```
+echo "================ Step 4 — Build OCI Image ==========="
+```
+
+```bash
+echo -e "Containerfile\n.dockerignore" > .dockerignore
+
+cat <<EOF > Containerfile
+FROM scratch
+COPY --chmod=755 . /${PLUGIN_SHORT}/
+EOF
+
+echo "  Building image: ghcr.io/${GHCR_USER}/rhdh-plugin-export-overlays/${PLUGIN_SHORT}:${TAG}"
+
+podman build --no-cache --platform linux/amd64 \
+  --annotation "io.backstage.dynamic-packages=${ANNOTATION}" \
+  -t ghcr.io/${GHCR_USER}/rhdh-plugin-export-overlays/${PLUGIN_SHORT}:${TAG} \
+  -f Containerfile .
+```
+
+**Validation:** Exit code 0 and output contains `Successfully tagged`.
+
+---
+
+## Step 5 — Verify Image
+
+```
+echo "================ Step 5 — Verify Image ==========="
+```
+
+```bash
+podman inspect ghcr.io/${GHCR_USER}/rhdh-plugin-export-overlays/${PLUGIN_SHORT}:${TAG} | \
+  python3 -c "
+import json, sys, base64
+d = json.load(sys.stdin)
+ann = d[0].get('Annotations', {}).get('io.backstage.dynamic-packages', '')
+if not ann:
+    print(' [FAIL]  io.backstage.dynamic-packages annotation MISSING')
+    sys.exit(1)
+decoded = json.loads(base64.b64decode(ann))
+features = list(decoded[0].values())[0].get('backstage', {}).get('features', {})
+print(' [PASS]  Annotation present')
+print(f' [PASS]  Features: {json.dumps(features)}')
+"
+```
+
+**Hard gate:** If annotation is missing, STOP. Rebuild with `--no-cache`.
+
+---
+
+## Step 6 — Push to GHCR
+
+```
+echo "================ Step 6 — Push to GHCR ==========="
+```
+
+```bash
+podman push ghcr.io/${GHCR_USER}/rhdh-plugin-export-overlays/${PLUGIN_SHORT}:${TAG}
+```
+
+**If push fails with `permission_denied`:**
+```
+ [FAIL]  Push failed — token lacks required scopes
+ Fix:
+   1. gh auth refresh -h github.com -s write:packages
+   2. gh auth token | podman login ghcr.io -u ${GHCR_USER} --password-stdin
+   3. Retry the push
+ Docs: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry
+```
+
+**After successful push:**
+```
+echo ""
+echo " [WARN]  If this is the FIRST push for this package, make it PUBLIC:"
+echo "         https://github.com/users/${GHCR_USER}/packages/container/package/rhdh-plugin-export-overlays%2F${PLUGIN_SHORT}"
+echo "         → Package settings → Change visibility → Public"
+echo ""
+```
+
+---
+
+## Step 7 — Deploy to Cluster
+
+```
+echo "================ Step 7 — Deploy to Cluster ==========="
+```
+
+### 7.1 — Ensure cluster login
+
+```bash
+if ! oc whoami &>/dev/null; then
+  echo " [FAIL]  Not logged into cluster"
+  echo " Fix: oc login ${CLUSTER_API} --username <user> --password <pass> --insecure-skip-tls-verify"
+  echo " Docs: https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html#cli-logging-in_cli-developer-commands"
+  exit 1
+fi
+echo " [PASS]  Cluster: $(oc whoami --show-server)"
+```
+
+### 7.2 — Update ConfigMap
+
+```bash
+oc get configmap dynamic-plugins -n ${NAMESPACE} \
+  -o jsonpath='{.data.dynamic-plugins\.yaml}' > /tmp/dynamic-plugins.yaml
+
+# Replace official image with test image
+sed -i.bak "s|ghcr.io/redhat-developer/rhdh-plugin-export-overlays/${PLUGIN_SHORT}:[^ '\"]*|ghcr.io/${GHCR_USER}/rhdh-plugin-export-overlays/${PLUGIN_SHORT}:${TAG}|g" /tmp/dynamic-plugins.yaml
+
+oc create configmap dynamic-plugins \
+  --from-file=dynamic-plugins.yaml=/tmp/dynamic-plugins.yaml \
+  -n ${NAMESPACE} --dry-run=client -o yaml | oc apply -f -
+
+echo "  ConfigMap updated"
+```
+
+### 7.3 — Restart pod
+
+```bash
+oc delete pod -n ${NAMESPACE} -l app.kubernetes.io/instance=redhat-developer-hub
+echo "  Pod deleted, waiting for new pod..."
+```
+
+---
+
+## Step 8 — Validate Deployment
+
+```
+echo "================ Step 8 — Validate Deployment ==========="
+```
+
+```bash
+echo "  Waiting for rollout..."
+oc rollout status deployment/redhat-developer-hub -n ${NAMESPACE} --timeout=180s
+
+POD=$(oc get pods -n ${NAMESPACE} -l app.kubernetes.io/instance=redhat-developer-hub -o name | head -1)
+echo "  Pod: ${POD}"
+
+echo "  Checking init container logs..."
+INSTALL_LOG=$(oc logs ${POD} -n ${NAMESPACE} -c install-dynamic-plugins 2>&1 | grep "${PLUGIN_SHORT}")
+if echo "$INSTALL_LOG" | grep -q "Installed"; then
+  echo " [PASS]  Plugin installed by init container"
+else
+  echo " [FAIL]  Plugin NOT found in init logs"
+  echo "  Detail: ${INSTALL_LOG}"
+  echo "  Fix: Check OCI annotation and image structure"
+  exit 1
+fi
+
+echo "  Checking for runtime errors..."
+ERRORS=$(oc logs ${POD} -n ${NAMESPACE} -c backstage-backend 2>&1 | grep -i "error" | grep "${PLUGIN_SHORT}")
+if [ -z "$ERRORS" ]; then
+  echo " [PASS]  No runtime errors"
+else
+  echo " [WARN]  Errors found:"
+  echo "  ${ERRORS}"
+fi
+
+echo "  Verifying plugin directory..."
+FILES=$(oc exec ${POD} -n ${NAMESPACE} -c backstage-backend -- ls /opt/app-root/src/dynamic-plugins-root/${PLUGIN_SHORT}/ 2>&1)
+if echo "$FILES" | grep -q "package.json"; then
+  echo " [PASS]  Plugin files present (package.json, dist/, dist-scalprum/)"
+else
+  echo " [FAIL]  Plugin directory empty or missing package.json"
+  echo "  Got: ${FILES}"
+  exit 1
+fi
+
+echo ""
+echo "================ DONE ==========="
+echo "  Image: ghcr.io/${GHCR_USER}/rhdh-plugin-export-overlays/${PLUGIN_SHORT}:${TAG}"
+echo "  Cluster: $(oc whoami --show-server)"
+echo "  Namespace: ${NAMESPACE}"
+echo "  Pod: ${POD}"
+echo ""
+echo "  Next: Open the RHDH UI and verify your changes are visible."
+echo "  App Visualizer: <rhdh-url>/_visualizer/tree"
+```
+
+---
+
+## Rollback
+
+```
+echo "================ Rollback — Reverting to official image ==========="
+```
+
+```bash
+cp /tmp/dynamic-plugins.yaml.bak /tmp/dynamic-plugins.yaml
+oc create configmap dynamic-plugins \
+  --from-file=dynamic-plugins.yaml=/tmp/dynamic-plugins.yaml \
+  -n ${NAMESPACE} --dry-run=client -o yaml | oc apply -f -
+oc delete pod -n ${NAMESPACE} -l app.kubernetes.io/instance=redhat-developer-hub
+oc rollout status deployment/redhat-developer-hub -n ${NAMESPACE} --timeout=180s
+echo " [PASS]  Rolled back to official image"
+```
+
+---
+
+## When NOT to Use
+
+- **Backend-only plugins** — this skill is for frontend dynamic plugins. Backend plugins follow a different OCI structure.
+- **Plugins already in the overlay CI** — if the plugin is already published via `rhdh-plugin-export-overlays` CI and you just need to bump a version, use the `overlay` skill instead.
+- **Local dev testing** — if you only need to test locally with `yarn start`, use `rhdh-local` skill or `packages: all` in `app-config.yaml`.
+- **Helm chart changes** — this skill deploys plugin OCI images, not Helm value changes.
+
+---
+
+<reference_index>
+
+## Reference Index
+
+| Reference | Load when... |
+|-----------|-------------|
+| `references/oci-structure.md` | When debugging image build or annotation issues |
+
+</reference_index>

--- a/skills/rhdh-deploy-local-plugin/SKILL.md
+++ b/skills/rhdh-deploy-local-plugin/SKILL.md
@@ -221,15 +221,16 @@ else
 fi
 ```
 
-**Validation:** Verify the image is publicly accessible before proceeding to deploy:
+**Validation:** Verify the package is actually public before proceeding to deploy (the `podman pull` check is unreliable here because podman is already authenticated to GHCR):
 
 ```bash
-podman pull ghcr.io/${GHCR_USER}/rhdh-plugin-export-overlays/${PLUGIN_SHORT}:${TAG}
-if [ $? -eq 0 ]; then
-  echo " [PASS]  Image is publicly pullable"
+VISIBILITY=$(gh api /user/packages/container/rhdh-plugin-export-overlays%2F${PLUGIN_SHORT} -q .visibility 2>/dev/null)
+if [ "$VISIBILITY" = "public" ]; then
+  echo " [PASS]  Package visibility confirmed: public"
 else
-  echo " [FAIL]  Image pull failed — package may still be private"
+  echo " [FAIL]  Package visibility: ${VISIBILITY:-unknown} (expected: public)"
   echo " Fix: https://github.com/users/${GHCR_USER}/packages/container/package/rhdh-plugin-export-overlays%2F${PLUGIN_SHORT}"
+  echo "       → Package settings → Change visibility → Public"
   exit 1
 fi
 ```

--- a/skills/rhdh-deploy-local-plugin/references/oci-structure.md
+++ b/skills/rhdh-deploy-local-plugin/references/oci-structure.md
@@ -1,0 +1,84 @@
+# OCI Image Structure
+
+## Expected Directory Layout
+
+RHDH's dynamic plugin installer expects the OCI image to contain the
+**extracted** plugin contents as a named directory — NOT a tarball.
+
+```
+/
+└── <plugin-short-name>/
+    ├── package.json
+    ├── dist/
+    │   └── *.js, *.js.map
+    ├── dist-scalprum/
+    │   └── *.js (module federation chunks)
+    └── alpha.d.ts (optional)
+```
+
+## Common Failures
+
+| Symptom | Root Cause | Fix |
+|---------|-----------|-----|
+| `ENOENT: no such file or directory, open '.../package.json'` | Image contains a `.tgz` archive instead of extracted directory | Use `FROM scratch` + `COPY . /<plugin-short-name>/` in Containerfile |
+| `InstallException: No plugins found in OCI image` | Missing `io.backstage.dynamic-packages` annotation | Rebuild with `--annotation "io.backstage.dynamic-packages=<base64>"` and `--no-cache` |
+| Plugin loads but features not discovered | Missing `backstage.features` in `dist-dynamic/package.json` | Run `npx @red-hat-developer-hub/cli plugin export` again (it generates the features field) |
+| Push fails with `permission_denied` | Token missing `write:packages` scope | `gh auth refresh -h github.com -s write:packages` then re-login to GHCR |
+| Image pulled but package not found | Wrong directory name in image | Must match the key in the annotation JSON object |
+
+## Annotation Format
+
+The annotation value is base64-encoded JSON:
+
+```json
+[
+  {
+    "<plugin-short-name>": {
+      "name": "@scope/package-name-dynamic",
+      "version": "1.2.3",
+      "backstage": {
+        "supported-versions": "1.52.0",
+        "features": {
+          "frontend": {
+            "default": { "type": "FrontendModule" },
+            "./alpha": { "type": "FrontendPlugin" }
+          }
+        }
+      },
+      "repository": { ... },
+      "license": "Apache-2.0"
+    }
+  }
+]
+```
+
+The JSON key (`<plugin-short-name>`) MUST match the directory name inside the image.
+The `backstage.features` field is populated by `npx @red-hat-developer-hub/cli plugin export`.
+
+## Containerfile Template
+
+```dockerfile
+FROM scratch
+COPY --chmod=755 . /<plugin-short-name>/
+```
+
+`.dockerignore`:
+```
+Containerfile
+.dockerignore
+```
+
+## Verifying a Working Image
+
+```bash
+# Check annotation exists
+podman inspect <image> | jq '.[0].Annotations["io.backstage.dynamic-packages"]'
+
+# Decode and pretty-print annotation
+podman inspect <image> | jq -r '.[0].Annotations["io.backstage.dynamic-packages"]' | base64 -d | jq .
+
+# Mount and check directory structure
+ID=$(podman create <image>)
+podman cp $ID:/<plugin-short-name>/package.json /dev/stdout | head -5
+podman rm $ID
+```

--- a/skills/rhdh-deploy-local-plugin/references/oci-structure.md
+++ b/skills/rhdh-deploy-local-plugin/references/oci-structure.md
@@ -1,5 +1,23 @@
 # OCI Image Structure
 
+> **Note:** `npx @red-hat-developer-hub/cli plugin package --tag <image>` handles OCI image creation automatically — including directory layout, annotation, and correct structure. This reference is for **troubleshooting** or understanding what the CLI does under the hood.
+
+## How `plugin package` Works
+
+The `plugin package` command from `@red-hat-developer-hub/cli`:
+1. Takes the `dist-dynamic/` output from `plugin export`
+2. Creates an OCI image with the plugin files as an extracted directory (not a tarball)
+3. Adds the `io.backstage.dynamic-packages` annotation (base64-encoded JSON) automatically
+4. Tags the image with the specified `--tag`
+5. Prints the `dynamic-plugins.yaml` entry to use on the cluster
+
+```bash
+npx @red-hat-developer-hub/cli@latest plugin package \
+  --tag ghcr.io/<user>/<repo>/<plugin-name>:v0.1.0
+```
+
+Docs: https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.9/html/installing_and_viewing_plugins_in_red_hat_developer_hub/assembly-third-party-plugins
+
 ## Expected Directory Layout
 
 RHDH's dynamic plugin installer expects the OCI image to contain the
@@ -20,15 +38,16 @@ RHDH's dynamic plugin installer expects the OCI image to contain the
 
 | Symptom | Root Cause | Fix |
 |---------|-----------|-----|
-| `ENOENT: no such file or directory, open '.../package.json'` | Image contains a `.tgz` archive instead of extracted directory | Use `FROM scratch` + `COPY . /<plugin-short-name>/` in Containerfile |
-| `InstallException: No plugins found in OCI image` | Missing `io.backstage.dynamic-packages` annotation | Rebuild with `--annotation "io.backstage.dynamic-packages=<base64>"` and `--no-cache` |
+| `ENOENT: no such file or directory, open '.../package.json'` | Image contains a `.tgz` archive instead of extracted directory | Use `plugin package` instead of manual `podman build` |
+| `InstallException: No plugins found in OCI image` | Missing `io.backstage.dynamic-packages` annotation | Use `plugin package` (adds annotation automatically) or rebuild manually with `--annotation` |
 | Plugin loads but features not discovered | Missing `backstage.features` in `dist-dynamic/package.json` | Run `npx @red-hat-developer-hub/cli plugin export` again (it generates the features field) |
 | Push fails with `permission_denied` | Token missing `write:packages` scope | `gh auth refresh -h github.com -s write:packages` then re-login to GHCR |
-| Image pulled but package not found | Wrong directory name in image | Must match the key in the annotation JSON object |
+| Image pulled but package not found | Wrong directory name in image vs annotation key | Use `plugin package` which ensures consistency |
+| `plugin package` fails with "container tool not found" | `podman` not on PATH or not running | `podman machine start` (macOS) or add `--container-tool docker` |
 
 ## Annotation Format
 
-The annotation value is base64-encoded JSON:
+The `io.backstage.dynamic-packages` annotation value is base64-encoded JSON (generated automatically by `plugin package`):
 
 ```json
 [
@@ -55,7 +74,9 @@ The annotation value is base64-encoded JSON:
 The JSON key (`<plugin-short-name>`) MUST match the directory name inside the image.
 The `backstage.features` field is populated by `npx @red-hat-developer-hub/cli plugin export`.
 
-## Containerfile Template
+## Manual Build (Fallback)
+
+Only use this if `plugin package` is unavailable or broken:
 
 ```dockerfile
 FROM scratch
@@ -66,6 +87,12 @@ COPY --chmod=755 . /<plugin-short-name>/
 ```
 Containerfile
 .dockerignore
+```
+
+```bash
+podman build --no-cache --platform linux/amd64 \
+  --annotation "io.backstage.dynamic-packages=<base64-encoded-json>" \
+  -t <image-tag> -f Containerfile .
 ```
 
 ## Verifying a Working Image


### PR DESCRIPTION
## Summary

- Adds `rhdh-deploy-local-plugin` skill — a Tier-3 operational workflow that automates building, packaging, and deploying local RHDH/BCP plugin changes as OCI images to an OpenShift cluster
- Handles the full lifecycle: build → export → annotate → OCI image → push to GHCR → update ConfigMap → restart pod → validate
- Includes hard gates at each step (annotation check, push auth, cluster login, pod health) with clear `[PASS]`/`[FAIL]` indicators and documentation links
- Step echo banners (`================ Step N — Title ===========`) for observable progress tracking
- Includes `references/oci-structure.md` documenting common failures, expected image layout, and the annotation format

## Motivation

Testing local plugin changes on a real RHDH cluster (especially dynamic plugin NFS discovery) requires precise OCI image construction with correct annotations and directory layout. The process is error-prone — common mistakes include:
- Missing `io.backstage.dynamic-packages` annotation → `InstallException`
- Shipping a `.tgz` archive instead of extracted directory → `ENOENT: no such file or directory`
- Missing `write:packages` scope → push permission denied
- Wrong directory name in image vs annotation key → plugin not found

This skill automates these error-prone steps and provides clear validation at each gate, making cluster testing a single-invocation workflow instead of a multi-hour debugging session.

## How to Use

### Prerequisites

- `podman`, `oc`, `gh`, `npx`, `python3`, `yarn` on PATH
- `gh` authenticated with `write:packages` scope
- GHCR login configured for podman
- Access to an OpenShift cluster with RHDH deployed

### Install

Install from local checkout (while PR is unmerged):

```
cd /path/to/rhdh-plugins
npx skills add /path/to/rhdh-skill --skill rhdh-deploy-local-plugin
```

After merge:

```
npx skills add redhat-developer/rhdh-skill --skill rhdh-deploy-local-plugin
```

### Invoke

```
# Deploy current workspace plugin to cluster
rhdh-deploy-local-plugin

# Explicit workspace and namespace
"deploy my adoption-insights changes to cluster in namespace helm-test"

# Trigger phrases
"test on cluster"
"build OCI image"
"push plugin to GHCR"
"deploy local changes to OpenShift"
"verify dynamic plugin on cluster"
```

### What it does

1. **Readiness check** — verifies all tools and auth with `[PASS]`/`[FAIL]` table
2. **Gathers inputs** — workspace, plugin, namespace, cluster API (infers from cwd)
3. **Builds & exports** — `yarn tsc` → `yarn build` → `npx @red-hat-developer-hub/cli plugin export`
4. **Generates annotation** — base64-encoded `io.backstage.dynamic-packages` JSON from `dist-dynamic/package.json`
5. **Builds OCI image** — `FROM scratch` + `COPY . /<plugin-short-name>/` with annotation
6. **Verifies image** — decodes annotation, validates structure
7. **Pushes to GHCR** — with auth error recovery guidance
8. **Deploys to cluster** — updates ConfigMap, restarts pod
9. **Validates deployment** — checks init logs, runtime errors, file structure

## Files

- **New**: `skills/rhdh-deploy-local-plugin/SKILL.md` — 8-step workflow with readiness check, intake, hard gates, rollback section, and "When NOT to Use"
- **New**: `skills/rhdh-deploy-local-plugin/references/oci-structure.md` — common failures table, annotation format, Containerfile template, verification commands

## Test plan

- [ ] Invoke skill with a workspace that has `dist-dynamic` output (e.g., adoption-insights)
- [ ] Verify readiness check catches missing `oc` login (warns, doesn't block)
- [ ] Verify annotation generation produces valid base64 JSON with `backstage.features`
- [ ] Verify image passes `podman inspect` validation
- [ ] Verify push + deploy to a test cluster succeeds
- [ ] Verify rollback section reverts to official image

Made with [Cursor](https://cursor.com)