### PR TITLE
chore(konflux-tekton-updates): fix migration guide URLs after build-definitions move

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Manage plugins in the [rhdh-plugin-export-overlays](https://github.com/redhat-de
 
 Update Konflux task digests and apply `MIGRATION.md` pipeline changes in [rhdh-plugin-catalog](https://gitlab.cee.redhat.com/rhidp/rhdh-plugin-catalog) or [rhdh](https://gitlab.cee.redhat.com/rhidp/rhdh) midstream.
 
-- **[konflux-tekton-updates](./skills/konflux-tekton-updates/SKILL.md)** — Run `.tekton/updateDigests.sh --minor --no-push`, apply [build-definitions](https://github.com/konflux-ci/build-definitions) task migrations, update shared pipelines/templates and PLR generators. Repo-specific file lists: [plugin-catalog](./skills/konflux-tekton-updates/references/plugin-catalog.md), [RHDH midstream](./skills/konflux-tekton-updates/references/rhdh-midstream.md).
+- **[konflux-tekton-updates](./skills/konflux-tekton-updates/SKILL.md)** — Run `.tekton/updateDigests.sh --minor --no-push`, apply task migrations from [build-pipeline-tasks](https://github.com/konflux-ci/build-pipeline-tasks) (and related repos; see [migration-urls](./skills/konflux-tekton-updates/references/migration-urls.md)), update shared pipelines/templates and PLR generators. Repo-specific file lists: [plugin-catalog](./skills/konflux-tekton-updates/references/plugin-catalog.md), [RHDH midstream](./skills/konflux-tekton-updates/references/rhdh-midstream.md).
 
 ```bash
 npx skills add redhat-developer/rhdh-skill --skill konflux-tekton-updates

--- a/skills/konflux-tekton-updates/SKILL.md
+++ b/skills/konflux-tekton-updates/SKILL.md
@@ -53,8 +53,8 @@ cd .tekton
 
 - Updates `tag@sha256` in `.tekton/*.yaml` and `.tekton-templates/*.yaml` (via `TEMPLATEPATH`).
 - On variant B, also updates `.tekton/build-pipeline-rhdh-*.yaml`.
-- Tag changes list `MIGRATION.md` URLs — they must resolve via [references/migration-urls.md](references/migration-urls.md) (not deleted `build-definitions/task/<name>/<tag>/` paths).
-- If `updateDigests.sh` still prints 404 `build-definitions/.../MIGRATION.md` links, patch it with `migrationDocURL` from that reference, then re-run or rewrite the printed URLs before opening a browser.
+- Tag changes list `MIGRATION.md` URLs via `migrationDocURL` in `updateDigests.sh` (see [references/migration-urls.md](references/migration-urls.md)). Do not use deleted `build-definitions/task/<name>/<tag>/` paths.
+- If `updateDigests.sh` still hard-codes those 404 URLs, update it to use `migrationDocURL`, then re-run or rewrite printed links before opening a browser.
 - Digest-only (no tag bump): `./updateDigests.sh --no-push -q`
 
 Review `git diff` for `quay.io/konflux-ci/tekton-catalog/task-*` changes.

--- a/skills/konflux-tekton-updates/SKILL.md
+++ b/skills/konflux-tekton-updates/SKILL.md
@@ -2,9 +2,10 @@
 name: konflux-tekton-updates
 description: >-
   Bumps Konflux Tekton task digests with .tekton/updateDigests.sh --minor --no-push,
-  applies konflux-ci/build-definitions MIGRATION.md pipeline fixes, and regenerates
-  PipelineRuns. Use for rhdh-plugin-catalog, RHDH midstream (4-rhdh), Konflux task
-  minor bumps, prefetch-dependencies-oci-ta, build-image-index, or updateDigests.sh.
+  applies MIGRATION.md pipeline fixes from build-pipeline-tasks (and related repos),
+  and regenerates PipelineRuns. Use for rhdh-plugin-catalog, RHDH midstream (4-rhdh),
+  Konflux task minor bumps, prefetch-dependencies-oci-ta, build-image-index, or
+  updateDigests.sh.
 ---
 
 # Konflux Tekton updates
@@ -52,18 +53,20 @@ cd .tekton
 
 - Updates `tag@sha256` in `.tekton/*.yaml` and `.tekton-templates/*.yaml` (via `TEMPLATEPATH`).
 - On variant B, also updates `.tekton/build-pipeline-rhdh-*.yaml`.
-- Tag changes list `MIGRATION.md` URLs under `konflux-ci/build-definitions`.
+- Tag changes list `MIGRATION.md` URLs — they must resolve via [references/migration-urls.md](references/migration-urls.md) (not deleted `build-definitions/task/<name>/<tag>/` paths).
+- If `updateDigests.sh` still prints 404 `build-definitions/.../MIGRATION.md` links, patch it with `migrationDocURL` from that reference, then re-run or rewrite the printed URLs before opening a browser.
 - Digest-only (no tag bump): `./updateDigests.sh --no-push -q`
 
 Review `git diff` for `quay.io/konflux-ci/tekton-catalog/task-*` changes.
 
 ### 2. Apply migrations
 
-For each URL from `updateDigests.sh` (or from the diff):
+For each tag bump from `updateDigests.sh` (or from the diff):
 
-1. Read `MIGRATION.md`.
-2. Apply **only** documented user actions in templates and shared pipelines (see [references/rhdh-midstream.md](references/rhdh-midstream.md) for per-variant file list).
-3. Skip “no action required” sections.
+1. Resolve the live migration doc with [references/migration-urls.md](references/migration-urls.md) (example: [`buildah-oci-ta/MIGRATION.md`](https://github.com/konflux-ci/build-pipeline-tasks/blob/main/task/buildah-oci-ta/MIGRATION.md)).
+2. Fetch raw `MIGRATION.md` (and `CHANGELOG.md` / `migrations/*.sh` if needed).
+3. Apply **only** documented user actions in templates and shared pipelines (see [references/rhdh-midstream.md](references/rhdh-midstream.md) for per-variant file list).
+4. Skip “no action required” sections.
 
 If PLRs still contain removed params (e.g. `dev-package-managers`) but templates are fixed, migrations are incomplete until step 3.
 
@@ -81,6 +84,8 @@ cd .tekton
 | `rhdh-1-rhel-9` | `1` | `rhdh-hub-1-push.yaml` |
 | `rhdh-1.9-rhel-9` | `1.9` | `rhdh-hub-1-9-push.yaml` |
 | `rhdh-1.10-rhel-9` | `1.10` | `rhdh-hub-1-10-push.yaml` |
+
+On **main** / next midstream trees whose CEL already uses `target_branch == "main"`, after regen with `-t 2` (or similar), restore CEL/`on-push-for-*` to `main` if the generator rewrote them to `release-<version>`.
 
 - **Variant A:** also patch `rhdh-rag-content-<N>-{push,pull}.yaml` by hand (inline `pipelineSpec`, not generated).
 - **Variant B:** hub/operator PLRs regenerate from `rhdh-hub.yaml` / `rhdh-operator.yaml`; `build-pipeline-*.yaml` is edited directly, not by the generator.
@@ -101,9 +106,12 @@ Use live `MIGRATION.md` as source of truth. Common cases:
 | `build-image-index` 0.2→0.3 | Remove `COMMIT_SHA` / `IMAGE_EXPIRES_AFTER` from **build-image-index** task only; keep on buildah (`build-container`) and prefetch |
 | `init` 0.3→0.4 | No pipeline changes |
 | `init` 0.4.1→0.4.2 | Remove broken auto-added `sast-target-dirs` pipeline param if present |
+| `init` 0.4.2→0.4.3 | Add opt-in pipeline params `source-date-epoch`, `rewrite-timestamp`, `omit-history` and wire to buildah as `SOURCE_DATE_EPOCH` / `REWRITE_TIMESTAMP` / `OMIT_HISTORY` |
+| `show-sbom` / `summary` (deprecated) | Remove `show-sbom` / `show-summary` finally tasks (migration scripts delete them) |
 
 ## Anti-patterns
 
+- Opening or fetching `build-definitions/blob/main/task/<name>/<full-tag>/MIGRATION.md` (deleted; use [migration-urls.md](references/migration-urls.md)).
 - Pushing without `--no-push` / `--nopush` and human sign-off.
 - Leaving removed task params (`dev-package-managers`, `COMMIT_SHA` on `build-image-index`).
 - Skipping `generatePipelineRuns.sh` after fixing templates while PLRs still reference old params.

--- a/skills/konflux-tekton-updates/references/migration-urls.md
+++ b/skills/konflux-tekton-updates/references/migration-urls.md
@@ -55,42 +55,14 @@ Examples:
 
 `build-pipeline-tasks` keeps a **single** `MIGRATION.md` per task (not per patch tag). Versioned dirs under `build-definitions/external-task/` are thin stubs only.
 
-## `updateDigests.sh` — print/open correct URLs
+## `updateDigests.sh`
 
-Replace the hard-coded `build-definitions/blob/main/task/${url_frag}/MIGRATION.md` assignment with:
-
-```bash
-# major.minor from tag (0.10.7 -> 0.10, 0.4.3 -> 0.4)
-migrationDocURL() {
-	local task_name="$1"
-	local new_tag="$2"
-	local mm
-	mm="$(echo "${new_tag}" | sed -E 's/^([0-9]+\.[0-9]+).*/\1/')"
-	case "${task_name}" in
-		validate-fbc)
-			echo "https://github.com/konflux-ci/konflux-operator-tasks/blob/main/task/${task_name}/${mm}/MIGRATION.md"
-			;;
-		rpms-signature-scan)
-			echo "https://github.com/konflux-ci/tekton-tools/blob/main/tasks/${task_name}/${mm}/MIGRATION.md"
-			;;
-		show-sbom|summary)
-			echo "https://github.com/konflux-ci/build-definitions/tree/main/task/${task_name}/${mm}/migrations"
-			;;
-		buildah|buildah-*|git-clone|git-clone-*|init|prefetch-dependencies|prefetch-dependencies-*|build-image-index|build-image-index-*|push-dockerfile|push-dockerfile-*|source-build|source-build-*|apply-tags)
-			echo "https://github.com/konflux-ci/build-pipeline-tasks/blob/main/task/${task_name}/MIGRATION.md"
-			;;
-		*)
-			echo "https://github.com/konflux-ci/build-pipeline-tasks/blob/main/task/${task_name}/MIGRATION.md"
-			;;
-	esac
-}
-```
-
-When recording a tag bump:
+`.tekton/updateDigests.sh` should call `migrationDocURL` (not hard-code `build-definitions/.../<tag>/MIGRATION.md`). Expected call site on tag bumps:
 
 ```bash
 task_name="${base#*/task-}"
-MIGRATIONS["${task_name}/${newTag}"]="$(migrationDocURL "${task_name}" "${newTag}")"
+url_frag="${task_name}/${newTag}"
+MIGRATIONS["$url_frag"]="$(migrationDocURL "${task_name}" "${newTag}")"
 ```
 
-If an older `updateDigests.sh` still emits 404 `build-definitions/.../<full-tag>/MIGRATION.md` links, **ignore those URLs** and resolve via this map before fetching or opening a browser.
+If a branch still has the old hard-coded URL, apply the same `migrationDocURL` + call-site change (see midstream/plugin-catalog), then re-run. Until then, resolve printed 404s via the table above before fetching or opening a browser.

--- a/skills/konflux-tekton-updates/references/migration-urls.md
+++ b/skills/konflux-tekton-updates/references/migration-urls.md
@@ -1,0 +1,96 @@
+# Konflux task migration URL map
+
+Many tasks left `konflux-ci/build-definitions` ([commit 9f9f0a4](https://github.com/konflux-ci/build-definitions/commit/9f9f0a4c92c15a1c7c85b14b1758cd223056f5ac)).
+`external-task/<name>/` stubs point at the upstream repo; **do not** open:
+
+```text
+https://github.com/konflux-ci/build-definitions/blob/main/task/<name>/<full-tag>/MIGRATION.md
+```
+
+Those paths 404 (e.g. `task/buildah-oci-ta/0.10.7/MIGRATION.md`).
+
+## Resolve a task → migration doc
+
+1. Task name = quay image after `task-` (e.g. `quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta` → `buildah-oci-ta`).
+2. Tag = new image tag (e.g. `0.10.7`). Use **major.minor** (`0.10`) only when the upstream path is versioned.
+3. Pick the URL from the table below (or the `migrationDocURL` function).
+4. Fetch **raw** content for agents:
+   - GitHub blob → `https://raw.githubusercontent.com/<org>/<repo>/main/<path>`
+5. If `MIGRATION.md` is missing, read `CHANGELOG.md` in the same task directory and any `migrations/*.sh` scripts.
+
+## Primary homes
+
+| Task name pattern | Migration URL |
+|-------------------|---------------|
+| `buildah`, `buildah-oci-ta`, `buildah-remote`, `buildah-remote-oci-ta`, `buildah-*-min` | `build-pipeline-tasks` → `/task/<name>/MIGRATION.md` |
+| `git-clone`, `git-clone-oci-ta`, `git-clone-oci-ta-min` | `build-pipeline-tasks` → `/task/<name>/MIGRATION.md` |
+| `init` | https://github.com/konflux-ci/build-pipeline-tasks/blob/main/task/init/MIGRATION.md |
+| `prefetch-dependencies`, `prefetch-dependencies-oci-ta`, `*-min` | `build-pipeline-tasks` → `/task/<name>/MIGRATION.md` |
+| `build-image-index`, `build-image-index-min` | `build-pipeline-tasks` → `/task/<name>/MIGRATION.md` |
+| `push-dockerfile`, `push-dockerfile-oci-ta` | `build-pipeline-tasks` → `/task/<name>/MIGRATION.md` |
+| `source-build`, `source-build-oci-ta` | `build-pipeline-tasks` → `/task/<name>/MIGRATION.md` |
+| `apply-tags` | https://github.com/konflux-ci/build-pipeline-tasks/blob/main/task/apply-tags/MIGRATION.md |
+| `validate-fbc` | `konflux-operator-tasks` → `/task/validate-fbc/<major.minor>/MIGRATION.md` |
+| `rpms-signature-scan` | `tekton-tools` → `/tasks/rpms-signature-scan/<major.minor>/MIGRATION.md` |
+| `show-sbom`, `summary` | Still in `build-definitions`: `/task/<name>/<major.minor>/migrations/` (scripts remove the finally task). Also see `CHANGELOG.md`. |
+| Other / unknown | Try `build-pipeline-tasks/task/<name>/MIGRATION.md` first; then `build-definitions/task/<name>/<major.minor>/MIGRATION.md` if still hosted there. |
+
+Base URLs:
+
+- https://github.com/konflux-ci/build-pipeline-tasks/blob/main/task/
+- https://github.com/konflux-ci/konflux-operator-tasks/blob/main/task/
+- https://github.com/konflux-ci/tekton-tools/blob/main/tasks/
+- https://github.com/konflux-ci/build-definitions/tree/main/task/
+
+Examples:
+
+| Bump | Open this |
+|------|-----------|
+| `buildah-oci-ta` 0.10 → 0.10.7 | https://github.com/konflux-ci/build-pipeline-tasks/blob/main/task/buildah-oci-ta/MIGRATION.md |
+| `prefetch-dependencies-oci-ta` 0.3.2 → 0.6.0 | https://github.com/konflux-ci/build-pipeline-tasks/blob/main/task/prefetch-dependencies-oci-ta/MIGRATION.md |
+| `init` 0.4.2 → 0.4.3 | https://github.com/konflux-ci/build-pipeline-tasks/blob/main/task/init/MIGRATION.md |
+| `validate-fbc` 0.1 → 0.3 | https://github.com/konflux-ci/konflux-operator-tasks/blob/main/task/validate-fbc/0.3/MIGRATION.md |
+| `rpms-signature-scan` 0.2 → 0.2.1 | https://github.com/konflux-ci/tekton-tools/blob/main/tasks/rpms-signature-scan/0.2/MIGRATION.md |
+| `show-sbom` 0.1 → 0.3 | https://github.com/konflux-ci/build-definitions/tree/main/task/show-sbom/0.3/migrations |
+
+`build-pipeline-tasks` keeps a **single** `MIGRATION.md` per task (not per patch tag). Versioned dirs under `build-definitions/external-task/` are thin stubs only.
+
+## `updateDigests.sh` — print/open correct URLs
+
+Replace the hard-coded `build-definitions/blob/main/task/${url_frag}/MIGRATION.md` assignment with:
+
+```bash
+# major.minor from tag (0.10.7 -> 0.10, 0.4.3 -> 0.4)
+migrationDocURL() {
+	local task_name="$1"
+	local new_tag="$2"
+	local mm
+	mm="$(echo "${new_tag}" | sed -E 's/^([0-9]+\.[0-9]+).*/\1/')"
+	case "${task_name}" in
+		validate-fbc)
+			echo "https://github.com/konflux-ci/konflux-operator-tasks/blob/main/task/${task_name}/${mm}/MIGRATION.md"
+			;;
+		rpms-signature-scan)
+			echo "https://github.com/konflux-ci/tekton-tools/blob/main/tasks/${task_name}/${mm}/MIGRATION.md"
+			;;
+		show-sbom|summary)
+			echo "https://github.com/konflux-ci/build-definitions/tree/main/task/${task_name}/${mm}/migrations"
+			;;
+		buildah|buildah-*|git-clone|git-clone-*|init|prefetch-dependencies|prefetch-dependencies-*|build-image-index|build-image-index-*|push-dockerfile|push-dockerfile-*|source-build|source-build-*|apply-tags)
+			echo "https://github.com/konflux-ci/build-pipeline-tasks/blob/main/task/${task_name}/MIGRATION.md"
+			;;
+		*)
+			echo "https://github.com/konflux-ci/build-pipeline-tasks/blob/main/task/${task_name}/MIGRATION.md"
+			;;
+	esac
+}
+```
+
+When recording a tag bump:
+
+```bash
+task_name="${base#*/task-}"
+MIGRATIONS["${task_name}/${newTag}"]="$(migrationDocURL "${task_name}" "${newTag}")"
+```
+
+If an older `updateDigests.sh` still emits 404 `build-definitions/.../<full-tag>/MIGRATION.md` links, **ignore those URLs** and resolve via this map before fetching or opening a browser.


### PR DESCRIPTION
## Summary
- Add `references/migration-urls.md` mapping Konflux tasks to live `MIGRATION.md` locations (`build-pipeline-tasks`, `konflux-operator-tasks`, `tekton-tools`, remaining `build-definitions` migrations).
- Update skill workflow to resolve those URLs instead of deleted `build-definitions/task/<name>/<full-tag>/MIGRATION.md` paths ([9f9f0a4](https://github.com/konflux-ci/build-definitions/commit/9f9f0a4c92c15a1c7c85b14b1758cd223056f5ac)).
- Include `migrationDocURL` bash helper for `updateDigests.sh` so browser-opened links are correct (e.g. [buildah-oci-ta/MIGRATION.md](https://github.com/konflux-ci/build-pipeline-tasks/blob/main/task/buildah-oci-ta/MIGRATION.md)).

## Test plan
- [ ] Open mapped URLs from the new reference; confirm 200 / content loads
- [ ] Run skill on a midstream/plugin-catalog digest bump and confirm printed migration links are not 404s
- [ ] `uv run pytest tests/unit/test_skill_structure.py` (frontmatter)


Made with [Cursor](https://cursor.com)