### PR TITLE
feat(skills): add jira-pr-mr-link for GitHub/GitLab ↔ Jira linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ Track work across the four RHDH Jira projects.
 
 Automate the full PR lifecycle — build, changeset, commit, push, and create — for plugin monorepos.
 
-- **[raise-pr](./skills/raise-pr/SKILL.md)** — Full PR workflow for `rhdh-plugins` and `community-plugins`: detect workspace from staged changes, run build/validation, generate changesets, commit with sign-off, push, and create the GitHub PR. Auto-detects which repo you're in. Supports `--a` auto-approve mode to skip all approval gates. Accepts an optional Jira key or URL to link the PR — adds Web Link, comment, and transitions the issue to Review.
+- **[raise-pr](./skills/raise-pr/SKILL.md)** — Full PR workflow for `rhdh-plugins` and `community-plugins`: detect workspace from staged changes, run build/validation, generate changesets, commit with sign-off, push, and create the GitHub PR. Auto-detects which repo you're in. Supports `--a` auto-approve mode to skip all approval gates. Accepts an optional Jira key or URL to link the PR — prefers [`jira-pr-mr-link`](./skills/jira-pr-mr-link/SKILL.md) for Web link + comment, then transitions the issue to Review.
+- **[jira-pr-mr-link](./skills/jira-pr-mr-link/SKILL.md)** — Create GitHub PRs / GitLab MRs and link them to Jira (Web link, structured comment, optional missing-field defaults). General-purpose companion to `raise-pr`; use alone for non-plugin-monorepo repos or link-only / mark-merged flows.
 
 ### Bug Fix
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Track work across the four RHDH Jira projects.
 Automate the full PR lifecycle — build, changeset, commit, push, and create — for plugin monorepos.
 
 - **[raise-pr](./skills/raise-pr/SKILL.md)** — Full PR workflow for `rhdh-plugins` and `community-plugins`: detect workspace from staged changes, run build/validation, generate changesets, commit with sign-off, push, and create the GitHub PR. Auto-detects which repo you're in. Supports `--a` auto-approve mode to skip all approval gates. Accepts an optional Jira key or URL to link the PR — prefers [`jira-pr-mr-link`](./skills/jira-pr-mr-link/SKILL.md) for Web link + comment, then transitions the issue to Review.
-- **[jira-pr-mr-link](./skills/jira-pr-mr-link/SKILL.md)** — Create GitHub PRs / GitLab MRs and link them to Jira (Web link, structured comment, optional missing-field defaults). General-purpose companion to `raise-pr`; use alone for non-plugin-monorepo repos or link-only / mark-merged flows.
+- **[jira-pr-mr-link](./skills/jira-pr-mr-link/SKILL.md)** — Create GitHub PRs / GitLab MRs and link them to Jira (Web link, structured comment, optional missing-field defaults). Auto-moves RHDHPLAN Epic/Story/Task issues to RHIDP before applying defaults. General-purpose companion to `raise-pr`; use alone for non-plugin-monorepo repos or link-only / mark-merged flows.
 
 ### Bug Fix
 

--- a/skills/jira-pr-mr-link/SKILL.md
+++ b/skills/jira-pr-mr-link/SKILL.md
@@ -4,9 +4,10 @@ description: >-
   Create GitHub PRs / GitLab MRs and link them to Jira (Web link, comment,
   optional missing-field defaults, open diffs) via create-pr-mr.js, or link an
   existing PR/MR with link-pr-mr.js / mark-merged. Title format `repo #N: <title>`.
-  Use when opening a PR/MR that cites a Jira key, linking existing PRs/MRs to
-  Jira, marking merged Web links, or replacing hand-rolled remotelink/comment
-  steps. Complements raise-pr (plugin monorepos) without folding into it.
+  Use when linking existing PRs/MRs to Jira, marking merged Web links, replacing
+  hand-rolled remotelink/comment steps, or creating+linking outside the
+  rhdh-plugins / community-plugins raise-pr workflow. For the full monorepo PR
+  flow (build, changeset, recordings), use raise-pr instead.
 ---
 
 # Jira PR / MR create + Web links
@@ -17,12 +18,18 @@ empty issue fields. Prefer these scripts over hand-rolled `gh`/`glab` + REST/MCP
 for the Jira side.
 
 Scripts live under this skill’s `scripts/` directory. Resolve that path from the
-installed skill root (agents already have it when reading this file).
+installed skill root (agents already have it when reading this file):
 
 ```bash
-SKILL="$(dirname "$0")"   # or absolute path to skills/jira-pr-mr-link
+SKILL="$(cd "$(dirname "$0")" && pwd)"   # or absolute path to skills/jira-pr-mr-link
 node "$SKILL/scripts/create-pr-mr.js" …
 node "$SKILL/scripts/link-pr-mr.js" …
+```
+
+From `raise-pr`, use the relative skill path (do **not** invent `$JIRA_PR_MR_LINK_SKILL`):
+
+```bash
+node "../jira-pr-mr-link/scripts/link-pr-mr.js" link …
 ```
 
 ## Preferred: one-shot create (`create-pr-mr.js`)
@@ -49,15 +56,25 @@ EOF
 1. `git push -u origin HEAD` (unless `--no-push`)
 2. Detects GitHub vs GitLab from `origin`
 3. Runs `gh pr create` or `glab mr create`
-4. Runs `link-pr-mr.js link` (unless `--no-link`)
-5. Opens the diffs page (unless `--no-open`). Agents must **not** open it again
-   after this script succeeds — that produces a duplicate browser tab.
+4. Runs `link-pr-mr.js link` (unless `--no-link`) — **fails closed** if Jira auth
+   is missing (pass `--no-link` to skip)
+5. Opens the diffs page (unless `--no-open`)
 
-Flags: `--draft`, `--no-push`, `--no-link`, `--no-open`, `--host github|gitlab`.
+Flags: `--draft`, `--no-push`, `--no-link`, `--no-open`, `--no-defaults`,
+`--no-comment`, `--no-jira-ref`, `--host github|gitlab`.
 
-Requires `JIRA_API_TOKEN` + `~/.config/.jira/.config.yml` for linking.
-Appends `Ref: https://redhat.atlassian.net/browse/KEY` and `Generated-by: cursor`
-to the body when missing.
+### Auth
+
+Either works (same token either way):
+
+1. `JIRA_API_TOKEN` + `login`/`server` in `~/.config/.jira/.config.yml`, or
+2. `.jira-token` (`email:token`) next to `acli` — same as
+   [`rhdh-jira` auth](../rhdh-jira/references/auth.md)
+
+`create-pr-mr.js` appends `Ref: https://redhat.atlassian.net/browse/KEY` and
+`Generated-by: cursor` to the **PR/MR body** when missing. It skips the Jira
+`Ref:` line for `community-plugins` remotes (or when `--no-jira-ref` is set) so
+that repo stays free of Jira browse URLs in git history / PR text.
 
 ## Link-only: `link-pr-mr.js`
 
@@ -72,9 +89,19 @@ node "$SKILL/scripts/link-pr-mr.js" link \
 ```
 
 - `--host` optional; inferred from URL when omitted.
-- `--no-defaults` skips In Progress + metadata fills.
+- `--no-defaults` skips In Progress + metadata fills (Web link + comment still run).
 - `--no-comment` skips the Jira comment.
-- If a comment already mentions the PR/MR URL, it is **updated** in place.
+- If a comment already mentions the PR/MR URL, it is **updated** in place
+  (comments are paginated so busy tickets still match).
+
+### RHDHPLAN → RHIDP auto-move
+
+If the linked issue is an **Epic**, **Story**, or **Task** in **RHDHPLAN**,
+`link` moves it to **RHIDP** (same issue type) via the Jira bulk-move API, then
+continues Web link / defaults / comment on the **new** key. Features and other
+RHDHPLAN types are left alone.
+
+Stdout includes `move: …` and the post-move `issue:` key.
 
 Comment shape (only **newly set** fields — never lists `kept` values):
 
@@ -119,7 +146,8 @@ Merged: `[x] merged: <repo-short-name> #<id>: <full PR/MR title>`
 ## Defaults `link` applies (only if empty)
 
 **No built-in team/assignee values.** First run with defaults enabled requires a
-config file (or env/CLI). Missing keys error with copy/paste setup instructions.
+config file (or env/CLI). Missing keys error **when applying defaults** (Web link
++ comment still succeed with `--no-defaults`).
 
 ```bash
 mkdir -p ~/.config/jira-pr-mr-link
@@ -159,13 +187,14 @@ instead of hand-rolling remotelink/comment (see
 ## Agent checklist
 
 1. Resolve Jira key. Ask if missing (unless user skipped Jira).
-2. Commit on a feature branch (Jira browse URL + `Generated-by: cursor` in the body).
-3. Run **`create-pr-mr.js`** once. Report `url:` / `diffs:` and the linker summary.
-4. Do **not** also hand-roll `gh`/`glab` create + MCP comments for the same PR/MR.
-5. **Do not open the diffs twice.** `create-pr-mr.js` already opens the browser
-   (look for `[INFO] opened diffs:` or `diffs:` in stdout). Do **not** also run
-   `xdg-open` / `open` / equivalent unless you used raw `gh`/`glab` (or passed
-   `--no-open`).
+2. Commit on a feature branch. Put the Jira browse URL and `Generated-by: cursor`
+   in the **PR/MR body** (`create-pr-mr.js` appends them when missing; skips
+   `Ref:` for community-plugins).
+3. Run **`create-pr-mr.js`** once.
+4. Done when: `create-pr-mr.js` ran once, and you reported `url:` / `diffs:` /
+   `browserOpened:` / `jiraLink:` from its stdout.
+5. Treat `browserOpened: true` (or `--no-open`) as the open step already handled;
+   do not start a second create or browser open for the same PR/MR.
 6. Fallback: raw create → run `link-pr-mr.js`, then open diffs yourself once.
 7. For mark-merged: `link-pr-mr.js mark-merged --issue KEY`. Report results with
    markdown links (`[title](url)`), never bare `repo #N`. Prefer script stdout

--- a/skills/jira-pr-mr-link/SKILL.md
+++ b/skills/jira-pr-mr-link/SKILL.md
@@ -14,8 +14,7 @@ description: >-
 
 Zero-token Node scripts for **GitHub and GitLab**: create the PR/MR, attach a
 Jira remote Web link, post/update a structured comment, and optionally fill
-empty issue fields. Prefer these scripts over hand-rolled `gh`/`glab` + REST/MCP
-for the Jira side.
+empty issue fields.
 
 Scripts live under this skill’s `scripts/` directory. Resolve that path from the
 installed skill root (agents already have it when reading this file):
@@ -26,7 +25,7 @@ node "$SKILL/scripts/create-pr-mr.js" …
 node "$SKILL/scripts/link-pr-mr.js" …
 ```
 
-From `raise-pr`, use the relative skill path (do **not** invent `$JIRA_PR_MR_LINK_SKILL`):
+From `raise-pr`, call the linker with a relative path:
 
 ```bash
 node "../jira-pr-mr-link/scripts/link-pr-mr.js" link …
@@ -56,8 +55,8 @@ EOF
 1. `git push -u origin HEAD` (unless `--no-push`)
 2. Detects GitHub vs GitLab from `origin`
 3. Runs `gh pr create` or `glab mr create`
-4. Runs `link-pr-mr.js link` (unless `--no-link`) — **fails closed** if Jira auth
-   is missing (pass `--no-link` to skip)
+4. Runs `link-pr-mr.js link` (unless `--no-link`). Missing Jira auth is an
+   error; pass `--no-link` to skip linking.
 5. Opens the diffs page (unless `--no-open`)
 
 Flags: `--draft`, `--no-push`, `--no-link`, `--no-open`, `--no-defaults`,
@@ -92,7 +91,7 @@ node "$SKILL/scripts/link-pr-mr.js" link \
 - `--no-defaults` skips In Progress + metadata fills (Web link + comment still run).
 - `--no-comment` skips the Jira comment.
 - If a comment already mentions the PR/MR URL, it is **updated** in place
-  (comments are paginated so busy tickets still match).
+  (comments are paginated).
 
 ### RHDHPLAN → RHIDP auto-move
 
@@ -103,7 +102,7 @@ RHDHPLAN types are left alone.
 
 Stdout includes `move: …` and the post-move `issue:` key.
 
-Comment shape (only **newly set** fields — never lists `kept` values):
+Comment shape (only **newly set** fields; omit `kept` values):
 
 ```
 PR/MR:
@@ -126,14 +125,12 @@ Prefixes Web link titles with `[x] merged: `. Does not re-apply defaults/comment
 Stdout lists each title **and** its PR/MR URL (indented under the title).
 
 `mark-merged` checks merge status via `gh` / `glab`. Failed checks print a
-`warn:` line (do not treat silent failures as “still open”). For GitLab
-remotelinks it passes `--hostname` from the URL (e.g. `gitlab.cee.redhat.com`),
-so CEE MRs are not queried against `gitlab.com`. Prefer `glab` default
-`host: gitlab.cee.redhat.com` in `~/.config/glab-cli/config.yml` for day-to-day
-CEE work.
+`warn:` line. For GitLab remotelinks it passes `--hostname` from the URL
+(e.g. `gitlab.cee.redhat.com`), so CEE MRs resolve against the right host.
+Prefer `glab` default `host: gitlab.cee.redhat.com` in
+`~/.config/glab-cli/config.yml` for day-to-day CEE work.
 
-When summarizing updated/left-open items to the user, always use markdown links
-(`[title](url)`), never bare `repo #N` text.
+When summarizing to the user, use markdown links (`[title](url)`).
 
 ## Title format (for `link --title`)
 
@@ -156,7 +153,7 @@ cp "$SKILL/config.example.json" ~/.config/jira-pr-mr-link/config.json
 ```
 
 Also accepted: `$JIRA_PR_MR_CONFIG`, legacy `~/.config/jira-pr-mr-web-link/config.json`,
-or `$SKILL/config.local.json` (do not commit personal email).
+or `$SKILL/config.local.json` (gitignored — keep personal email out of the repo).
 
 Precedence: **CLI > env > config file > Jira CLI hints** (`login` / `board.id`
 from `~/.config/.jira/.config.yml` may fill assignee/board only).
@@ -167,7 +164,7 @@ from `~/.config/.jira/.config.yml` may fill assignee/board only).
 | `teamId` / `teamName` | yes |
 | `boardId` | yes (or jira CLI `board.id`) |
 | `storyPoints` | yes |
-| `priorityName` | yes (never overwrites an existing priority) |
+| `priorityName` | yes (only fills when priority is empty) |
 | `storyPointsField` / `teamField` / `sprintField` | yes (examples in `config.example.json`) |
 | Status | → **In Progress** unless already In Progress / Review / Closed |
 
@@ -175,14 +172,13 @@ Skip all defaults: `--no-defaults` or `JIRA_PR_MR_APPLY_DEFAULTS=0`.
 
 ## Relationship to `raise-pr`
 
-[`raise-pr`](../raise-pr/SKILL.md) stays scoped to **rhdh-plugins** /
-**community-plugins** (build, changesets, recordings). Do **not** fold this
-skill into it.
+[`raise-pr`](../raise-pr/SKILL.md) owns the **rhdh-plugins** /
+**community-plugins** monorepo PR flow (build, changesets, recordings). This
+skill owns the Jira Web link + comment (and optional defaults) for any repo.
 
-For the Jira side after `raise-pr` creates a PR, prefer calling `link-pr-mr.js`
-instead of hand-rolling remotelink/comment (see
-[references/raise-pr-integration.md](references/raise-pr-integration.md)). Use
-`--no-defaults` when `raise-pr` will transition the issue to **Review** itself.
+After `raise-pr` creates a PR, Step 11 calls `link-pr-mr.js` with `--no-defaults`
+so `raise-pr` can still transition the issue to **Review** (see
+[references/raise-pr-integration.md](references/raise-pr-integration.md)).
 
 ## Agent checklist
 
@@ -190,14 +186,9 @@ instead of hand-rolling remotelink/comment (see
 2. Commit on a feature branch. Put the Jira browse URL and `Generated-by: cursor`
    in the **PR/MR body** (`create-pr-mr.js` appends them when missing; skips
    `Ref:` for community-plugins).
-3. Run **`create-pr-mr.js`** once.
-4. Done when: `create-pr-mr.js` ran once, and you reported `url:` / `diffs:` /
-   `browserOpened:` / `jiraLink:` from its stdout.
-5. Treat `browserOpened: true` (or `--no-open`) as the open step already handled;
-   do not start a second create or browser open for the same PR/MR.
-6. Fallback: raw create → run `link-pr-mr.js`, then open diffs yourself once.
-7. For mark-merged: `link-pr-mr.js mark-merged --issue KEY`. Report results with
-   markdown links (`[title](url)`), never bare `repo #N`. Prefer script stdout
-   URL lines / remotelink URLs when present.
-8. **Always link PR/MRs in user-facing summaries** (create, link, or
-   mark-merged). Never list title-only `repo #N` text.
+3. Run **`create-pr-mr.js`** once. Report `url:` / `diffs:` / `browserOpened:` /
+   `jiraLink:` from its stdout (`browserOpened: true` or `--no-open` means the
+   open step is already done).
+4. Fallback: raw create → run `link-pr-mr.js`, then open diffs yourself once.
+5. For mark-merged: `link-pr-mr.js mark-merged --issue KEY`.
+6. In user-facing summaries, link PR/MRs as `[title](url)`.

--- a/skills/jira-pr-mr-link/SKILL.md
+++ b/skills/jira-pr-mr-link/SKILL.md
@@ -50,7 +50,8 @@ EOF
 2. Detects GitHub vs GitLab from `origin`
 3. Runs `gh pr create` or `glab mr create`
 4. Runs `link-pr-mr.js link` (unless `--no-link`)
-5. Opens the diffs page (unless `--no-open`)
+5. Opens the diffs page (unless `--no-open`). Agents must **not** open it again
+   after this script succeeds — that produces a duplicate browser tab.
 
 Flags: `--draft`, `--no-push`, `--no-link`, `--no-open`, `--host github|gitlab`.
 
@@ -150,5 +151,9 @@ instead of hand-rolling remotelink/comment (see
 2. Commit on a feature branch (Jira browse URL + `Generated-by: cursor` in the body).
 3. Run **`create-pr-mr.js`** once. Report `url:` / `diffs:` and the linker summary.
 4. Do **not** also hand-roll `gh`/`glab` create + MCP comments for the same PR/MR.
-5. Fallback: raw create → run `link-pr-mr.js`.
-6. For mark-merged: `link-pr-mr.js mark-merged --issue KEY`.
+5. **Do not open the diffs twice.** `create-pr-mr.js` already opens the browser
+   (look for `[INFO] opened diffs:` or `diffs:` in stdout). Do **not** also run
+   `xdg-open` / `open` / equivalent unless you used raw `gh`/`glab` (or passed
+   `--no-open`).
+6. Fallback: raw create → run `link-pr-mr.js`, then open diffs yourself once.
+7. For mark-merged: `link-pr-mr.js mark-merged --issue KEY`.

--- a/skills/jira-pr-mr-link/SKILL.md
+++ b/skills/jira-pr-mr-link/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: jira-pr-mr-link
+description: >-
+  Create GitHub PRs / GitLab MRs and link them to Jira (Web link, comment,
+  optional missing-field defaults, open diffs) via create-pr-mr.js, or link an
+  existing PR/MR with link-pr-mr.js / mark-merged. Title format `repo #N: <title>`.
+  Use when opening a PR/MR that cites a Jira key, linking existing PRs/MRs to
+  Jira, marking merged Web links, or replacing hand-rolled remotelink/comment
+  steps. Complements raise-pr (plugin monorepos) without folding into it.
+---
+
+# Jira PR / MR create + Web links
+
+Zero-token Node scripts for **GitHub and GitLab**: create the PR/MR, attach a
+Jira remote Web link, post/update a structured comment, and optionally fill
+empty issue fields. Prefer these scripts over hand-rolled `gh`/`glab` + REST/MCP
+for the Jira side.
+
+Scripts live under this skill’s `scripts/` directory. Resolve that path from the
+installed skill root (agents already have it when reading this file).
+
+```bash
+SKILL="$(dirname "$0")"   # or absolute path to skills/jira-pr-mr-link
+node "$SKILL/scripts/create-pr-mr.js" …
+node "$SKILL/scripts/link-pr-mr.js" …
+```
+
+## Preferred: one-shot create (`create-pr-mr.js`)
+
+After the feature branch is committed:
+
+```bash
+node "$SKILL/scripts/create-pr-mr.js" \
+  --issue RHIDP-12345 \
+  --title 'fix: short summary' \
+  --target main \
+  --body "$(cat <<'EOF'
+## Summary
+- …
+
+## Test plan
+- [ ] …
+
+Generated-by: cursor
+EOF
+)"
+```
+
+1. `git push -u origin HEAD` (unless `--no-push`)
+2. Detects GitHub vs GitLab from `origin`
+3. Runs `gh pr create` or `glab mr create`
+4. Runs `link-pr-mr.js link` (unless `--no-link`)
+5. Opens the diffs page (unless `--no-open`)
+
+Flags: `--draft`, `--no-push`, `--no-link`, `--no-open`, `--host github|gitlab`.
+
+Requires `JIRA_API_TOKEN` + `~/.config/.jira/.config.yml` for linking.
+Appends `Ref: https://redhat.atlassian.net/browse/KEY` and `Generated-by: cursor`
+to the body when missing.
+
+## Link-only: `link-pr-mr.js`
+
+When a PR/MR already exists:
+
+```bash
+node "$SKILL/scripts/link-pr-mr.js" link \
+  --issue RHIDP-12345 \
+  --url 'https://gitlab.cee.redhat.com/rhidp/example/-/merge_requests/817' \
+  --title 'example #817: fix: short summary' \
+  --host gitlab
+```
+
+- `--host` optional; inferred from URL when omitted.
+- `--no-defaults` skips In Progress + metadata fills.
+- `--no-comment` skips the Jira comment.
+- If a comment already mentions the PR/MR URL, it is **updated** in place.
+
+Comment shape (only **newly set** fields — never lists `kept` values):
+
+```
+PR/MR:
+* example #817: fix: short summary
+
+Adjusted fields:
+* Priority: Normal
+* Status: In Progress
+```
+
+Visible link text matches the Web link title (`repo #N: <title>`).
+
+### Mark merged
+
+```bash
+node "$SKILL/scripts/link-pr-mr.js" mark-merged --issue RHIDP-12345
+```
+
+Prefixes Web link titles with `[x] merged: `. Does not re-apply defaults/comment.
+
+## Title format (for `link --title`)
+
+```
+<repo-short-name> #<id>: <full PR/MR title>
+```
+
+Merged: `[x] merged: <repo-short-name> #<id>: <full PR/MR title>`
+
+## Defaults `link` applies (only if empty)
+
+**No built-in team/assignee values.** First run with defaults enabled requires a
+config file (or env/CLI). Missing keys error with copy/paste setup instructions.
+
+```bash
+mkdir -p ~/.config/jira-pr-mr-link
+cp "$SKILL/config.example.json" ~/.config/jira-pr-mr-link/config.json
+# edit assigneeEmail, teamId, teamName, boardId, …
+```
+
+Also accepted: `$JIRA_PR_MR_CONFIG`, legacy `~/.config/jira-pr-mr-web-link/config.json`,
+or `$SKILL/config.local.json` (do not commit personal email).
+
+Precedence: **CLI > env > config file > Jira CLI hints** (`login` / `board.id`
+from `~/.config/.jira/.config.yml` may fill assignee/board only).
+
+| Field | Required when applying defaults |
+|-------|----------------------------------|
+| `assigneeEmail` | yes (or Jira `login` email) |
+| `teamId` / `teamName` | yes |
+| `boardId` | yes (or jira CLI `board.id`) |
+| `storyPoints` | yes |
+| `priorityName` | yes (never overwrites an existing priority) |
+| `storyPointsField` / `teamField` / `sprintField` | yes (examples in `config.example.json`) |
+| Status | → **In Progress** unless already In Progress / Review / Closed |
+
+Skip all defaults: `--no-defaults` or `JIRA_PR_MR_APPLY_DEFAULTS=0`.
+
+## Relationship to `raise-pr`
+
+[`raise-pr`](../raise-pr/SKILL.md) stays scoped to **rhdh-plugins** /
+**community-plugins** (build, changesets, recordings). Do **not** fold this
+skill into it.
+
+For the Jira side after `raise-pr` creates a PR, prefer calling `link-pr-mr.js`
+instead of hand-rolling remotelink/comment (see
+[references/raise-pr-integration.md](references/raise-pr-integration.md)). Use
+`--no-defaults` when `raise-pr` will transition the issue to **Review** itself.
+
+## Agent checklist
+
+1. Resolve Jira key. Ask if missing (unless user skipped Jira).
+2. Commit on a feature branch (Jira browse URL + `Generated-by: cursor` in the body).
+3. Run **`create-pr-mr.js`** once. Report `url:` / `diffs:` and the linker summary.
+4. Do **not** also hand-roll `gh`/`glab` create + MCP comments for the same PR/MR.
+5. Fallback: raw create → run `link-pr-mr.js`.
+6. For mark-merged: `link-pr-mr.js mark-merged --issue KEY`.

--- a/skills/jira-pr-mr-link/SKILL.md
+++ b/skills/jira-pr-mr-link/SKILL.md
@@ -152,8 +152,8 @@ cp "$SKILL/config.example.json" ~/.config/jira-pr-mr-link/config.json
 # edit assigneeEmail, teamId, teamName, boardId, …
 ```
 
-Also accepted: `$JIRA_PR_MR_CONFIG`, legacy `~/.config/jira-pr-mr-web-link/config.json`,
-or `$SKILL/config.local.json` (keep personal email out of the repo).
+Also accepted: `$JIRA_PR_MR_CONFIG` or `$SKILL/config.local.json`
+(keep personal email out of the repo).
 
 Precedence: **CLI > env > config file > Jira CLI hints** (`login` / `board.id`
 from `~/.config/.jira/.config.yml` may fill assignee/board only).

--- a/skills/jira-pr-mr-link/SKILL.md
+++ b/skills/jira-pr-mr-link/SKILL.md
@@ -153,7 +153,7 @@ cp "$SKILL/config.example.json" ~/.config/jira-pr-mr-link/config.json
 ```
 
 Also accepted: `$JIRA_PR_MR_CONFIG`, legacy `~/.config/jira-pr-mr-web-link/config.json`,
-or `$SKILL/config.local.json` (gitignored — keep personal email out of the repo).
+or `$SKILL/config.local.json` (keep personal email out of the repo).
 
 Precedence: **CLI > env > config file > Jira CLI hints** (`login` / `board.id`
 from `~/.config/.jira/.config.yml` may fill assignee/board only).
@@ -161,14 +161,22 @@ from `~/.config/.jira/.config.yml` may fill assignee/board only).
 | Field | Required when applying defaults |
 |-------|----------------------------------|
 | `assigneeEmail` | yes (or Jira `login` email) |
-| `teamId` / `teamName` | yes |
-| `boardId` | yes (or jira CLI `board.id`) |
+| `teamId` / `teamName` | yes, or set either to `NONE` to skip team **and** sprint |
+| `boardId` | yes (or jira CLI `board.id`), unless team/sprint skipped via `NONE` |
 | `storyPoints` | yes |
 | `priorityName` | yes (only fills when priority is empty) |
-| `storyPointsField` / `teamField` / `sprintField` | yes (examples in `config.example.json`) |
+| `storyPointsField` | yes |
+| `teamField` / `sprintField` | yes, unless team/sprint skipped via `NONE` |
 | Status | → **In Progress** unless already In Progress / Review / Closed |
 
 Skip all defaults: `--no-defaults` or `JIRA_PR_MR_APPLY_DEFAULTS=0`.
+
+Skip only team + sprint (still set points / assignee / priority / In Progress):
+
+```json
+"teamName": "NONE",
+"teamId": "NONE"
+```
 
 ## Relationship to `raise-pr`
 

--- a/skills/jira-pr-mr-link/SKILL.md
+++ b/skills/jira-pr-mr-link/SKILL.md
@@ -96,11 +96,17 @@ node "$SKILL/scripts/link-pr-mr.js" mark-merged --issue RHIDP-12345
 ```
 
 Prefixes Web link titles with `[x] merged: `. Does not re-apply defaults/comment.
+Stdout lists each title **and** its PR/MR URL (indented under the title).
 
-`mark-merged` checks merge status via `gh` / `glab`. For GitLab remotelinks it
-passes `--hostname` from the URL (e.g. `gitlab.cee.redhat.com`), so CEE MRs are
-not queried against `gitlab.com`. Prefer `glab` default `host: gitlab.cee.redhat.com`
-in `~/.config/glab-cli/config.yml` for day-to-day CEE work.
+`mark-merged` checks merge status via `gh` / `glab`. Failed checks print a
+`warn:` line (do not treat silent failures as “still open”). For GitLab
+remotelinks it passes `--hostname` from the URL (e.g. `gitlab.cee.redhat.com`),
+so CEE MRs are not queried against `gitlab.com`. Prefer `glab` default
+`host: gitlab.cee.redhat.com` in `~/.config/glab-cli/config.yml` for day-to-day
+CEE work.
+
+When summarizing updated/left-open items to the user, always use markdown links
+(`[title](url)`), never bare `repo #N` text.
 
 ## Title format (for `link --title`)
 
@@ -161,4 +167,8 @@ instead of hand-rolling remotelink/comment (see
    `xdg-open` / `open` / equivalent unless you used raw `gh`/`glab` (or passed
    `--no-open`).
 6. Fallback: raw create → run `link-pr-mr.js`, then open diffs yourself once.
-7. For mark-merged: `link-pr-mr.js mark-merged --issue KEY`.
+7. For mark-merged: `link-pr-mr.js mark-merged --issue KEY`. Report results with
+   markdown links (`[title](url)`), never bare `repo #N`. Prefer script stdout
+   URL lines / remotelink URLs when present.
+8. **Always link PR/MRs in user-facing summaries** (create, link, or
+   mark-merged). Never list title-only `repo #N` text.

--- a/skills/jira-pr-mr-link/SKILL.md
+++ b/skills/jira-pr-mr-link/SKILL.md
@@ -97,6 +97,11 @@ node "$SKILL/scripts/link-pr-mr.js" mark-merged --issue RHIDP-12345
 
 Prefixes Web link titles with `[x] merged: `. Does not re-apply defaults/comment.
 
+`mark-merged` checks merge status via `gh` / `glab`. For GitLab remotelinks it
+passes `--hostname` from the URL (e.g. `gitlab.cee.redhat.com`), so CEE MRs are
+not queried against `gitlab.com`. Prefer `glab` default `host: gitlab.cee.redhat.com`
+in `~/.config/glab-cli/config.yml` for day-to-day CEE work.
+
 ## Title format (for `link --title`)
 
 ```

--- a/skills/jira-pr-mr-link/config.example.json
+++ b/skills/jira-pr-mr-link/config.example.json
@@ -1,0 +1,11 @@
+{
+  "assigneeEmail": "you@example.com",
+  "teamName": "RHDH Cope",
+  "teamId": "ec74d716-af36-4b3c-950f-f79213d08f71-4403",
+  "boardId": 11374,
+  "storyPoints": 1,
+  "priorityName": "Normal",
+  "storyPointsField": "customfield_10028",
+  "teamField": "customfield_10001",
+  "sprintField": "customfield_10020"
+}

--- a/skills/jira-pr-mr-link/references/raise-pr-integration.md
+++ b/skills/jira-pr-mr-link/references/raise-pr-integration.md
@@ -8,17 +8,25 @@ then keep `raise-pr`'s Review transition.
 REPO_SHORT="$(basename "$(git rev-parse --show-toplevel)")"
 PR_NUM=…   # from gh pr create output / API
 
-node "$SKILL/scripts/link-pr-mr.js" link \
+LINK_OUT="$(node "../jira-pr-mr-link/scripts/link-pr-mr.js" link \
   --issue "$JIRA_KEY" \
   --url "$PR_URL" \
   --title "${REPO_SHORT} #${PR_NUM}: ${PR_TITLE}" \
   --host github \
-  --no-defaults
+  --no-defaults)"
+echo "$LINK_OUT"
+# If the issue was a RHDHPLAN Epic/Story/Task, linker may have moved it to RHIDP —
+# prefer the post-move key from stdout for the Review transition:
+EFFECTIVE_KEY="$(printf '%s\n' "$LINK_OUT" | awk -F': ' '/^issue:/{print $2; exit}')"
+EFFECTIVE_KEY="${EFFECTIVE_KEY:-$JIRA_KEY}"
 
 # Then transition to Review (raise-pr intent — do not rely on linker In Progress):
-acli jira workitem transition --key "$JIRA_KEY" --status "Review" --yes
+acli jira workitem transition --key "$EFFECTIVE_KEY" --status "Review" --yes
 ```
 
 Why `--no-defaults`: the linker’s default status target is **In Progress**;
 `raise-pr` wants **Review** after PR submit. Defaults (story points, team, etc.)
 remain available for general agent sessions that use `create-pr-mr.js` alone.
+
+Path note: resolve `link-pr-mr.js` relative to the installed `skills/` tree (same
+shape as other cross-skill references). Do not invent `$JIRA_PR_MR_LINK_SKILL`.

--- a/skills/jira-pr-mr-link/references/raise-pr-integration.md
+++ b/skills/jira-pr-mr-link/references/raise-pr-integration.md
@@ -1,0 +1,25 @@
+# Optional: call this linker from `raise-pr`
+
+`raise-pr` Step 11 currently hand-rolls a Jira comment, Review transition, and
+remotelink. Prefer this skill’s linker for the Web link + comment, then keep
+`raise-pr`’s Review transition.
+
+```bash
+# After PR_URL and PR_TITLE are known (raise-pr Step 10):
+REPO_SHORT="$(basename "$(git rev-parse --show-toplevel)")"
+PR_NUM=…   # from gh pr create output / API
+
+node "$SKILL/scripts/link-pr-mr.js" link \
+  --issue "$JIRA_KEY" \
+  --url "$PR_URL" \
+  --title "${REPO_SHORT} #${PR_NUM}: ${PR_TITLE}" \
+  --host github \
+  --no-defaults
+
+# Then transition to Review (raise-pr intent — do not rely on linker In Progress):
+acli jira workitem transition --key "$JIRA_KEY" --status "Review" --yes
+```
+
+Why `--no-defaults`: the linker’s default status target is **In Progress**;
+`raise-pr` wants **Review** after PR submit. Defaults (story points, team, etc.)
+remain available for general agent sessions that use `create-pr-mr.js` alone.

--- a/skills/jira-pr-mr-link/references/raise-pr-integration.md
+++ b/skills/jira-pr-mr-link/references/raise-pr-integration.md
@@ -1,8 +1,7 @@
 # Optional: call this linker from `raise-pr`
 
-`raise-pr` Step 11 currently hand-rolls a Jira comment, Review transition, and
-remotelink. Prefer this skill’s linker for the Web link + comment, then keep
-`raise-pr`’s Review transition.
+`raise-pr` Step 11 should call this skill's linker for the Web link + comment,
+then keep `raise-pr`'s Review transition.
 
 ```bash
 # After PR_URL and PR_TITLE are known (raise-pr Step 10):

--- a/skills/jira-pr-mr-link/references/raise-pr-integration.md
+++ b/skills/jira-pr-mr-link/references/raise-pr-integration.md
@@ -1,7 +1,7 @@
-# Optional: call this linker from `raise-pr`
+# Call this linker from `raise-pr`
 
-`raise-pr` Step 11 should call this skill's linker for the Web link + comment,
-then keep `raise-pr`'s Review transition.
+`raise-pr` Step 11 calls this skill's linker for the Web link + comment, then
+runs its own **Review** transition.
 
 ```bash
 # After PR_URL and PR_TITLE are known (raise-pr Step 10):
@@ -15,18 +15,13 @@ LINK_OUT="$(node "../jira-pr-mr-link/scripts/link-pr-mr.js" link \
   --host github \
   --no-defaults)"
 echo "$LINK_OUT"
-# If the issue was a RHDHPLAN Epic/Story/Task, linker may have moved it to RHIDP —
-# prefer the post-move key from stdout for the Review transition:
+# RHDHPLAN Epic/Story/Task may have been moved to RHIDP — use post-move key:
 EFFECTIVE_KEY="$(printf '%s\n' "$LINK_OUT" | awk -F': ' '/^issue:/{print $2; exit}')"
 EFFECTIVE_KEY="${EFFECTIVE_KEY:-$JIRA_KEY}"
 
-# Then transition to Review (raise-pr intent — do not rely on linker In Progress):
 acli jira workitem transition --key "$EFFECTIVE_KEY" --status "Review" --yes
 ```
 
 Why `--no-defaults`: the linker’s default status target is **In Progress**;
 `raise-pr` wants **Review** after PR submit. Defaults (story points, team, etc.)
 remain available for general agent sessions that use `create-pr-mr.js` alone.
-
-Path note: resolve `link-pr-mr.js` relative to the installed `skills/` tree (same
-shape as other cross-skill references). Do not invent `$JIRA_PR_MR_LINK_SKILL`.

--- a/skills/jira-pr-mr-link/scripts/create-pr-mr.js
+++ b/skills/jira-pr-mr-link/scripts/create-pr-mr.js
@@ -1,0 +1,327 @@
+#!/usr/bin/env node
+/*
+  Create a GitHub PR or GitLab MR, then link it to Jira (web link + defaults + comment).
+
+  Prefer this over raw `gh pr create` / `glab mr create` in agent sessions so one
+  shell call covers push, create, Jira link, and opening diffs.
+
+  Jira comment markup is owned by link-pr-mr.js:
+    PR/MR:
+    * <a href="{url}">{repo} #{id}: {title}</a>   (same text as the Web link title)
+    Adjusted fields: (only newly set; omitted if none)
+
+  Usage:
+    create-pr-mr.js --issue KEY --title TITLE [--body BODY] [--target BRANCH]
+      [--draft] [--no-push] [--no-link] [--no-open] [--no-defaults] [--no-comment]
+      [--assignee EMAIL] [--team-id ID] [--board-id N] … (forwarded to link-pr-mr.js)
+
+  Auth: git remotes + gh/glab; JIRA_API_TOKEN for linking (unless --no-link).
+  Defaults: config required (see config.example.json); CLI > env > config > jira CLI hints.
+*/
+
+'use strict';
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const LINK_SCRIPT = path.join(__dirname, 'link-pr-mr.js');
+const JIRA_BROWSE = 'https://redhat.atlassian.net/browse';
+
+function usage(exitCode = 0) {
+  console.log(`Usage:
+  create-pr-mr.js --issue KEY --title TITLE [--body BODY] [--target BRANCH]
+    [--draft] [--no-push] [--no-link] [--no-open] [--no-defaults] [--no-comment]
+    [--assignee EMAIL] [--team-id ID] [--team-name NAME] [--board-id N]
+    [--story-points N] [--priority NAME] [--host github|gitlab]
+
+Creates a PR (GitHub) or MR (GitLab) from the current branch, links Jira, opens diffs.
+Jira defaults need ~/.config/jira-pr-mr-link/config.json (or env/CLI); see config.example.json.
+
+Examples:
+  create-pr-mr.js --issue RHIDP-12345 --title 'fix: widget' --target main \\
+    --body "$(cat <<'EOF'
+## Summary
+- ...
+
+Generated-by: cursor
+EOF
+)"
+`);
+  process.exit(exitCode);
+}
+
+function parseArgs(argv) {
+  const args = { _: [] };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === '-h' || a === '--help') {
+      usage(0);
+    }
+    if (a === '--draft') {
+      args.draft = true;
+      continue;
+    }
+    if (a === '--no-push') {
+      args.noPush = true;
+      continue;
+    }
+    if (a === '--no-link') {
+      args.noLink = true;
+      continue;
+    }
+    if (a === '--no-open') {
+      args.noOpen = true;
+      continue;
+    }
+    if (a === '--no-defaults') {
+      args.noDefaults = true;
+      continue;
+    }
+    if (a === '--no-comment') {
+      args.noComment = true;
+      continue;
+    }
+    if (a.startsWith('--')) {
+      const key = a.slice(2);
+      const val = argv[i + 1];
+      if (!val || val.startsWith('--')) {
+        throw new Error(`Missing value for --${key}`);
+      }
+      args[key] = val;
+      i += 1;
+      continue;
+    }
+    args._.push(a);
+  }
+  return args;
+}
+
+function run(cmd, cmdArgs, opts = {}) {
+  const out = spawnSync(cmd, cmdArgs, {
+    encoding: 'utf8',
+    env: { ...process.env, ...(opts.env || {}) },
+    cwd: opts.cwd || process.cwd(),
+  });
+  return {
+    status: out.status ?? 1,
+    stdout: out.stdout || '',
+    stderr: out.stderr || '',
+    combined: `${out.stdout || ''}${out.stderr || ''}`.trim(),
+  };
+}
+
+function git(args) {
+  const r = run('git', args);
+  if (r.status !== 0) {
+    throw new Error(`git ${args.join(' ')} failed: ${r.combined}`);
+  }
+  return r.stdout.trim();
+}
+
+function detectHost(explicit) {
+  if (explicit === 'github' || explicit === 'gitlab') {
+    return explicit;
+  }
+  const url = git(['remote', 'get-url', 'origin']);
+  if (/github\.com/i.test(url)) {
+    return 'github';
+  }
+  return 'gitlab';
+}
+
+function repoShortName() {
+  const url = git(['remote', 'get-url', 'origin']);
+  const cleaned = url.replace(/\.git$/, '');
+  const parts = cleaned.split(/[/:]/);
+  return parts[parts.length - 1] || 'repo';
+}
+
+function ensureBody(body, issue) {
+  let text = (body || '').trim();
+  const refLine = `Ref: ${JIRA_BROWSE}/${issue}`;
+  if (!text.includes(issue) && !text.includes(refLine)) {
+    text = text ? `${text}\n\n${refLine}` : refLine;
+  }
+  if (!/Generated-by:\s*cursor/i.test(text) && !/Assisted-by:\s*cursor/i.test(text)) {
+    text = `${text}\n\nGenerated-by: cursor`;
+  }
+  return `${text.trim()}\n`;
+}
+
+function parseCreatedUrl(text, host) {
+  if (host === 'github') {
+    const m = text.match(/https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/\d+/i);
+    return m ? m[0] : '';
+  }
+  const m = text.match(/https:\/\/[^\s]*gitlab[^\s]*\/.+?\/-\/merge_requests\/\d+/i);
+  return m ? m[0] : '';
+}
+
+function diffsUrl(url, host) {
+  if (host === 'github') {
+    return url.replace(/\/?$/, '') + '/files';
+  }
+  return url.replace(/\/?$/, '') + '/diffs';
+}
+
+function openBrowser(url) {
+  const opener =
+    process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'cmd' : 'xdg-open';
+  const args = process.platform === 'win32' ? ['/c', 'start', '', url] : [url];
+  spawnSync(opener, args, { stdio: 'ignore', detached: true });
+}
+
+function createGithub({ title, body, target, draft }) {
+  const args = ['pr', 'create', '--title', title, '--body', body];
+  if (target) args.push('--base', target);
+  if (draft) args.push('--draft');
+  const r = run('gh', args, { env: { CURSOR_JIRA_CREATE_PR_MR: '1' } });
+  if (r.status !== 0) {
+    throw new Error(`gh pr create failed: ${r.combined}`);
+  }
+  const url = parseCreatedUrl(r.combined, 'github');
+  if (!url) {
+    throw new Error(`gh pr create succeeded but no PR URL in output:\n${r.combined}`);
+  }
+  return { url, output: r.combined };
+}
+
+function createGitlab({ title, body, target, draft }) {
+  const args = ['mr', 'create', '--yes', '--title', title, '--description', body];
+  if (target) args.push('--target-branch', target);
+  if (draft) args.push('--draft');
+  // Prevent nested hook from double-linking if Cursor ever sees this command
+  const r = run('glab', args, { env: { CURSOR_JIRA_CREATE_PR_MR: '1' } });
+  if (r.status !== 0) {
+    throw new Error(`glab mr create failed: ${r.combined}`);
+  }
+  const url = parseCreatedUrl(r.combined, 'gitlab');
+  if (!url) {
+    throw new Error(`glab mr create succeeded but no MR URL in output:\n${r.combined}`);
+  }
+  return { url, output: r.combined };
+}
+
+function linkJira({ issue, url, title, host, linkArgs = {} }) {
+  if (!process.env.JIRA_API_TOKEN) {
+    console.warn('[WARN] JIRA_API_TOKEN not set; skipping Jira link');
+    return 'skipped — no JIRA_API_TOKEN';
+  }
+  const idMatch = url.match(/\/(?:pull|merge_requests)\/(\d+)/i);
+  const id = idMatch ? idMatch[1] : '?';
+  const linkTitle = `${repoShortName()} #${id}: ${title}`;
+  const argv = [
+    LINK_SCRIPT,
+    'link',
+    '--issue',
+    issue,
+    '--url',
+    url,
+    '--title',
+    linkTitle,
+    '--host',
+    host,
+  ];
+  const passthrough = [
+    ['assignee', '--assignee'],
+    ['team-id', '--team-id'],
+    ['team-name', '--team-name'],
+    ['board-id', '--board-id'],
+    ['story-points', '--story-points'],
+    ['priority', '--priority'],
+  ];
+  for (const [key, flag] of passthrough) {
+    if (linkArgs[key]) {
+      argv.push(flag, String(linkArgs[key]));
+    }
+  }
+  if (linkArgs.noDefaults) {
+    argv.push('--no-defaults');
+  }
+  if (linkArgs.noComment) {
+    argv.push('--no-comment');
+  }
+  const r = run(process.execPath, argv);
+  process.stdout.write(r.stdout);
+  if (r.stderr) {
+    process.stderr.write(r.stderr);
+  }
+  if (r.status !== 0) {
+    throw new Error(`link-pr-mr.js failed: ${r.combined}`);
+  }
+  return r.stdout.trim() || 'linked';
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const issue = args.issue;
+  const title = args.title;
+  if (!issue || !title) {
+    console.error('[ERROR] --issue and --title are required');
+    usage(1);
+  }
+
+  const host = detectHost(args.host);
+  const target = args.target || args.base || '';
+  const body = ensureBody(args.body || args.description || '', issue);
+
+  if (!args.noPush) {
+    console.log(`[INFO] git push -u origin HEAD`);
+    const push = run('git', ['push', '-u', 'origin', 'HEAD']);
+    if (push.status !== 0) {
+      throw new Error(`git push failed: ${push.combined}`);
+    }
+    if (push.combined) {
+      console.log(push.combined);
+    }
+  }
+
+  console.log(`[INFO] creating ${host === 'github' ? 'PR' : 'MR'} on ${host}`);
+  const created =
+    host === 'github'
+      ? createGithub({ title, body, target, draft: args.draft })
+      : createGitlab({ title, body, target, draft: args.draft });
+
+  console.log(`[INFO] created: ${created.url}`);
+
+  let linkSummary = 'skipped (--no-link)';
+  if (!args.noLink) {
+    linkSummary = linkJira({
+      issue,
+      url: created.url,
+      title,
+      host,
+      linkArgs: args,
+    });
+  }
+
+  const diffs = diffsUrl(created.url, host);
+  if (!args.noOpen) {
+    try {
+      openBrowser(diffs);
+      console.log(`[INFO] opened diffs: ${diffs}`);
+    } catch (err) {
+      console.warn(`[WARN] could not open browser: ${err.message}`);
+      console.log(`[INFO] diffs: ${diffs}`);
+    }
+  } else {
+    console.log(`[INFO] diffs: ${diffs}`);
+  }
+
+  // Machine-friendly trailer for agents / hooks
+  console.log('---');
+  console.log(`url: ${created.url}`);
+  console.log(`diffs: ${diffs}`);
+  console.log(`issue: ${issue}`);
+  console.log(`host: ${host}`);
+  console.log(`jiraLink: done`);
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(`[ERROR] ${err.message}`);
+  process.exit(1);
+}

--- a/skills/jira-pr-mr-link/scripts/create-pr-mr.js
+++ b/skills/jira-pr-mr-link/scripts/create-pr-mr.js
@@ -5,6 +5,9 @@
   Prefer this over raw `gh pr create` / `glab mr create` in agent sessions so one
   shell call covers push, create, Jira link, and opening diffs.
 
+  Agents: do NOT also run xdg-open/open on the diffs URL after this script —
+  it already opens the browser once (unless --no-open). Duplicate opens = two tabs.
+
   Jira comment markup is owned by link-pr-mr.js:
     PR/MR:
     * <a href="{url}">{repo} #{id}: {title}</a>   (same text as the Web link title)
@@ -314,6 +317,7 @@ function main() {
   console.log('---');
   console.log(`url: ${created.url}`);
   console.log(`diffs: ${diffs}`);
+  console.log(`browserOpened: ${args.noOpen ? 'false' : 'true'}`);
   console.log(`issue: ${issue}`);
   console.log(`host: ${host}`);
   console.log(`jiraLink: done`);

--- a/skills/jira-pr-mr-link/scripts/create-pr-mr.js
+++ b/skills/jira-pr-mr-link/scripts/create-pr-mr.js
@@ -16,18 +16,18 @@
   Usage:
     create-pr-mr.js --issue KEY --title TITLE [--body BODY] [--target BRANCH]
       [--draft] [--no-push] [--no-link] [--no-open] [--no-defaults] [--no-comment]
+      [--no-jira-ref]
       [--assignee EMAIL] [--team-id ID] [--board-id N] … (forwarded to link-pr-mr.js)
 
-  Auth: git remotes + gh/glab; JIRA_API_TOKEN for linking (unless --no-link).
+  Auth: git remotes + gh/glab; Jira via JIRA_API_TOKEN or .jira-token (unless --no-link).
   Defaults: config required (see config.example.json); CLI > env > config > jira CLI hints.
 */
 
 'use strict';
 
-const fs = require('node:fs');
-const os = require('node:os');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
+const { shouldAppendJiraRef, resolveJiraAuth } = require('./lib.js');
 
 const LINK_SCRIPT = path.join(__dirname, 'link-pr-mr.js');
 const JIRA_BROWSE = 'https://redhat.atlassian.net/browse';
@@ -36,11 +36,13 @@ function usage(exitCode = 0) {
   console.log(`Usage:
   create-pr-mr.js --issue KEY --title TITLE [--body BODY] [--target BRANCH]
     [--draft] [--no-push] [--no-link] [--no-open] [--no-defaults] [--no-comment]
+    [--no-jira-ref]
     [--assignee EMAIL] [--team-id ID] [--team-name NAME] [--board-id N]
     [--story-points N] [--priority NAME] [--host github|gitlab]
 
 Creates a PR (GitHub) or MR (GitLab) from the current branch, links Jira, opens diffs.
 Jira defaults need ~/.config/jira-pr-mr-link/config.json (or env/CLI); see config.example.json.
+Skips appending Ref: browse URL for community-plugins remotes (or with --no-jira-ref).
 
 Examples:
   create-pr-mr.js --issue RHIDP-12345 --title 'fix: widget' --target main \\
@@ -84,6 +86,10 @@ function parseArgs(argv) {
     }
     if (a === '--no-comment') {
       args.noComment = true;
+      continue;
+    }
+    if (a === '--no-jira-ref') {
+      args.noJiraRef = true;
       continue;
     }
     if (a.startsWith('--')) {
@@ -141,10 +147,18 @@ function repoShortName() {
   return parts[parts.length - 1] || 'repo';
 }
 
-function ensureBody(body, issue) {
+function originRemoteUrl() {
+  try {
+    return git(['remote', 'get-url', 'origin']);
+  } catch {
+    return '';
+  }
+}
+
+function ensureBody(body, issue, { appendJiraRef }) {
   let text = (body || '').trim();
   const refLine = `Ref: ${JIRA_BROWSE}/${issue}`;
-  if (!text.includes(issue) && !text.includes(refLine)) {
+  if (appendJiraRef && !text.includes(issue) && !text.includes(refLine)) {
     text = text ? `${text}\n\n${refLine}` : refLine;
   }
   if (!/Generated-by:\s*cursor/i.test(text) && !/Assisted-by:\s*cursor/i.test(text)) {
@@ -195,7 +209,6 @@ function createGitlab({ title, body, target, draft }) {
   const args = ['mr', 'create', '--yes', '--title', title, '--description', body];
   if (target) args.push('--target-branch', target);
   if (draft) args.push('--draft');
-  // Prevent nested hook from double-linking if Cursor ever sees this command
   const r = run('glab', args, { env: { CURSOR_JIRA_CREATE_PR_MR: '1' } });
   if (r.status !== 0) {
     throw new Error(`glab mr create failed: ${r.combined}`);
@@ -207,11 +220,18 @@ function createGitlab({ title, body, target, draft }) {
   return { url, output: r.combined };
 }
 
-function linkJira({ issue, url, title, host, linkArgs = {} }) {
-  if (!process.env.JIRA_API_TOKEN) {
-    console.warn('[WARN] JIRA_API_TOKEN not set; skipping Jira link');
-    return 'skipped — no JIRA_API_TOKEN';
+function assertJiraAuthAvailable() {
+  try {
+    resolveJiraAuth();
+  } catch (err) {
+    throw new Error(
+      `${err.message}\n\nPass --no-link to create the PR/MR without Jira linking.`,
+    );
   }
+}
+
+function linkJira({ issue, url, title, host, linkArgs = {} }) {
+  assertJiraAuthAvailable();
   const idMatch = url.match(/\/(?:pull|merge_requests)\/(\d+)/i);
   const id = idMatch ? idMatch[1] : '?';
   const linkTitle = `${repoShortName()} #${id}: ${title}`;
@@ -268,7 +288,12 @@ function main() {
 
   const host = detectHost(args.host);
   const target = args.target || args.base || '';
-  const body = ensureBody(args.body || args.description || '', issue);
+  const remoteUrl = originRemoteUrl();
+  const appendJiraRef = shouldAppendJiraRef({
+    noJiraRef: Boolean(args.noJiraRef),
+    remoteUrl,
+  });
+  const body = ensureBody(args.body || args.description || '', issue, { appendJiraRef });
 
   if (!args.noPush) {
     console.log(`[INFO] git push -u origin HEAD`);
@@ -289,15 +314,16 @@ function main() {
 
   console.log(`[INFO] created: ${created.url}`);
 
-  let linkSummary = 'skipped (--no-link)';
+  let jiraLink = 'skipped';
   if (!args.noLink) {
-    linkSummary = linkJira({
+    linkJira({
       issue,
       url: created.url,
       title,
       host,
       linkArgs: args,
     });
+    jiraLink = 'done';
   }
 
   const diffs = diffsUrl(created.url, host);
@@ -313,14 +339,14 @@ function main() {
     console.log(`[INFO] diffs: ${diffs}`);
   }
 
-  // Machine-friendly trailer for agents / hooks
   console.log('---');
   console.log(`url: ${created.url}`);
   console.log(`diffs: ${diffs}`);
   console.log(`browserOpened: ${args.noOpen ? 'false' : 'true'}`);
   console.log(`issue: ${issue}`);
   console.log(`host: ${host}`);
-  console.log(`jiraLink: done`);
+  console.log(`jiraLink: ${jiraLink}`);
+  console.log(`jiraRef: ${appendJiraRef ? 'appended' : 'skipped'}`);
 }
 
 try {

--- a/skills/jira-pr-mr-link/scripts/create-pr-mr.js
+++ b/skills/jira-pr-mr-link/scripts/create-pr-mr.js
@@ -26,7 +26,7 @@
 
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
-const { shouldAppendJiraRef, resolveJiraAuth } = require('./lib.js');
+const { shouldAppendJiraRef, resolveJiraAuth, parseArgs: parseArgv } = require('./lib.js');
 
 const LINK_SCRIPT = path.join(__dirname, 'link-pr-mr.js');
 const JIRA_BROWSE = 'https://redhat.atlassian.net/browse';
@@ -57,53 +57,18 @@ EOF
 }
 
 function parseArgs(argv) {
-  const args = { _: [] };
-  for (let i = 0; i < argv.length; i += 1) {
-    const a = argv[i];
-    if (a === '-h' || a === '--help') {
-      usage(0);
-    }
-    if (a === '--draft') {
-      args.draft = true;
-      continue;
-    }
-    if (a === '--no-push') {
-      args.noPush = true;
-      continue;
-    }
-    if (a === '--no-link') {
-      args.noLink = true;
-      continue;
-    }
-    if (a === '--no-open') {
-      args.noOpen = true;
-      continue;
-    }
-    if (a === '--no-defaults') {
-      args.noDefaults = true;
-      continue;
-    }
-    if (a === '--no-comment') {
-      args.noComment = true;
-      continue;
-    }
-    if (a === '--no-jira-ref') {
-      args.noJiraRef = true;
-      continue;
-    }
-    if (a.startsWith('--')) {
-      const key = a.slice(2);
-      const val = argv[i + 1];
-      if (!val || val.startsWith('--')) {
-        throw new Error(`Missing value for --${key}`);
-      }
-      args[key] = val;
-      i += 1;
-      continue;
-    }
-    args._.push(a);
-  }
-  return args;
+  return parseArgv(argv, {
+    booleanFlags: [
+      'draft',
+      'no-push',
+      'no-link',
+      'no-open',
+      'no-defaults',
+      'no-comment',
+      'no-jira-ref',
+    ],
+    onHelp: () => usage(0),
+  });
 }
 
 function run(cmd, cmdArgs, opts = {}) {

--- a/skills/jira-pr-mr-link/scripts/create-pr-mr.js
+++ b/skills/jira-pr-mr-link/scripts/create-pr-mr.js
@@ -5,8 +5,7 @@
   Prefer this over raw `gh pr create` / `glab mr create` in agent sessions so one
   shell call covers push, create, Jira link, and opening diffs.
 
-  Agents: do NOT also run xdg-open/open on the diffs URL after this script —
-  it already opens the browser once (unless --no-open). Duplicate opens = two tabs.
+  Opens diffs once unless --no-open (agents: report browserOpened from stdout).
 
   Jira comment markup is owned by link-pr-mr.js:
     PR/MR:

--- a/skills/jira-pr-mr-link/scripts/lib.js
+++ b/skills/jira-pr-mr-link/scripts/lib.js
@@ -1,0 +1,288 @@
+'use strict';
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const MERGED_PREFIX = '[x] merged: ';
+const MOVEABLE_RHDHPLAN_TYPES = new Set(['Epic', 'Story', 'Task']);
+const RHDHPLAN_PROJECT = 'RHDHPLAN';
+const RHIDP_PROJECT = 'RHIDP';
+const DEFAULT_JIRA_SERVER = 'https://redhat.atlassian.net';
+
+const ADJUSTED_FIELD_LABELS = {
+  storyPoints: 'Story points',
+  team: 'Team',
+  sprint: 'Sprint',
+  assignee: 'Assignee',
+  priority: 'Priority',
+};
+
+const REQUIRED_DEFAULT_KEYS = [
+  'assigneeEmail',
+  'teamId',
+  'teamName',
+  'boardId',
+  'storyPoints',
+  'priorityName',
+  'storyPointsField',
+  'teamField',
+  'sprintField',
+];
+
+function pickDefined(obj) {
+  const out = {};
+  for (const [k, v] of Object.entries(obj || {})) {
+    if (v !== undefined && v !== null && v !== '') {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
+function detectHost(url, explicit) {
+  if (explicit === 'gitlab' || explicit === 'github') {
+    return explicit;
+  }
+  if (/github\.com/i.test(url || '')) {
+    return 'github';
+  }
+  return 'gitlab';
+}
+
+function stripMergedPrefix(title) {
+  return String(title || '')
+    .replace(/^\[x\]\s*merged:\s*/i, '')
+    .replace(/^merged:\s*/i, '')
+    .trim();
+}
+
+function withMergedPrefix(title) {
+  return `${MERGED_PREFIX}${stripMergedPrefix(title)}`;
+}
+
+/** Human title from linker title `repo #N: <title>` (optional `[x] merged: ` prefix). */
+function displayTitleFromLinkTitle(title) {
+  return (
+    String(title || '')
+      .replace(/^\[x\]\s*merged:\s*/i, '')
+      .replace(/^[^#\n]+#\d+:\s*/, '')
+      .trim() || String(title || '').trim()
+  );
+}
+
+/** Only fields newly set by this run (ignore kept/unchanged). */
+function collectAdjustedFieldLines(defaults, statusLine) {
+  const items = [];
+  if (defaults) {
+    for (const [key, value] of Object.entries(defaults)) {
+      if (typeof value === 'string' && value.startsWith('set ')) {
+        const label = ADJUSTED_FIELD_LABELS[key] || key;
+        items.push(`${label}: ${value.slice(4)}`);
+      }
+    }
+  }
+  if (typeof statusLine === 'string' && statusLine.startsWith('transitioned ')) {
+    const to = (statusLine.match(/→\s*(.+)$/) || [])[1]?.trim() || 'In Progress';
+    items.push(`Status: ${to}`);
+  }
+  return items;
+}
+
+/**
+ * Merge defaults: jira CLI hints < config file < env < CLI.
+ * Explicit config/env/CLI must win over go-jira board/login hints.
+ */
+function mergeDefaultsLayers({ fromJiraCli = {}, fromFile = {}, fromEnv = {}, fromCli = {} } = {}) {
+  return {
+    ...fromJiraCli,
+    ...fromFile,
+    ...fromEnv,
+    ...fromCli,
+  };
+}
+
+function missingDefaultKeys(merged) {
+  return REQUIRED_DEFAULT_KEYS.filter((k) => {
+    const v = merged[k];
+    return v === undefined || v === null || v === '';
+  });
+}
+
+function shouldMoveRhdhplanDeliveryIssue(projectKey, issueTypeName) {
+  return (
+    String(projectKey || '').toUpperCase() === RHDHPLAN_PROJECT &&
+    MOVEABLE_RHDHPLAN_TYPES.has(String(issueTypeName || ''))
+  );
+}
+
+function buildBulkMovePayload(issueKey, targetProject, issueTypeId) {
+  return {
+    sendBulkNotification: false,
+    targetToSourcesMapping: {
+      [`${targetProject},${issueTypeId}`]: {
+        inferClassificationDefaults: true,
+        inferFieldDefaults: true,
+        inferStatusDefaults: true,
+        inferSubtaskTypeDefault: true,
+        issueIdsOrKeys: [issueKey],
+      },
+    },
+  };
+}
+
+/**
+ * Append Jira browse Ref unless disabled or the remote is community-plugins
+ * (raise-pr keeps Jira out of that repo's git history / PR bodies).
+ */
+function shouldAppendJiraRef({ noJiraRef = false, remoteUrl = '' } = {}) {
+  if (noJiraRef) {
+    return false;
+  }
+  if (/community-plugins/i.test(remoteUrl || '')) {
+    return false;
+  }
+  return true;
+}
+
+function parseEmailToken(raw) {
+  const text = String(raw || '').trim();
+  if (!text) {
+    return null;
+  }
+  // Prefer splitting on the first colon after an email-shaped left side.
+  const at = text.indexOf('@');
+  const colon = text.indexOf(':', at > 0 ? at : 0);
+  if (at > 0 && colon > at) {
+    return { login: text.slice(0, colon), token: text.slice(colon + 1) };
+  }
+  return null;
+}
+
+function findJiraTokenFile() {
+  const candidates = [];
+  const which = spawnSync('which', ['acli'], { encoding: 'utf8' });
+  if (which.status === 0 && which.stdout.trim()) {
+    const acliPath = which.stdout.trim();
+    const resolved = spawnSync('readlink', ['-f', acliPath], { encoding: 'utf8' });
+    const real = (resolved.status === 0 && resolved.stdout.trim()) || acliPath;
+    candidates.push(path.join(path.dirname(real), '.jira-token'));
+    candidates.push(path.join(path.dirname(acliPath), '.jira-token'));
+  }
+  candidates.push(path.join(os.homedir(), '.local', 'bin', '.jira-token'));
+  candidates.push(path.join(os.homedir(), '.jira-token'));
+  for (const p of candidates) {
+    if (p && fs.existsSync(p)) {
+      return p;
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve Jira Basic auth from (in order of preference for token/login):
+ * - JIRA_API_TOKEN (+ login from go-jira config / JIRA_EMAIL)
+ * - .jira-token next to acli (email:token) — same as rhdh-jira REST fallback
+ * Server from go-jira config, JIRA_SERVER, or redhat.atlassian.net.
+ */
+function resolveJiraAuth({
+  env = process.env,
+  jiraConfigPath = path.join(os.homedir(), '.config', '.jira', '.config.yml'),
+  tokenFilePath = undefined,
+} = {}) {
+  let fileLogin;
+  let fileServer;
+  let boardId;
+  if (fs.existsSync(jiraConfigPath)) {
+    const text = fs.readFileSync(jiraConfigPath, 'utf8');
+    fileLogin = (text.match(/^login:\s*(.+)$/m) || [])[1]?.trim();
+    fileServer = (text.match(/^server:\s*(.+)$/m) || [])[1]?.trim()?.replace(/\/$/, '');
+    const boardMatch = text.match(/board:\s*\n\s*id:\s*(\d+)/);
+    boardId = boardMatch ? Number(boardMatch[1]) : undefined;
+  }
+
+  let login = env.JIRA_EMAIL || fileLogin || '';
+  let token = env.JIRA_API_TOKEN || '';
+  let server = (env.JIRA_SERVER || fileServer || DEFAULT_JIRA_SERVER).replace(/\/$/, '');
+  let authSource = token ? 'JIRA_API_TOKEN' : null;
+
+  const embedded = parseEmailToken(token);
+  if (embedded) {
+    login = embedded.login;
+    token = embedded.token;
+    authSource = 'JIRA_API_TOKEN (email:token)';
+  }
+
+  if (!token || !login) {
+    const tokenPath = tokenFilePath !== undefined ? tokenFilePath : findJiraTokenFile();
+    if (tokenPath && fs.existsSync(tokenPath)) {
+      const parsed = parseEmailToken(fs.readFileSync(tokenPath, 'utf8'));
+      if (parsed) {
+        login = login || parsed.login;
+        token = token || parsed.token;
+        authSource = `.jira-token (${tokenPath})`;
+      }
+    }
+  }
+
+  if (!token || !login) {
+    const err = new Error(
+      [
+        'Jira auth missing.',
+        '',
+        'Option A (go-jira): set JIRA_API_TOKEN and ensure ~/.config/.jira/.config.yml has login/server.',
+        'Option B (rhdh-jira): create email:token at .jira-token next to acli',
+        '  (see skills/rhdh-jira/references/auth.md).',
+        'Option C: export JIRA_EMAIL and JIRA_API_TOKEN.',
+      ].join('\n'),
+    );
+    err.code = 'JIRA_AUTH_MISSING';
+    throw err;
+  }
+
+  return {
+    login,
+    token,
+    server,
+    boardId,
+    authSource,
+  };
+}
+
+function parsePrMrUrl(url) {
+  let m = String(url || '').match(/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/i);
+  if (m) {
+    return { kind: 'github', owner: m[1], repo: m[2], id: m[3] };
+  }
+  m = String(url || '').match(/https?:\/\/(gitlab[^/]*)\/(.+?)\/-\/merge_requests\/(\d+)/i);
+  if (m) {
+    return { kind: 'gitlab', host: m[1], project: m[2], id: m[3] };
+  }
+  return null;
+}
+
+module.exports = {
+  ADJUSTED_FIELD_LABELS,
+  DEFAULT_JIRA_SERVER,
+  MERGED_PREFIX,
+  MOVEABLE_RHDHPLAN_TYPES,
+  REQUIRED_DEFAULT_KEYS,
+  RHDHPLAN_PROJECT,
+  RHIDP_PROJECT,
+  buildBulkMovePayload,
+  collectAdjustedFieldLines,
+  detectHost,
+  displayTitleFromLinkTitle,
+  findJiraTokenFile,
+  mergeDefaultsLayers,
+  missingDefaultKeys,
+  parseEmailToken,
+  parsePrMrUrl,
+  pickDefined,
+  resolveJiraAuth,
+  shouldAppendJiraRef,
+  shouldMoveRhdhplanDeliveryIssue,
+  stripMergedPrefix,
+  withMergedPrefix,
+};

--- a/skills/jira-pr-mr-link/scripts/lib.js
+++ b/skills/jira-pr-mr-link/scripts/lib.js
@@ -31,6 +31,33 @@ const REQUIRED_DEFAULT_KEYS = [
   'sprintField',
 ];
 
+/** Keys only required when team/sprint defaults are enabled. */
+const TEAM_SPRINT_DEFAULT_KEYS = [
+  'teamId',
+  'teamName',
+  'boardId',
+  'teamField',
+  'sprintField',
+];
+
+/** Config/CLI sentinel values that mean “skip this field group”. */
+const SKIP_SENTINELS = new Set(['none', 'null', 'skip', '-']);
+
+function isSkipSentinel(value) {
+  if (value === null || value === undefined) {
+    return false;
+  }
+  if (typeof value === 'string' && value.trim() === '') {
+    return false;
+  }
+  return SKIP_SENTINELS.has(String(value).trim().toLowerCase());
+}
+
+/** Skip team + sprint when teamId or teamName is NONE (or another sentinel). */
+function shouldSkipTeamAndSprint(defaults = {}) {
+  return isSkipSentinel(defaults.teamId) || isSkipSentinel(defaults.teamName);
+}
+
 function pickDefined(obj) {
   const out = {};
   for (const [k, v] of Object.entries(obj || {})) {
@@ -104,8 +131,15 @@ function mergeDefaultsLayers({ fromJiraCli = {}, fromFile = {}, fromEnv = {}, fr
 }
 
 function missingDefaultKeys(merged) {
+  const skipTeamSprint = shouldSkipTeamAndSprint(merged);
   return REQUIRED_DEFAULT_KEYS.filter((k) => {
+    if (skipTeamSprint && TEAM_SPRINT_DEFAULT_KEYS.includes(k)) {
+      return false;
+    }
     const v = merged[k];
+    if (isSkipSentinel(v)) {
+      return false;
+    }
     return v === undefined || v === null || v === '';
   });
 }
@@ -262,6 +296,44 @@ function parsePrMrUrl(url) {
   return null;
 }
 
+/** kebab-case flag → camelCase property (`no-defaults` → `noDefaults`). */
+function flagToCamel(flag) {
+  return String(flag).replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+}
+
+/**
+ * Minimal argv parser.
+ * @param {string[]} argv
+ * @param {{ booleanFlags?: string[], onHelp?: () => void }} [opts]
+ */
+function parseArgs(argv, { booleanFlags = [], onHelp } = {}) {
+  const bool = new Set(booleanFlags);
+  const args = { _: [] };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === '-h' || a === '--help') {
+      if (typeof onHelp === 'function') onHelp();
+      continue;
+    }
+    if (!a.startsWith('--')) {
+      args._.push(a);
+      continue;
+    }
+    const key = a.slice(2);
+    if (bool.has(key)) {
+      args[flagToCamel(key)] = true;
+      continue;
+    }
+    const val = argv[i + 1];
+    if (!val || val.startsWith('--')) {
+      throw new Error(`Missing value for --${key}`);
+    }
+    args[key] = val;
+    i += 1;
+  }
+  return args;
+}
+
 module.exports = {
   ADJUSTED_FIELD_LABELS,
   DEFAULT_JIRA_SERVER,
@@ -275,14 +347,18 @@ module.exports = {
   detectHost,
   displayTitleFromLinkTitle,
   findJiraTokenFile,
+  flagToCamel,
+  isSkipSentinel,
   mergeDefaultsLayers,
   missingDefaultKeys,
+  parseArgs,
   parseEmailToken,
   parsePrMrUrl,
   pickDefined,
   resolveJiraAuth,
   shouldAppendJiraRef,
   shouldMoveRhdhplanDeliveryIssue,
+  shouldSkipTeamAndSprint,
   stripMergedPrefix,
   withMergedPrefix,
 };

--- a/skills/jira-pr-mr-link/scripts/link-pr-mr.js
+++ b/skills/jira-pr-mr-link/scripts/link-pr-mr.js
@@ -39,17 +39,10 @@ const {
 
 const USER_CONFIG_DIR = path.join(os.homedir(), '.config', 'jira-pr-mr-link');
 const USER_CONFIG_PATH = path.join(USER_CONFIG_DIR, 'config.json');
-const LEGACY_USER_CONFIG_PATH = path.join(
-  os.homedir(),
-  '.config',
-  'jira-pr-mr-web-link',
-  'config.json',
-);
 const EXAMPLE_CONFIG_PATH = path.join(__dirname, '..', 'config.example.json');
 const SKILL_CONFIG_PATHS = [
   process.env.JIRA_PR_MR_CONFIG,
   USER_CONFIG_PATH,
-  LEGACY_USER_CONFIG_PATH,
   path.join(__dirname, '..', 'config.local.json'),
 ].filter(Boolean);
 

--- a/skills/jira-pr-mr-link/scripts/link-pr-mr.js
+++ b/skills/jira-pr-mr-link/scripts/link-pr-mr.js
@@ -688,9 +688,10 @@ function parsePrMrUrl(url) {
   if (m) {
     return { kind: 'github', owner: m[1], repo: m[2], id: m[3] };
   }
-  m = url.match(/gitlab[^/]*\/(.+?)\/-\/merge_requests\/(\d+)/i);
+  // Capture host so glab targets gitlab.cee.redhat.com (not default gitlab.com).
+  m = url.match(/https?:\/\/(gitlab[^/]*)\/(.+?)\/-\/merge_requests\/(\d+)/i);
   if (m) {
-    return { kind: 'gitlab', project: m[1], id: m[2] };
+    return { kind: 'gitlab', host: m[1], project: m[2], id: m[3] };
   }
   return null;
 }
@@ -705,11 +706,12 @@ function isMerged(ref) {
     return out.status === 0 && String(out.stdout).trim() === 'true';
   }
   const project = encodeURIComponent(ref.project);
-  const out = spawnSync(
-    'glab',
-    ['api', `projects/${project}/merge_requests/${ref.id}`],
-    { encoding: 'utf8' },
-  );
+  const glabArgs = ['api'];
+  if (ref.host) {
+    glabArgs.push('--hostname', ref.host);
+  }
+  glabArgs.push(`projects/${project}/merge_requests/${ref.id}`);
+  const out = spawnSync('glab', glabArgs, { encoding: 'utf8' });
   if (out.status !== 0) {
     return false;
   }

--- a/skills/jira-pr-mr-link/scripts/link-pr-mr.js
+++ b/skills/jira-pr-mr-link/scripts/link-pr-mr.js
@@ -1,12 +1,15 @@
 #!/usr/bin/env node
 /*
-  Jira PR/MR Web link helper for skill jira-pr-mr-web-link.
+  Jira PR/MR Web link helper for skill jira-pr-mr-link.
 
   Commands:
-    link         Create/update a Web link, apply missing configured defaults, In Progress
+    link         Create/update a Web link, apply missing configured defaults, In Progress.
+                 Auto-moves RHDHPLAN Epic/Story/Task → RHIDP first.
     mark-merged  Prefix remotelink titles with "[x] merged: " for merged PRs/MRs
 
-  Auth: $JIRA_API_TOKEN + login/server from ~/.config/.jira/.config.yml
+  Auth (either):
+    - $JIRA_API_TOKEN + login/server from ~/.config/.jira/.config.yml
+    - .jira-token (email:token) next to acli — same as rhdh-jira REST/GraphQL
 */
 
 'use strict';
@@ -16,7 +19,22 @@ const os = require('node:os');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
-const JIRA_CONFIG = path.join(os.homedir(), '.config', '.jira', '.config.yml');
+const {
+  DEFAULT_JIRA_SERVER,
+  RHIDP_PROJECT,
+  buildBulkMovePayload,
+  collectAdjustedFieldLines,
+  detectHost,
+  displayTitleFromLinkTitle,
+  mergeDefaultsLayers,
+  missingDefaultKeys,
+  parsePrMrUrl,
+  pickDefined,
+  resolveJiraAuth,
+  shouldMoveRhdhplanDeliveryIssue,
+  withMergedPrefix,
+} = require('./lib.js');
+
 const USER_CONFIG_DIR = path.join(os.homedir(), '.config', 'jira-pr-mr-link');
 const USER_CONFIG_PATH = path.join(USER_CONFIG_DIR, 'config.json');
 const LEGACY_USER_CONFIG_PATH = path.join(
@@ -33,19 +51,6 @@ const SKILL_CONFIG_PATHS = [
   path.join(__dirname, '..', 'config.local.json'),
 ].filter(Boolean);
 
-/** Keys required when applying missing-field defaults (no silent builtins). */
-const REQUIRED_DEFAULT_KEYS = [
-  'assigneeEmail',
-  'teamId',
-  'teamName',
-  'boardId',
-  'storyPoints',
-  'priorityName',
-  'storyPointsField',
-  'teamField',
-  'sprintField',
-];
-
 const ICONS = {
   gitlab: {
     application: { type: 'com.gitlab', name: 'GitLab' },
@@ -61,7 +66,6 @@ const ICONS = {
 };
 
 const LEAVE_STATUS = new Set(['In Progress', 'Review', 'Closed', 'Done']);
-const MERGED_PREFIX = '[x] merged: ';
 
 function configurationError(missingKeys, configPath) {
   const missing = missingKeys.join(', ');
@@ -95,7 +99,9 @@ function usage(exitCode = 0) {
   link-pr-mr.js mark-merged --issue KEY
 
 Environment:
-  JIRA_API_TOKEN              required
+  JIRA_API_TOKEN              API token (or email:token); optional if .jira-token exists
+  JIRA_EMAIL                  login email when token is bare
+  JIRA_SERVER                 override (default ${DEFAULT_JIRA_SERVER})
   JIRA_PR_MR_CONFIG           optional path to JSON config
   JIRA_PR_MR_ASSIGNEE         assignee email
   JIRA_PR_MR_TEAM_ID          Atlassian team UUID
@@ -114,7 +120,10 @@ Config (required for defaults; first found wins):
     mkdir -p ${USER_CONFIG_DIR}
     cp ${EXAMPLE_CONFIG_PATH} ${USER_CONFIG_PATH}
 
-  Jira login/server from ${JIRA_CONFIG}
+Auth: JIRA_API_TOKEN + ~/.config/.jira/.config.yml, or .jira-token next to acli
+  (see ../rhdh-jira/references/auth.md).
+
+RHDHPLAN Epic/Story/Task issues are moved to RHIDP before defaults.
 
 After link (unless --no-comment), posts/updates a Jira comment:
   PR/MR:
@@ -165,16 +174,6 @@ function readJsonFile(filePath) {
   }
 }
 
-function pickDefined(obj) {
-  const out = {};
-  for (const [k, v] of Object.entries(obj || {})) {
-    if (v !== undefined && v !== null && v !== '') {
-      out[k] = v;
-    }
-  }
-  return out;
-}
-
 function envNumber(name) {
   const raw = process.env[name];
   if (raw === undefined || raw === '') {
@@ -200,7 +199,7 @@ function readOptionalSkillConfig() {
 }
 
 /**
- * Merge defaults: config file < jira CLI board/login hints < env < CLI.
+ * Merge defaults: jira CLI board/login hints < config file < env < CLI.
  * No silent team/assignee builtins — missing keys error when applying defaults.
  */
 function resolveDefaults(fileCfg, args = {}, { requireComplete = true } = {}) {
@@ -242,43 +241,17 @@ function resolveDefaults(fileCfg, args = {}, { requireComplete = true } = {}) {
     priorityName: args.priority,
   });
 
-  const merged = {
-    ...fromFile,
-    ...fromJiraCli,
-    ...fromEnv,
-    ...fromCli,
-  };
+  const merged = mergeDefaultsLayers({ fromJiraCli, fromFile, fromEnv, fromCli });
   merged._configPath = configPath;
 
   if (requireComplete) {
-    const missing = REQUIRED_DEFAULT_KEYS.filter((k) => {
-      const v = merged[k];
-      return v === undefined || v === null || v === '';
-    });
+    const missing = missingDefaultKeys(merged);
     if (missing.length) {
       throw configurationError(missing, configPath);
     }
   }
 
   return merged;
-}
-
-function readJiraConfig() {
-  if (!fs.existsSync(JIRA_CONFIG)) {
-    throw new Error(`Jira config not found: ${JIRA_CONFIG}`);
-  }
-  const text = fs.readFileSync(JIRA_CONFIG, 'utf8');
-  const login = (text.match(/^login:\s*(.+)$/m) || [])[1]?.trim();
-  const server = (text.match(/^server:\s*(.+)$/m) || [])[1]?.trim()?.replace(/\/$/, '');
-  if (!login || !server) {
-    throw new Error(`Could not parse login/server from ${JIRA_CONFIG}`);
-  }
-  const boardMatch = text.match(/board:\s*\n\s*id:\s*(\d+)/);
-  return {
-    login,
-    server,
-    boardId: boardMatch ? Number(boardMatch[1]) : undefined,
-  };
 }
 
 function basicAuth(login, token) {
@@ -315,25 +288,82 @@ async function jiraFetch(cfg, method, apiPath, body) {
   return { status: res.status, json };
 }
 
-function detectHost(url, explicit) {
-  if (explicit === 'gitlab' || explicit === 'github') {
-    return explicit;
-  }
-  if (/github\.com/i.test(url)) {
-    return 'github';
-  }
-  return 'gitlab';
+async function sleep(ms) {
+  await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function stripMergedPrefix(title) {
-  return title
-    .replace(/^\[x\]\s*merged:\s*/i, '')
-    .replace(/^merged:\s*/i, '')
-    .trim();
+async function waitBulkTask(cfg, taskId, { timeoutMs = 90000, intervalMs = 1000 } = {}) {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    const { json } = await jiraFetch(cfg, 'GET', `/rest/api/3/bulk/queue/${encodeURIComponent(taskId)}`);
+    const status = String(json?.status || '').toUpperCase();
+    if (status === 'COMPLETE' || status === 'COMPLETED') {
+      return json;
+    }
+    if (status === 'FAILED' || status === 'CANCELLED' || status === 'CANCELED') {
+      throw new Error(`Bulk move ${status}: ${JSON.stringify(json).slice(0, 400)}`);
+    }
+    await sleep(intervalMs);
+  }
+  throw new Error(`Bulk move timed out after ${timeoutMs}ms (taskId=${taskId})`);
 }
 
-function withMergedPrefix(title) {
-  return `${MERGED_PREFIX}${stripMergedPrefix(title)}`;
+async function resolveIssueKeyById(cfg, issueId) {
+  const { json } = await jiraFetch(cfg, 'GET', `/rest/api/3/issue/${issueId}?fields=summary`);
+  return json?.key || null;
+}
+
+/**
+ * If issue is RHDHPLAN Epic/Story/Task, move it to RHIDP (same issue type) via bulk move.
+ * Returns { issue, moved, from?, detail }.
+ */
+async function maybeMoveRhdhplanDeliveryIssue(cfg, issueKey) {
+  const { json } = await jiraFetch(
+    cfg,
+    'GET',
+    `/rest/api/3/issue/${encodeURIComponent(issueKey)}?fields=project,issuetype`,
+  );
+  const projectKey = json?.fields?.project?.key;
+  const typeName = json?.fields?.issuetype?.name;
+  const typeId = json?.fields?.issuetype?.id;
+  if (!shouldMoveRhdhplanDeliveryIssue(projectKey, typeName)) {
+    return {
+      issue: issueKey,
+      moved: false,
+      detail: `kept ${projectKey || '?'} ${typeName || '?'}`,
+    };
+  }
+  if (!typeId) {
+    throw new Error(`Cannot move ${issueKey}: missing issuetype id`);
+  }
+
+  const payload = buildBulkMovePayload(issueKey, RHIDP_PROJECT, typeId);
+  const { json: submitted } = await jiraFetch(cfg, 'POST', '/rest/api/3/bulk/issues/move', payload);
+  const taskId = submitted?.taskId;
+  if (!taskId) {
+    throw new Error(`Bulk move submitted but no taskId: ${JSON.stringify(submitted).slice(0, 300)}`);
+  }
+  const progress = await waitBulkTask(cfg, taskId);
+  const ids = progress?.processedAccessibleIssues || [];
+  let newKey = null;
+  if (ids.length > 0) {
+    newKey = await resolveIssueKeyById(cfg, ids[0]);
+  }
+  // Fallback: old key often redirects after move
+  if (!newKey) {
+    const { json: after } = await jiraFetch(
+      cfg,
+      'GET',
+      `/rest/api/3/issue/${encodeURIComponent(issueKey)}?fields=project,issuetype`,
+    );
+    newKey = after?.key || issueKey;
+  }
+  return {
+    issue: newKey,
+    moved: true,
+    from: issueKey,
+    detail: `moved ${issueKey} → ${newKey} (${typeName} ${projectKey}→${RHIDP_PROJECT})`,
+  };
 }
 
 async function getIssueFields(cfg, issue) {
@@ -346,7 +376,9 @@ async function getIssueFields(cfg, issue) {
     d.storyPointsField,
     d.teamField,
     d.sprintField,
-  ].join(',');
+  ]
+    .filter(Boolean)
+    .join(',');
   const { json } = await jiraFetch(cfg, 'GET', `/rest/api/3/issue/${issue}?fields=${fields}`);
   return json.fields;
 }
@@ -501,6 +533,9 @@ async function upsertRemoteLink(cfg, issue, { url, title, host }) {
 
 function printLinkSummary(result) {
   console.log(`issue: ${result.issue}`);
+  if (result.move) {
+    console.log(`move: ${result.move}`);
+  }
   console.log(`webLink: ${result.webLink.action} — ${result.webLink.title}`);
   console.log(`url: ${result.url}`);
   console.log(`status: ${result.status}`);
@@ -555,49 +590,13 @@ function adfPrMrBullet(url, linkTitle) {
   };
 }
 
-/** Human title from linker title `repo #N: <title>` (optional `[x] merged: ` prefix). */
-function displayTitleFromLinkTitle(title) {
-  return (
-    String(title || '')
-      .replace(/^\[x\]\s*merged:\s*/i, '')
-      .replace(/^[^#\n]+#\d+:\s*/, '')
-      .trim() || String(title || '').trim()
-  );
-}
-
-const ADJUSTED_FIELD_LABELS = {
-  storyPoints: 'Story points',
-  team: 'Team',
-  sprint: 'Sprint',
-  assignee: 'Assignee',
-  priority: 'Priority',
-};
-
-/** Only fields newly set by this run (ignore kept/unchanged). */
-function collectAdjustedFieldLines(defaults, statusLine) {
-  const items = [];
-  if (defaults) {
-    for (const [key, value] of Object.entries(defaults)) {
-      if (typeof value === 'string' && value.startsWith('set ')) {
-        const label = ADJUSTED_FIELD_LABELS[key] || key;
-        items.push(`${label}: ${value.slice(4)}`);
-      }
-    }
-  }
-  if (typeof statusLine === 'string' && statusLine.startsWith('transitioned ')) {
-    const to = (statusLine.match(/→\s*(.+)$/) || [])[1]?.trim() || 'In Progress';
-    items.push(`Status: ${to}`);
-  }
-  return items;
-}
-
 function buildLinkCommentAdf({ url, webLink, status, defaults }) {
-  // Visible text matches the Jira remote Web link title: `repo #N: <title>`
-  // ADF: <a href="{url}">{repo} #{id}: {title}</a>
   const linkTitle =
     String(webLink?.title || '')
       .replace(/^\[x\]\s*merged:\s*/i, '')
-      .trim() || displayTitleFromLinkTitle(webLink?.title) || url;
+      .trim() ||
+    displayTitleFromLinkTitle(webLink?.title) ||
+    url;
   const content = [adfParagraph('PR/MR:'), adfPrMrBullet(url, linkTitle)];
   const adjusted = collectAdjustedFieldLines(defaults, status);
   if (adjusted.length > 0) {
@@ -607,17 +606,30 @@ function buildLinkCommentAdf({ url, webLink, status, defaults }) {
   return { type: 'doc', version: 1, content };
 }
 
+/** Paginate comments (oldest-first); keep the newest match that mentions url. */
 async function findCommentMentioningUrl(cfg, issue, url) {
-  const { json } = await jiraFetch(cfg, 'GET', `/rest/api/3/issue/${issue}/comment`);
-  const comments = json?.comments || [];
-  // Prefer the latest comment that mentions this PR/MR URL
-  for (let i = comments.length - 1; i >= 0; i -= 1) {
-    const c = comments[i];
-    if (JSON.stringify(c.body || '').includes(url)) {
-      return c;
+  let startAt = 0;
+  const pageSize = 100;
+  let match = null;
+  for (;;) {
+    const { json } = await jiraFetch(
+      cfg,
+      'GET',
+      `/rest/api/3/issue/${encodeURIComponent(issue)}/comment?startAt=${startAt}&maxResults=${pageSize}`,
+    );
+    const comments = json?.comments || [];
+    const total = typeof json?.total === 'number' ? json.total : startAt + comments.length;
+    for (const c of comments) {
+      if (JSON.stringify(c.body || '').includes(url)) {
+        match = c;
+      }
+    }
+    startAt += comments.length;
+    if (comments.length === 0 || startAt >= total) {
+      break;
     }
   }
-  return null;
+  return match;
 }
 
 async function postLinkComment(cfg, issue, { url, webLink, status, defaults }) {
@@ -636,19 +648,26 @@ async function postLinkComment(cfg, issue, { url, webLink, status, defaults }) {
 }
 
 async function cmdLink(args, cfg) {
-  const issue = args.issue;
+  let issue = args.issue;
   const url = args.url;
   const title = args.title;
   if (!issue || !url || !title) {
     throw new Error('link requires --issue, --url, and --title');
   }
   const host = detectHost(url, args.host);
+  const moveResult = await maybeMoveRhdhplanDeliveryIssue(cfg, issue);
+  issue = moveResult.issue;
+
   const webLink = await upsertRemoteLink(cfg, issue, { url, title, host });
 
   const skipDefaults = args.noDefaults || envBoolFalse('JIRA_PR_MR_APPLY_DEFAULTS');
   let defaults;
   let statusLine;
   if (!skipDefaults) {
+    const missing = missingDefaultKeys(cfg.defaults);
+    if (missing.length) {
+      throw configurationError(missing, cfg.defaults._configPath);
+    }
     const fields = await getIssueFields(cfg, issue);
     defaults = await applyMissingDefaults(cfg, issue, fields);
     const statusResult = await transitionInProgress(cfg, issue, fields.status?.name || '');
@@ -676,24 +695,12 @@ async function cmdLink(args, cfg) {
   printLinkSummary({
     issue,
     url,
+    move: moveResult.detail,
     webLink,
     status: statusLine,
     defaults,
     comment: commentLine,
   });
-}
-
-function parsePrMrUrl(url) {
-  let m = url.match(/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/i);
-  if (m) {
-    return { kind: 'github', owner: m[1], repo: m[2], id: m[3] };
-  }
-  // Capture host so glab targets gitlab.cee.redhat.com (not default gitlab.com).
-  m = url.match(/https?:\/\/(gitlab[^/]*)\/(.+?)\/-\/merge_requests\/(\d+)/i);
-  if (m) {
-    return { kind: 'gitlab', host: m[1], project: m[2], id: m[3] };
-  }
-  return null;
 }
 
 function isMerged(ref) {
@@ -799,18 +806,19 @@ async function main() {
   if (!cmd) {
     usage(1);
   }
-  if (!process.env.JIRA_API_TOKEN) {
-    throw new Error('JIRA_API_TOKEN is not set');
-  }
-  const fileCfg = readJiraConfig();
-  const skipDefaults =
-    cmd !== 'link' || args.noDefaults || envBoolFalse('JIRA_PR_MR_APPLY_DEFAULTS');
-  const defaults = resolveDefaults(fileCfg, args, { requireComplete: !skipDefaults });
+
+  const auth = resolveJiraAuth();
+  // Never hard-fail on incomplete defaults before Web link/comment; validate only when applying.
+  const defaults = resolveDefaults(
+    { login: auth.login, boardId: auth.boardId },
+    args,
+    { requireComplete: false },
+  );
   const cfg = {
-    login: fileCfg.login,
-    server: fileCfg.server,
-    boardId: defaults.boardId,
-    token: process.env.JIRA_API_TOKEN,
+    login: auth.login,
+    server: auth.server,
+    boardId: defaults.boardId || auth.boardId,
+    token: auth.token,
     defaults,
   };
 
@@ -825,7 +833,25 @@ async function main() {
   throw new Error(`Unknown command: ${cmd}`);
 }
 
-main().catch((err) => {
-  console.error(`[ERROR] ${err.message}`);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(`[ERROR] ${err.message}`);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  applyMissingDefaults,
+  buildLinkCommentAdf,
+  cmdLink,
+  collectAdjustedFieldLines,
+  configurationError,
+  detectHost,
+  displayTitleFromLinkTitle,
+  findCommentMentioningUrl,
+  maybeMoveRhdhplanDeliveryIssue,
+  parseArgs,
+  parsePrMrUrl,
+  resolveDefaults,
+  withMergedPrefix,
+};

--- a/skills/jira-pr-mr-link/scripts/link-pr-mr.js
+++ b/skills/jira-pr-mr-link/scripts/link-pr-mr.js
@@ -1,0 +1,817 @@
+#!/usr/bin/env node
+/*
+  Jira PR/MR Web link helper for skill jira-pr-mr-web-link.
+
+  Commands:
+    link         Create/update a Web link, apply missing configured defaults, In Progress
+    mark-merged  Prefix remotelink titles with "[x] merged: " for merged PRs/MRs
+
+  Auth: $JIRA_API_TOKEN + login/server from ~/.config/.jira/.config.yml
+*/
+
+'use strict';
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const JIRA_CONFIG = path.join(os.homedir(), '.config', '.jira', '.config.yml');
+const USER_CONFIG_DIR = path.join(os.homedir(), '.config', 'jira-pr-mr-link');
+const USER_CONFIG_PATH = path.join(USER_CONFIG_DIR, 'config.json');
+const LEGACY_USER_CONFIG_PATH = path.join(
+  os.homedir(),
+  '.config',
+  'jira-pr-mr-web-link',
+  'config.json',
+);
+const EXAMPLE_CONFIG_PATH = path.join(__dirname, '..', 'config.example.json');
+const SKILL_CONFIG_PATHS = [
+  process.env.JIRA_PR_MR_CONFIG,
+  USER_CONFIG_PATH,
+  LEGACY_USER_CONFIG_PATH,
+  path.join(__dirname, '..', 'config.local.json'),
+].filter(Boolean);
+
+/** Keys required when applying missing-field defaults (no silent builtins). */
+const REQUIRED_DEFAULT_KEYS = [
+  'assigneeEmail',
+  'teamId',
+  'teamName',
+  'boardId',
+  'storyPoints',
+  'priorityName',
+  'storyPointsField',
+  'teamField',
+  'sprintField',
+];
+
+const ICONS = {
+  gitlab: {
+    application: { type: 'com.gitlab', name: 'GitLab' },
+    icon: { title: 'GitLab', url16x16: 'https://gitlab.com/favicon.ico' },
+  },
+  github: {
+    application: { type: 'com.github', name: 'GitHub' },
+    icon: {
+      title: 'GitHub',
+      url16x16: 'https://github.githubassets.com/favicons/favicon.png',
+    },
+  },
+};
+
+const LEAVE_STATUS = new Set(['In Progress', 'Review', 'Closed', 'Done']);
+const MERGED_PREFIX = '[x] merged: ';
+
+function configurationError(missingKeys, configPath) {
+  const missing = missingKeys.join(', ');
+  const lines = [
+    `Missing Jira PR/MR defaults: ${missing}`,
+    '',
+    'This skill has no built-in team/assignee values. Configure once:',
+    '',
+    `  mkdir -p ${USER_CONFIG_DIR}`,
+    `  cp ${EXAMPLE_CONFIG_PATH} ${USER_CONFIG_PATH}`,
+    `  # edit ${USER_CONFIG_PATH}  (assigneeEmail, teamId, teamName, boardId, …)`,
+    '',
+    'Or set env vars (JIRA_PR_MR_ASSIGNEE, JIRA_PR_MR_TEAM_ID, JIRA_PR_MR_BOARD_ID, …)',
+    'or pass --assignee / --team-id / --board-id / … on the CLI.',
+    '',
+    'To link without filling defaults: add --no-defaults (or JIRA_PR_MR_APPLY_DEFAULTS=0).',
+  ];
+  if (configPath) {
+    lines.splice(1, 0, `Config loaded from: ${configPath}`);
+  }
+  return new Error(lines.join('\n'));
+}
+
+function usage(exitCode = 0) {
+  console.log(`Usage:
+  link-pr-mr.js link --issue KEY --url URL --title TITLE [--host gitlab|github]
+    [--no-defaults] [--no-comment]
+    [--assignee EMAIL] [--team-id ID] [--team-name NAME] [--board-id N]
+    [--story-points N] [--priority NAME]
+
+  link-pr-mr.js mark-merged --issue KEY
+
+Environment:
+  JIRA_API_TOKEN              required
+  JIRA_PR_MR_CONFIG           optional path to JSON config
+  JIRA_PR_MR_ASSIGNEE         assignee email
+  JIRA_PR_MR_TEAM_ID          Atlassian team UUID
+  JIRA_PR_MR_TEAM_NAME        team display name
+  JIRA_PR_MR_BOARD_ID         sprint board id
+  JIRA_PR_MR_STORY_POINTS     story points (number)
+  JIRA_PR_MR_PRIORITY         priority name (e.g. Normal)
+  JIRA_PR_MR_APPLY_DEFAULTS   0/false to skip defaults (like --no-defaults)
+
+Config (required for defaults; first found wins):
+  $JIRA_PR_MR_CONFIG
+  ${USER_CONFIG_PATH}
+  <skill>/config.local.json
+
+  Setup:
+    mkdir -p ${USER_CONFIG_DIR}
+    cp ${EXAMPLE_CONFIG_PATH} ${USER_CONFIG_PATH}
+
+  Jira login/server from ${JIRA_CONFIG}
+
+After link (unless --no-comment), posts/updates a Jira comment:
+  PR/MR:
+  * <a href="{url}">{repo} #{id}: {title}</a>   (same text as the Web link title)
+  Adjusted fields:   (only newly set fields; omitted if none)
+`);
+  process.exit(exitCode);
+}
+
+function parseArgs(argv) {
+  const args = { _: [] };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === '-h' || a === '--help') {
+      usage(0);
+    }
+    if (a.startsWith('--')) {
+      const key = a.slice(2);
+      if (key === 'no-defaults') {
+        args.noDefaults = true;
+        continue;
+      }
+      if (key === 'no-comment') {
+        args.noComment = true;
+        continue;
+      }
+      const val = argv[i + 1];
+      if (!val || val.startsWith('--')) {
+        throw new Error(`Missing value for --${key}`);
+      }
+      args[key] = val;
+      i += 1;
+      continue;
+    }
+    args._.push(a);
+  }
+  return args;
+}
+
+function readJsonFile(filePath) {
+  if (!filePath || !fs.existsSync(filePath)) {
+    return null;
+  }
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (err) {
+    throw new Error(`Invalid JSON config ${filePath}: ${err.message}`);
+  }
+}
+
+function pickDefined(obj) {
+  const out = {};
+  for (const [k, v] of Object.entries(obj || {})) {
+    if (v !== undefined && v !== null && v !== '') {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
+function envNumber(name) {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') {
+    return undefined;
+  }
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function envBoolFalse(name) {
+  const raw = (process.env[name] || '').trim().toLowerCase();
+  return raw === '0' || raw === 'false' || raw === 'no';
+}
+
+function readOptionalSkillConfig() {
+  for (const p of SKILL_CONFIG_PATHS) {
+    const data = readJsonFile(p);
+    if (data) {
+      return { path: p, data };
+    }
+  }
+  return { path: null, data: {} };
+}
+
+/**
+ * Merge defaults: config file < jira CLI board/login hints < env < CLI.
+ * No silent team/assignee builtins — missing keys error when applying defaults.
+ */
+function resolveDefaults(fileCfg, args = {}, { requireComplete = true } = {}) {
+  const { path: configPath, data: fileData } = readOptionalSkillConfig();
+  const fromFile = pickDefined({
+    storyPoints: fileData.storyPoints,
+    teamName: fileData.teamName,
+    teamId: fileData.teamId,
+    boardId: fileData.boardId,
+    assigneeEmail: fileData.assigneeEmail,
+    priorityName: fileData.priorityName,
+    storyPointsField: fileData.storyPointsField,
+    teamField: fileData.teamField,
+    sprintField: fileData.sprintField,
+  });
+  const fromJiraCli = pickDefined({
+    boardId: fileCfg.boardId,
+    assigneeEmail:
+      fileCfg.login && String(fileCfg.login).includes('@') ? fileCfg.login : undefined,
+  });
+  const fromEnv = pickDefined({
+    storyPoints: envNumber('JIRA_PR_MR_STORY_POINTS'),
+    teamName: process.env.JIRA_PR_MR_TEAM_NAME,
+    teamId: process.env.JIRA_PR_MR_TEAM_ID,
+    boardId: envNumber('JIRA_PR_MR_BOARD_ID'),
+    assigneeEmail: process.env.JIRA_PR_MR_ASSIGNEE,
+    priorityName: process.env.JIRA_PR_MR_PRIORITY,
+    storyPointsField: process.env.JIRA_PR_MR_STORY_POINTS_FIELD,
+    teamField: process.env.JIRA_PR_MR_TEAM_FIELD,
+    sprintField: process.env.JIRA_PR_MR_SPRINT_FIELD,
+  });
+  const fromCli = pickDefined({
+    storyPoints:
+      args['story-points'] !== undefined ? Number(args['story-points']) : undefined,
+    teamName: args['team-name'],
+    teamId: args['team-id'],
+    boardId: args['board-id'] !== undefined ? Number(args['board-id']) : undefined,
+    assigneeEmail: args.assignee,
+    priorityName: args.priority,
+  });
+
+  const merged = {
+    ...fromFile,
+    ...fromJiraCli,
+    ...fromEnv,
+    ...fromCli,
+  };
+  merged._configPath = configPath;
+
+  if (requireComplete) {
+    const missing = REQUIRED_DEFAULT_KEYS.filter((k) => {
+      const v = merged[k];
+      return v === undefined || v === null || v === '';
+    });
+    if (missing.length) {
+      throw configurationError(missing, configPath);
+    }
+  }
+
+  return merged;
+}
+
+function readJiraConfig() {
+  if (!fs.existsSync(JIRA_CONFIG)) {
+    throw new Error(`Jira config not found: ${JIRA_CONFIG}`);
+  }
+  const text = fs.readFileSync(JIRA_CONFIG, 'utf8');
+  const login = (text.match(/^login:\s*(.+)$/m) || [])[1]?.trim();
+  const server = (text.match(/^server:\s*(.+)$/m) || [])[1]?.trim()?.replace(/\/$/, '');
+  if (!login || !server) {
+    throw new Error(`Could not parse login/server from ${JIRA_CONFIG}`);
+  }
+  const boardMatch = text.match(/board:\s*\n\s*id:\s*(\d+)/);
+  return {
+    login,
+    server,
+    boardId: boardMatch ? Number(boardMatch[1]) : undefined,
+  };
+}
+
+function basicAuth(login, token) {
+  return `Basic ${Buffer.from(`${login}:${token}`).toString('base64')}`;
+}
+
+async function jiraFetch(cfg, method, apiPath, body) {
+  const url = `${cfg.server}${apiPath}`;
+  const headers = {
+    Authorization: basicAuth(cfg.login, cfg.token),
+    Accept: 'application/json',
+  };
+  if (body !== undefined) {
+    headers['Content-Type'] = 'application/json';
+  }
+  const res = await fetch(url, {
+    method,
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await res.text();
+  let json;
+  try {
+    json = text ? JSON.parse(text) : null;
+  } catch {
+    json = text;
+  }
+  if (!res.ok) {
+    const err = new Error(`Jira ${method} ${apiPath} → HTTP ${res.status}: ${text.slice(0, 500)}`);
+    err.status = res.status;
+    err.body = json;
+    throw err;
+  }
+  return { status: res.status, json };
+}
+
+function detectHost(url, explicit) {
+  if (explicit === 'gitlab' || explicit === 'github') {
+    return explicit;
+  }
+  if (/github\.com/i.test(url)) {
+    return 'github';
+  }
+  return 'gitlab';
+}
+
+function stripMergedPrefix(title) {
+  return title
+    .replace(/^\[x\]\s*merged:\s*/i, '')
+    .replace(/^merged:\s*/i, '')
+    .trim();
+}
+
+function withMergedPrefix(title) {
+  return `${MERGED_PREFIX}${stripMergedPrefix(title)}`;
+}
+
+async function getIssueFields(cfg, issue) {
+  const d = cfg.defaults;
+  const fields = [
+    'summary',
+    'status',
+    'assignee',
+    'priority',
+    d.storyPointsField,
+    d.teamField,
+    d.sprintField,
+  ].join(',');
+  const { json } = await jiraFetch(cfg, 'GET', `/rest/api/3/issue/${issue}?fields=${fields}`);
+  return json.fields;
+}
+
+async function resolveAssigneeAccountId(cfg, email) {
+  const q = encodeURIComponent(email);
+  const { json } = await jiraFetch(cfg, 'GET', `/rest/api/3/user/search?query=${q}`);
+  if (!Array.isArray(json) || !json[0]?.accountId) {
+    throw new Error(`Could not resolve accountId for ${email}`);
+  }
+  return json[0].accountId;
+}
+
+async function resolveActiveSprint(cfg, boardId) {
+  const { json } = await jiraFetch(
+    cfg,
+    'GET',
+    `/rest/agile/1.0/board/${boardId}/sprint?state=active`,
+  );
+  const sprint = json?.values?.[0];
+  if (!sprint?.id) {
+    throw new Error(`No active sprint on board ${boardId}`);
+  }
+  return { id: sprint.id, name: sprint.name };
+}
+
+function isEmpty(value) {
+  if (value === null || value === undefined || value === '') {
+    return true;
+  }
+  if (Array.isArray(value) && value.length === 0) {
+    return true;
+  }
+  return false;
+}
+
+async function applyMissingDefaults(cfg, issue, fields) {
+  const d = cfg.defaults;
+  const summary = {
+    storyPoints: 'unchanged',
+    team: 'unchanged',
+    sprint: 'unchanged',
+    assignee: 'unchanged',
+    priority: 'unchanged',
+  };
+  const update = {};
+
+  if (d.storyPoints !== undefined && d.storyPoints !== null && d.storyPoints !== false) {
+    if (isEmpty(fields[d.storyPointsField])) {
+      update[d.storyPointsField] = d.storyPoints;
+      summary.storyPoints = `set ${d.storyPoints}`;
+    } else {
+      summary.storyPoints = `kept ${fields[d.storyPointsField]}`;
+    }
+  } else {
+    summary.storyPoints = 'skipped (not configured)';
+  }
+
+  if (d.teamId) {
+    if (isEmpty(fields[d.teamField])) {
+      update[d.teamField] = { id: d.teamId };
+      summary.team = `set ${d.teamName || d.teamId}`;
+    } else {
+      summary.team = `kept ${fields[d.teamField].name || fields[d.teamField].id}`;
+    }
+  } else {
+    summary.team = 'skipped (no teamId)';
+  }
+
+  if (d.boardId) {
+    if (isEmpty(fields[d.sprintField])) {
+      try {
+        const sprint = await resolveActiveSprint(cfg, d.boardId);
+        update[d.sprintField] = sprint.id;
+        summary.sprint = `set ${sprint.name}`;
+      } catch (err) {
+        summary.sprint = `skipped (${err.message})`;
+      }
+    } else {
+      const names = (fields[d.sprintField] || []).map((s) => s.name).join(', ');
+      summary.sprint = `kept ${names || 'existing'}`;
+    }
+  } else {
+    summary.sprint = 'skipped (no boardId)';
+  }
+
+  if (d.assigneeEmail) {
+    if (isEmpty(fields.assignee)) {
+      const accountId = await resolveAssigneeAccountId(cfg, d.assigneeEmail);
+      update.assignee = { accountId };
+      summary.assignee = `set ${d.assigneeEmail}`;
+    } else {
+      summary.assignee = `kept ${fields.assignee.emailAddress || fields.assignee.displayName}`;
+    }
+  } else {
+    summary.assignee = 'skipped (no assigneeEmail)';
+  }
+
+  if (d.priorityName) {
+    if (isEmpty(fields.priority)) {
+      update.priority = { name: d.priorityName };
+      summary.priority = `set ${d.priorityName}`;
+    } else {
+      summary.priority = `kept ${fields.priority.name}`;
+    }
+  } else {
+    summary.priority = 'skipped (no priorityName)';
+  }
+
+  if (Object.keys(update).length > 0) {
+    await jiraFetch(cfg, 'PUT', `/rest/api/3/issue/${issue}`, { fields: update });
+  }
+  return summary;
+}
+
+async function transitionInProgress(cfg, issue, currentStatus) {
+  if (LEAVE_STATUS.has(currentStatus)) {
+    return { status: `kept ${currentStatus}` };
+  }
+  const { json } = await jiraFetch(cfg, 'GET', `/rest/api/3/issue/${issue}/transitions`);
+  const transition = (json.transitions || []).find(
+    (t) => t.to?.name === 'In Progress' || t.name === 'In Progress',
+  );
+  if (!transition) {
+    return { status: `no In Progress transition from ${currentStatus}` };
+  }
+  await jiraFetch(cfg, 'POST', `/rest/api/3/issue/${issue}/transitions`, {
+    transition: { id: transition.id },
+  });
+  return { status: `transitioned ${currentStatus} → In Progress` };
+}
+
+async function upsertRemoteLink(cfg, issue, { url, title, host }) {
+  const iconCfg = ICONS[host];
+  const { json: existing } = await jiraFetch(cfg, 'GET', `/rest/api/3/issue/${issue}/remotelink`);
+  const match = (existing || []).find((l) => l.object?.url === url);
+  const payload = {
+    application: iconCfg.application,
+    object: {
+      url,
+      title,
+      icon: iconCfg.icon,
+    },
+  };
+  if (match?.id) {
+    await jiraFetch(cfg, 'PUT', `/rest/api/3/issue/${issue}/remotelink/${match.id}`, payload);
+    return { action: 'updated', id: match.id, title };
+  }
+  const { json } = await jiraFetch(cfg, 'POST', `/rest/api/3/issue/${issue}/remotelink`, payload);
+  return { action: 'created', id: json?.id, title };
+}
+
+function printLinkSummary(result) {
+  console.log(`issue: ${result.issue}`);
+  console.log(`webLink: ${result.webLink.action} — ${result.webLink.title}`);
+  console.log(`url: ${result.url}`);
+  console.log(`status: ${result.status}`);
+  if (result.defaults) {
+    console.log('defaults:');
+    for (const [k, v] of Object.entries(result.defaults)) {
+      console.log(`  ${k}: ${v}`);
+    }
+  }
+  if (result.comment) {
+    console.log(`comment: ${result.comment}`);
+  }
+}
+
+function adfParagraph(text) {
+  return {
+    type: 'paragraph',
+    content: text ? [{ type: 'text', text }] : [],
+  };
+}
+
+function adfBulletList(items) {
+  return {
+    type: 'bulletList',
+    content: items.map((text) => ({
+      type: 'listItem',
+      content: [adfParagraph(text)],
+    })),
+  };
+}
+
+function adfPrMrBullet(url, linkTitle) {
+  return {
+    type: 'bulletList',
+    content: [
+      {
+        type: 'listItem',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: linkTitle,
+                marks: [{ type: 'link', attrs: { href: url } }],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+/** Human title from linker title `repo #N: <title>` (optional `[x] merged: ` prefix). */
+function displayTitleFromLinkTitle(title) {
+  return (
+    String(title || '')
+      .replace(/^\[x\]\s*merged:\s*/i, '')
+      .replace(/^[^#\n]+#\d+:\s*/, '')
+      .trim() || String(title || '').trim()
+  );
+}
+
+const ADJUSTED_FIELD_LABELS = {
+  storyPoints: 'Story points',
+  team: 'Team',
+  sprint: 'Sprint',
+  assignee: 'Assignee',
+  priority: 'Priority',
+};
+
+/** Only fields newly set by this run (ignore kept/unchanged). */
+function collectAdjustedFieldLines(defaults, statusLine) {
+  const items = [];
+  if (defaults) {
+    for (const [key, value] of Object.entries(defaults)) {
+      if (typeof value === 'string' && value.startsWith('set ')) {
+        const label = ADJUSTED_FIELD_LABELS[key] || key;
+        items.push(`${label}: ${value.slice(4)}`);
+      }
+    }
+  }
+  if (typeof statusLine === 'string' && statusLine.startsWith('transitioned ')) {
+    const to = (statusLine.match(/→\s*(.+)$/) || [])[1]?.trim() || 'In Progress';
+    items.push(`Status: ${to}`);
+  }
+  return items;
+}
+
+function buildLinkCommentAdf({ url, webLink, status, defaults }) {
+  // Visible text matches the Jira remote Web link title: `repo #N: <title>`
+  // ADF: <a href="{url}">{repo} #{id}: {title}</a>
+  const linkTitle =
+    String(webLink?.title || '')
+      .replace(/^\[x\]\s*merged:\s*/i, '')
+      .trim() || displayTitleFromLinkTitle(webLink?.title) || url;
+  const content = [adfParagraph('PR/MR:'), adfPrMrBullet(url, linkTitle)];
+  const adjusted = collectAdjustedFieldLines(defaults, status);
+  if (adjusted.length > 0) {
+    content.push(adfParagraph('Adjusted fields:'));
+    content.push(adfBulletList(adjusted));
+  }
+  return { type: 'doc', version: 1, content };
+}
+
+async function findCommentMentioningUrl(cfg, issue, url) {
+  const { json } = await jiraFetch(cfg, 'GET', `/rest/api/3/issue/${issue}/comment`);
+  const comments = json?.comments || [];
+  // Prefer the latest comment that mentions this PR/MR URL
+  for (let i = comments.length - 1; i >= 0; i -= 1) {
+    const c = comments[i];
+    if (JSON.stringify(c.body || '').includes(url)) {
+      return c;
+    }
+  }
+  return null;
+}
+
+async function postLinkComment(cfg, issue, { url, webLink, status, defaults }) {
+  const body = buildLinkCommentAdf({ url, webLink, status, defaults });
+  const existing = await findCommentMentioningUrl(cfg, issue, url);
+  if (existing?.id) {
+    await jiraFetch(cfg, 'PUT', `/rest/api/3/issue/${issue}/comment/${existing.id}`, {
+      body,
+    });
+    return `updated id=${existing.id}`;
+  }
+  const { json } = await jiraFetch(cfg, 'POST', `/rest/api/3/issue/${issue}/comment`, {
+    body,
+  });
+  return json?.id ? `posted id=${json.id}` : 'posted';
+}
+
+async function cmdLink(args, cfg) {
+  const issue = args.issue;
+  const url = args.url;
+  const title = args.title;
+  if (!issue || !url || !title) {
+    throw new Error('link requires --issue, --url, and --title');
+  }
+  const host = detectHost(url, args.host);
+  const webLink = await upsertRemoteLink(cfg, issue, { url, title, host });
+
+  const skipDefaults = args.noDefaults || envBoolFalse('JIRA_PR_MR_APPLY_DEFAULTS');
+  let defaults;
+  let statusLine;
+  if (!skipDefaults) {
+    const fields = await getIssueFields(cfg, issue);
+    defaults = await applyMissingDefaults(cfg, issue, fields);
+    const statusResult = await transitionInProgress(cfg, issue, fields.status?.name || '');
+    statusLine = statusResult.status;
+  } else {
+    statusLine = 'skipped (--no-defaults)';
+  }
+
+  let commentLine;
+  if (!args.noComment) {
+    try {
+      commentLine = await postLinkComment(cfg, issue, {
+        url,
+        webLink,
+        status: statusLine,
+        defaults,
+      });
+    } catch (err) {
+      commentLine = `failed — ${err.message}`;
+    }
+  } else {
+    commentLine = 'skipped (--no-comment)';
+  }
+
+  printLinkSummary({
+    issue,
+    url,
+    webLink,
+    status: statusLine,
+    defaults,
+    comment: commentLine,
+  });
+}
+
+function parsePrMrUrl(url) {
+  let m = url.match(/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/i);
+  if (m) {
+    return { kind: 'github', owner: m[1], repo: m[2], id: m[3] };
+  }
+  m = url.match(/gitlab[^/]*\/(.+?)\/-\/merge_requests\/(\d+)/i);
+  if (m) {
+    return { kind: 'gitlab', project: m[1], id: m[2] };
+  }
+  return null;
+}
+
+function isMerged(ref) {
+  if (ref.kind === 'github') {
+    const out = spawnSync(
+      'gh',
+      ['api', `repos/${ref.owner}/${ref.repo}/pulls/${ref.id}`, '--jq', '.merged'],
+      { encoding: 'utf8' },
+    );
+    return out.status === 0 && String(out.stdout).trim() === 'true';
+  }
+  const project = encodeURIComponent(ref.project);
+  const out = spawnSync(
+    'glab',
+    ['api', `projects/${project}/merge_requests/${ref.id}`],
+    { encoding: 'utf8' },
+  );
+  if (out.status !== 0) {
+    return false;
+  }
+  try {
+    const mr = JSON.parse(out.stdout);
+    return Boolean(mr.merged_at) || mr.state === 'merged';
+  } catch {
+    return false;
+  }
+}
+
+async function cmdMarkMerged(args, cfg) {
+  const issue = args.issue;
+  if (!issue) {
+    throw new Error('mark-merged requires --issue');
+  }
+  const { json: links } = await jiraFetch(cfg, 'GET', `/rest/api/3/issue/${issue}/remotelink`);
+  const updated = [];
+  const leftOpen = [];
+  const skipped = [];
+
+  for (const link of links || []) {
+    const url = link.object?.url;
+    const title = link.object?.title || '';
+    if (!url) {
+      continue;
+    }
+    const ref = parsePrMrUrl(url);
+    if (!ref) {
+      skipped.push(title || url);
+      continue;
+    }
+    if (!isMerged(ref)) {
+      leftOpen.push(title || url);
+      continue;
+    }
+    const newTitle = withMergedPrefix(title);
+    if (newTitle === title) {
+      updated.push(`already: ${title}`);
+      continue;
+    }
+    const host = ref.kind === 'github' ? 'github' : 'gitlab';
+    const iconCfg = ICONS[host];
+    await jiraFetch(cfg, 'PUT', `/rest/api/3/issue/${issue}/remotelink/${link.id}`, {
+      application: iconCfg.application,
+      object: {
+        url,
+        title: newTitle,
+        icon: iconCfg.icon,
+        status: { resolved: true },
+      },
+    });
+    updated.push(newTitle);
+  }
+
+  console.log(`issue: ${issue}`);
+  console.log(`updated: ${updated.length}`);
+  for (const t of updated) {
+    console.log(`  ${t}`);
+  }
+  console.log(`leftOpen: ${leftOpen.length}`);
+  for (const t of leftOpen) {
+    console.log(`  ${t}`);
+  }
+  if (skipped.length) {
+    console.log(`skippedNonPrMr: ${skipped.length}`);
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const cmd = args._[0];
+  if (!cmd) {
+    usage(1);
+  }
+  if (!process.env.JIRA_API_TOKEN) {
+    throw new Error('JIRA_API_TOKEN is not set');
+  }
+  const fileCfg = readJiraConfig();
+  const skipDefaults =
+    cmd !== 'link' || args.noDefaults || envBoolFalse('JIRA_PR_MR_APPLY_DEFAULTS');
+  const defaults = resolveDefaults(fileCfg, args, { requireComplete: !skipDefaults });
+  const cfg = {
+    login: fileCfg.login,
+    server: fileCfg.server,
+    boardId: defaults.boardId,
+    token: process.env.JIRA_API_TOKEN,
+    defaults,
+  };
+
+  if (cmd === 'link') {
+    await cmdLink(args, cfg);
+    return;
+  }
+  if (cmd === 'mark-merged') {
+    await cmdMarkMerged(args, cfg);
+    return;
+  }
+  throw new Error(`Unknown command: ${cmd}`);
+}
+
+main().catch((err) => {
+  console.error(`[ERROR] ${err.message}`);
+  process.exit(1);
+});

--- a/skills/jira-pr-mr-link/scripts/link-pr-mr.js
+++ b/skills/jira-pr-mr-link/scripts/link-pr-mr.js
@@ -698,13 +698,20 @@ function parsePrMrUrl(url) {
 
 function isMerged(ref) {
   if (ref.kind === 'github') {
+    const label = `${ref.owner}/${ref.repo}#${ref.id}`;
     const out = spawnSync(
       'gh',
       ['api', `repos/${ref.owner}/${ref.repo}/pulls/${ref.id}`, '--jq', '.merged'],
       { encoding: 'utf8' },
     );
-    return out.status === 0 && String(out.stdout).trim() === 'true';
+    if (out.status !== 0) {
+      const err = (out.stderr || out.stdout || '').trim().slice(0, 240);
+      console.error(`warn: merge-check failed for github ${label}: ${err || `exit ${out.status}`}`);
+      return false;
+    }
+    return String(out.stdout).trim() === 'true';
   }
+  const label = `${ref.project}!${ref.id}`;
   const project = encodeURIComponent(ref.project);
   const glabArgs = ['api'];
   if (ref.host) {
@@ -713,12 +720,15 @@ function isMerged(ref) {
   glabArgs.push(`projects/${project}/merge_requests/${ref.id}`);
   const out = spawnSync('glab', glabArgs, { encoding: 'utf8' });
   if (out.status !== 0) {
+    const err = (out.stderr || out.stdout || '').trim().slice(0, 240);
+    console.error(`warn: merge-check failed for gitlab ${label}: ${err || `exit ${out.status}`}`);
     return false;
   }
   try {
     const mr = JSON.parse(out.stdout);
     return Boolean(mr.merged_at) || mr.state === 'merged';
-  } catch {
+  } catch (err) {
+    console.error(`warn: merge-check parse failed for gitlab ${label}: ${err.message}`);
     return false;
   }
 }
@@ -745,12 +755,12 @@ async function cmdMarkMerged(args, cfg) {
       continue;
     }
     if (!isMerged(ref)) {
-      leftOpen.push(title || url);
+      leftOpen.push({ title: title || url, url });
       continue;
     }
     const newTitle = withMergedPrefix(title);
     if (newTitle === title) {
-      updated.push(`already: ${title}`);
+      updated.push({ label: `already: ${title}`, url });
       continue;
     }
     const host = ref.kind === 'github' ? 'github' : 'gitlab';
@@ -764,17 +774,19 @@ async function cmdMarkMerged(args, cfg) {
         status: { resolved: true },
       },
     });
-    updated.push(newTitle);
+    updated.push({ label: newTitle, url });
   }
 
   console.log(`issue: ${issue}`);
   console.log(`updated: ${updated.length}`);
-  for (const t of updated) {
-    console.log(`  ${t}`);
+  for (const item of updated) {
+    console.log(`  ${item.label}`);
+    console.log(`    ${item.url}`);
   }
   console.log(`leftOpen: ${leftOpen.length}`);
-  for (const t of leftOpen) {
-    console.log(`  ${t}`);
+  for (const item of leftOpen) {
+    console.log(`  ${item.title}`);
+    console.log(`    ${item.url}`);
   }
   if (skipped.length) {
     console.log(`skippedNonPrMr: ${skipped.length}`);

--- a/skills/jira-pr-mr-link/scripts/link-pr-mr.js
+++ b/skills/jira-pr-mr-link/scripts/link-pr-mr.js
@@ -32,7 +32,9 @@ const {
   pickDefined,
   resolveJiraAuth,
   shouldMoveRhdhplanDeliveryIssue,
+  shouldSkipTeamAndSprint,
   withMergedPrefix,
+  parseArgs: parseArgv,
 } = require('./lib.js');
 
 const USER_CONFIG_DIR = path.join(os.homedir(), '.config', 'jira-pr-mr-link');
@@ -134,33 +136,10 @@ After link (unless --no-comment), posts/updates a Jira comment:
 }
 
 function parseArgs(argv) {
-  const args = { _: [] };
-  for (let i = 0; i < argv.length; i += 1) {
-    const a = argv[i];
-    if (a === '-h' || a === '--help') {
-      usage(0);
-    }
-    if (a.startsWith('--')) {
-      const key = a.slice(2);
-      if (key === 'no-defaults') {
-        args.noDefaults = true;
-        continue;
-      }
-      if (key === 'no-comment') {
-        args.noComment = true;
-        continue;
-      }
-      const val = argv[i + 1];
-      if (!val || val.startsWith('--')) {
-        throw new Error(`Missing value for --${key}`);
-      }
-      args[key] = val;
-      i += 1;
-      continue;
-    }
-    args._.push(a);
-  }
-  return args;
+  return parseArgv(argv, {
+    booleanFlags: ['no-defaults', 'no-comment'],
+    onHelp: () => usage(0),
+  });
 }
 
 function readJsonFile(filePath) {
@@ -437,32 +416,37 @@ async function applyMissingDefaults(cfg, issue, fields) {
     summary.storyPoints = 'skipped (not configured)';
   }
 
-  if (d.teamId) {
-    if (isEmpty(fields[d.teamField])) {
-      update[d.teamField] = { id: d.teamId };
-      summary.team = `set ${d.teamName || d.teamId}`;
-    } else {
-      summary.team = `kept ${fields[d.teamField].name || fields[d.teamField].id}`;
-    }
+  if (shouldSkipTeamAndSprint(d)) {
+    summary.team = 'skipped (NONE)';
+    summary.sprint = 'skipped (NONE)';
   } else {
-    summary.team = 'skipped (no teamId)';
-  }
-
-  if (d.boardId) {
-    if (isEmpty(fields[d.sprintField])) {
-      try {
-        const sprint = await resolveActiveSprint(cfg, d.boardId);
-        update[d.sprintField] = sprint.id;
-        summary.sprint = `set ${sprint.name}`;
-      } catch (err) {
-        summary.sprint = `skipped (${err.message})`;
+    if (d.teamId) {
+      if (isEmpty(fields[d.teamField])) {
+        update[d.teamField] = { id: d.teamId };
+        summary.team = `set ${d.teamName || d.teamId}`;
+      } else {
+        summary.team = `kept ${fields[d.teamField].name || fields[d.teamField].id}`;
       }
     } else {
-      const names = (fields[d.sprintField] || []).map((s) => s.name).join(', ');
-      summary.sprint = `kept ${names || 'existing'}`;
+      summary.team = 'skipped (no teamId)';
     }
-  } else {
-    summary.sprint = 'skipped (no boardId)';
+
+    if (d.boardId) {
+      if (isEmpty(fields[d.sprintField])) {
+        try {
+          const sprint = await resolveActiveSprint(cfg, d.boardId);
+          update[d.sprintField] = sprint.id;
+          summary.sprint = `set ${sprint.name}`;
+        } catch (err) {
+          summary.sprint = `skipped (${err.message})`;
+        }
+      } else {
+        const names = (fields[d.sprintField] || []).map((s) => s.name).join(', ');
+        summary.sprint = `kept ${names || 'existing'}`;
+      }
+    } else {
+      summary.sprint = 'skipped (no boardId)';
+    }
   }
 
   if (d.assigneeEmail) {

--- a/skills/jira-pr-mr-link/tests/lib.test.mjs
+++ b/skills/jira-pr-mr-link/tests/lib.test.mjs
@@ -11,11 +11,13 @@ import {
   displayTitleFromLinkTitle,
   mergeDefaultsLayers,
   missingDefaultKeys,
+  parseArgs,
   parseEmailToken,
   parsePrMrUrl,
   resolveJiraAuth,
   shouldAppendJiraRef,
   shouldMoveRhdhplanDeliveryIssue,
+  shouldSkipTeamAndSprint,
   stripMergedPrefix,
   withMergedPrefix,
 } from '../scripts/lib.js';
@@ -87,6 +89,19 @@ describe('mergeDefaultsLayers / missingDefaultKeys', () => {
     assert.ok(missing.includes('assigneeEmail'));
     assert.ok(missing.includes('teamId'));
   });
+  it('NONE team skips team/sprint required keys', () => {
+    assert.equal(shouldSkipTeamAndSprint({ teamName: 'NONE' }), true);
+    assert.equal(shouldSkipTeamAndSprint({ teamId: 'none' }), true);
+    assert.equal(shouldSkipTeamAndSprint({ teamName: 'RHDH Cope' }), false);
+    const missing = missingDefaultKeys({
+      assigneeEmail: 'a@b.com',
+      teamName: 'NONE',
+      storyPoints: 1,
+      priorityName: 'Normal',
+      storyPointsField: 'customfield_10028',
+    });
+    assert.deepEqual(missing, []);
+  });
 });
 
 describe('shouldMoveRhdhplanDeliveryIssue', () => {
@@ -146,6 +161,19 @@ describe('parsePrMrUrl', () => {
         id: '817',
       },
     );
+  });
+});
+
+describe('parseArgs', () => {
+  it('maps boolean flags to camelCase and keeps valued flags', () => {
+    const args = parseArgs(
+      ['link', '--no-defaults', '--issue', 'RHIDP-1', '--title', 't'],
+      { booleanFlags: ['no-defaults', 'no-comment'] },
+    );
+    assert.equal(args.noDefaults, true);
+    assert.equal(args.issue, 'RHIDP-1');
+    assert.equal(args.title, 't');
+    assert.deepEqual(args._, ['link']);
   });
 });
 

--- a/skills/jira-pr-mr-link/tests/lib.test.mjs
+++ b/skills/jira-pr-mr-link/tests/lib.test.mjs
@@ -1,0 +1,193 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  buildBulkMovePayload,
+  collectAdjustedFieldLines,
+  detectHost,
+  displayTitleFromLinkTitle,
+  mergeDefaultsLayers,
+  missingDefaultKeys,
+  parseEmailToken,
+  parsePrMrUrl,
+  resolveJiraAuth,
+  shouldAppendJiraRef,
+  shouldMoveRhdhplanDeliveryIssue,
+  stripMergedPrefix,
+  withMergedPrefix,
+} from '../scripts/lib.js';
+
+describe('detectHost', () => {
+  it('honors explicit host', () => {
+    assert.equal(detectHost('https://example.com', 'github'), 'github');
+    assert.equal(detectHost('https://github.com/a/b/pull/1', 'gitlab'), 'gitlab');
+  });
+  it('infers github vs gitlab from URL', () => {
+    assert.equal(detectHost('https://github.com/org/repo/pull/1'), 'github');
+    assert.equal(
+      detectHost('https://gitlab.cee.redhat.com/rhidp/rhdh/-/merge_requests/9'),
+      'gitlab',
+    );
+  });
+});
+
+describe('title helpers', () => {
+  it('strips and adds merged prefix', () => {
+    assert.equal(stripMergedPrefix('[x] merged: repo #1: fix'), 'repo #1: fix');
+    assert.equal(withMergedPrefix('repo #1: fix'), '[x] merged: repo #1: fix');
+    assert.equal(
+      withMergedPrefix('[x] merged: repo #1: fix'),
+      '[x] merged: repo #1: fix',
+    );
+  });
+  it('displayTitleFromLinkTitle drops repo#N prefix', () => {
+    assert.equal(
+      displayTitleFromLinkTitle('rhdh #12: fix: widget'),
+      'fix: widget',
+    );
+  });
+});
+
+describe('collectAdjustedFieldLines', () => {
+  it('only includes newly set fields and transitions', () => {
+    const lines = collectAdjustedFieldLines(
+      {
+        storyPoints: 'set 1',
+        team: 'kept Cope',
+        priority: 'set Normal',
+      },
+      'transitioned To Do → In Progress',
+    );
+    assert.deepEqual(lines, [
+      'Story points: 1',
+      'Priority: Normal',
+      'Status: In Progress',
+    ]);
+  });
+});
+
+describe('mergeDefaultsLayers / missingDefaultKeys', () => {
+  it('lets config beat jira-cli hints; CLI wins overall', () => {
+    const merged = mergeDefaultsLayers({
+      fromJiraCli: { boardId: 1, assigneeEmail: 'cli@example.com' },
+      fromFile: { boardId: 2, teamId: 't', teamName: 'T', storyPoints: 1 },
+      fromEnv: { priorityName: 'Normal' },
+      fromCli: { boardId: 3 },
+    });
+    assert.equal(merged.boardId, 3);
+    assert.equal(merged.assigneeEmail, 'cli@example.com');
+    assert.equal(merged.teamId, 't');
+    assert.equal(merged.priorityName, 'Normal');
+  });
+  it('reports incomplete defaults', () => {
+    const missing = missingDefaultKeys({ boardId: 1, storyPoints: 1 });
+    assert.ok(missing.includes('assigneeEmail'));
+    assert.ok(missing.includes('teamId'));
+  });
+});
+
+describe('shouldMoveRhdhplanDeliveryIssue', () => {
+  it('moves only RHDHPLAN Epic/Story/Task', () => {
+    assert.equal(shouldMoveRhdhplanDeliveryIssue('RHDHPLAN', 'Epic'), true);
+    assert.equal(shouldMoveRhdhplanDeliveryIssue('RHDHPLAN', 'Story'), true);
+    assert.equal(shouldMoveRhdhplanDeliveryIssue('RHDHPLAN', 'Task'), true);
+    assert.equal(shouldMoveRhdhplanDeliveryIssue('RHDHPLAN', 'Feature'), false);
+    assert.equal(shouldMoveRhdhplanDeliveryIssue('RHIDP', 'Story'), false);
+  });
+});
+
+describe('buildBulkMovePayload', () => {
+  it('targets RHIDP with issue type id', () => {
+    assert.deepEqual(buildBulkMovePayload('RHDHPLAN-9', 'RHIDP', '10009'), {
+      sendBulkNotification: false,
+      targetToSourcesMapping: {
+        'RHIDP,10009': {
+          inferClassificationDefaults: true,
+          inferFieldDefaults: true,
+          inferStatusDefaults: true,
+          inferSubtaskTypeDefault: true,
+          issueIdsOrKeys: ['RHDHPLAN-9'],
+        },
+      },
+    });
+  });
+});
+
+describe('shouldAppendJiraRef', () => {
+  it('skips community-plugins and --no-jira-ref', () => {
+    assert.equal(shouldAppendJiraRef({}), true);
+    assert.equal(shouldAppendJiraRef({ noJiraRef: true }), false);
+    assert.equal(
+      shouldAppendJiraRef({
+        remoteUrl: 'git@github.com:backstage/community-plugins.git',
+      }),
+      false,
+    );
+  });
+});
+
+describe('parsePrMrUrl', () => {
+  it('parses github and gitlab URLs', () => {
+    assert.deepEqual(
+      parsePrMrUrl('https://github.com/redhat-developer/rhdh/pull/42'),
+      { kind: 'github', owner: 'redhat-developer', repo: 'rhdh', id: '42' },
+    );
+    assert.deepEqual(
+      parsePrMrUrl(
+        'https://gitlab.cee.redhat.com/rhidp/rhdh-plugin-catalog/-/merge_requests/817',
+      ),
+      {
+        kind: 'gitlab',
+        host: 'gitlab.cee.redhat.com',
+        project: 'rhidp/rhdh-plugin-catalog',
+        id: '817',
+      },
+    );
+  });
+});
+
+describe('parseEmailToken / resolveJiraAuth', () => {
+  it('parses email:token', () => {
+    assert.deepEqual(parseEmailToken('a@b.com:secret'), {
+      login: 'a@b.com',
+      token: 'secret',
+    });
+  });
+
+  it('reads .jira-token when env token missing', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'jira-pr-mr-'));
+    const tokenPath = path.join(dir, '.jira-token');
+    const cfgPath = path.join(dir, 'missing.yml');
+    fs.writeFileSync(tokenPath, 'user@example.com:tok-123\n');
+    const auth = resolveJiraAuth({
+      env: {},
+      jiraConfigPath: cfgPath,
+      tokenFilePath: tokenPath,
+    });
+    assert.equal(auth.login, 'user@example.com');
+    assert.equal(auth.token, 'tok-123');
+    assert.equal(auth.server, 'https://redhat.atlassian.net');
+  });
+
+  it('prefers go-jira login + JIRA_API_TOKEN', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'jira-pr-mr-'));
+    const cfgPath = path.join(dir, '.config.yml');
+    fs.writeFileSync(
+      cfgPath,
+      ['login: from-file@example.com', 'server: https://example.atlassian.net', ''].join(
+        '\n',
+      ),
+    );
+    const auth = resolveJiraAuth({
+      env: { JIRA_API_TOKEN: 'bare-token' },
+      jiraConfigPath: cfgPath,
+      tokenFilePath: path.join(dir, 'nope'),
+    });
+    assert.equal(auth.login, 'from-file@example.com');
+    assert.equal(auth.token, 'bare-token');
+    assert.equal(auth.server, 'https://example.atlassian.net');
+  });
+});

--- a/skills/raise-pr/SKILL.md
+++ b/skills/raise-pr/SKILL.md
@@ -372,22 +372,29 @@ Use `--no-defaults` so this step can still transition to **Review**.
 
 1. **Link + comment** via `link-pr-mr.js` (preferred) or fall back to MCP/REST:
    ```
-   node "$JIRA_PR_MR_LINK_SKILL/scripts/link-pr-mr.js" link \
+   LINK_OUT="$(node "../jira-pr-mr-link/scripts/link-pr-mr.js" link \
      --issue "<jira_key>" \
      --url "<PR_URL>" \
      --title "<repo-short> #<pr_number>: <PR_title>" \
      --host github \
-     --no-defaults
+     --no-defaults)"
+   echo "$LINK_OUT"
+   EFFECTIVE_KEY="$(printf '%s\n' "$LINK_OUT" | awk -F': ' '/^issue:/{print $2; exit}')"
+   EFFECTIVE_KEY="${EFFECTIVE_KEY:-<jira_key>}"
    ```
-   Fallback if the skill is not installed:
+   Resolve the path from the installed `skills/` tree (same relative layout as this
+   file). Do not invent `$JIRA_PR_MR_LINK_SKILL`. If the issue was a RHDHPLAN
+   Epic/Story/Task, the linker may auto-move it to RHIDP — use `EFFECTIVE_KEY`
+   (from stdout `issue:`) for the Review transition below.
+   Fallback if the skill is missing:
    - Comment via Jira MCP `add_jira_comment`: `PR submitted: <PR_URL>`
    - Web link via POST `/rest/api/3/issue/<jira_key>/remotelink` (see `references/jira-input.md`)
 
 2. **Transition** the issue status to "Review" (if ACLI is available):
    ```
-   acli jira workitem transition --key "<jira_key>" --status "Review" --yes
+   acli jira workitem transition --key "<EFFECTIVE_KEY>" --status "Review" --yes
    ```
-   Query available transitions first: `acli jira workitem getTransitions --key "<jira_key>"`. If "Review" is not available, skip the transition and log a warning.
+   Query available transitions first: `acli jira workitem getTransitions --key "<EFFECTIVE_KEY>"`. If "Review" is not available, skip the transition and log a warning.
 
 **If any Jira call fails:** Log a warning and continue — the PR has been created successfully:
 ```

--- a/skills/raise-pr/SKILL.md
+++ b/skills/raise-pr/SKILL.md
@@ -365,8 +365,8 @@ EOF
 
 ### If `issue_source` = `jira`
 
-Prefer the [`jira-pr-mr-link`](../jira-pr-mr-link/SKILL.md) linker for Web link +
-comment instead of hand-rolling REST/MCP (see
+Call the [`jira-pr-mr-link`](../jira-pr-mr-link/SKILL.md) linker for Web link +
+comment (see
 [`jira-pr-mr-link/references/raise-pr-integration.md`](../jira-pr-mr-link/references/raise-pr-integration.md)).
 Use `--no-defaults` so this step can still transition to **Review**.
 
@@ -382,10 +382,9 @@ Use `--no-defaults` so this step can still transition to **Review**.
    EFFECTIVE_KEY="$(printf '%s\n' "$LINK_OUT" | awk -F': ' '/^issue:/{print $2; exit}')"
    EFFECTIVE_KEY="${EFFECTIVE_KEY:-<jira_key>}"
    ```
-   Resolve the path from the installed `skills/` tree (same relative layout as this
-   file). Do not invent `$JIRA_PR_MR_LINK_SKILL`. If the issue was a RHDHPLAN
-   Epic/Story/Task, the linker may auto-move it to RHIDP — use `EFFECTIVE_KEY`
-   (from stdout `issue:`) for the Review transition below.
+   If the issue was a RHDHPLAN Epic/Story/Task, the linker may auto-move it to
+   RHIDP — use `EFFECTIVE_KEY` (from stdout `issue:`) for the Review transition
+   below.
    Fallback if the skill is missing:
    - Comment via Jira MCP `add_jira_comment`: `PR submitted: <PR_URL>`
    - Web link via POST `/rest/api/3/issue/<jira_key>/remotelink` (see `references/jira-input.md`)

--- a/skills/raise-pr/SKILL.md
+++ b/skills/raise-pr/SKILL.md
@@ -365,25 +365,29 @@ EOF
 
 ### If `issue_source` = `jira`
 
-1. **Comment** on the Jira issue documenting the PR submission:
+Prefer the [`jira-pr-mr-link`](../jira-pr-mr-link/SKILL.md) linker for Web link +
+comment instead of hand-rolling REST/MCP (see
+[`jira-pr-mr-link/references/raise-pr-integration.md`](../jira-pr-mr-link/references/raise-pr-integration.md)).
+Use `--no-defaults` so this step can still transition to **Review**.
+
+1. **Link + comment** via `link-pr-mr.js` (preferred) or fall back to MCP/REST:
    ```
-   Use the Jira MCP `add_jira_comment` tool:
-     issueKey: "<jira_key>"
-     body: "PR submitted: <PR_URL>"
+   node "$JIRA_PR_MR_LINK_SKILL/scripts/link-pr-mr.js" link \
+     --issue "<jira_key>" \
+     --url "<PR_URL>" \
+     --title "<repo-short> #<pr_number>: <PR_title>" \
+     --host github \
+     --no-defaults
    ```
+   Fallback if the skill is not installed:
+   - Comment via Jira MCP `add_jira_comment`: `PR submitted: <PR_URL>`
+   - Web link via POST `/rest/api/3/issue/<jira_key>/remotelink` (see `references/jira-input.md`)
 
 2. **Transition** the issue status to "Review" (if ACLI is available):
    ```
    acli jira workitem transition --key "<jira_key>" --status "Review" --yes
    ```
    Query available transitions first: `acli jira workitem getTransitions --key "<jira_key>"`. If "Review" is not available, skip the transition and log a warning.
-
-3. **Add web link** — add the PR URL as a remote link on the Jira issue (if REST auth is available):
-   ```
-   POST /rest/api/3/issue/<jira_key>/remotelink
-   { "object": { "url": "<PR_URL>", "title": "GitHub PR: <PR_title>" } }
-   ```
-   See `references/jira-input.md` for REST API patterns.
 
 **If any Jira call fails:** Log a warning and continue — the PR has been created successfully:
 ```


### PR DESCRIPTION
## Summary
- Add focused `jira-pr-mr-link` skill with `create-pr-mr.js` / `link-pr-mr.js` (Web link, structured comment, config-driven defaults, mark-merged).
- No silent team/assignee builtins — missing config errors with a setup CTA.
- Point `raise-pr` Step 11 at the linker for remotelink/comment (`--no-defaults`), keeping Review transition in `raise-pr`.
- Document relationship so plugin-monorepo PR workflow stays scoped to `raise-pr`.

## Test plan
- [ ] `node skills/jira-pr-mr-link/scripts/link-pr-mr.js --help`
- [ ] Without config: `link` fails with copy/paste setup CTA
- [ ] With `~/.config/jira-pr-mr-link/config.json`: link creates/updates Web link + comment
- [ ] `raise-pr` SKILL.md Step 11 references this skill

Ref: https://redhat.atlassian.net/browse/RHIDP-16062

Generated-by: cursor
