### PR TITLE
feat(skills): add rhdh-bump-yarn for multi-repo Yarn Berry bumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ npx skills add redhat-developer/rhdh-skill --skill base-images-and-rpms
 
 Align Yarn Berry across the RHDH plugin/export/midstream/downstream trees via `yarn set version` + install (plus Containerfile / `ENV YARN=`).
 
-- **[rhdh-bump-yarn](./skills/rhdh-bump-yarn/SKILL.md)** — Bump Yarn (e.g. 4.12/4.14 → 4.17.1; rhdh-cli 3.8.6 with `--from 3.8.6`) in rhdh-plugins, rhdh, overlays, rhdh-cli, rhdh downstream, and rhdh-plugin-catalog. Lock refresh can take **>45 minutes** for a full multi-repo run; use `--scan` / `--dry-run` / `--no-refresh-locks` as needed.
+- **[rhdh-bump-yarn](./skills/rhdh-bump-yarn/SKILL.md)** — Bump Yarn (e.g. 4.12/4.14 → 4.17.1; rhdh-cli 3.8.6 with `--from 3.8.6`) in rhdh-plugins, rhdh, overlays, rhdh-cli, plus GitLab CEE midstream ([rhdh](https://gitlab.cee.redhat.com/rhidp/rhdh), [rhdh-plugin-catalog](https://gitlab.cee.redhat.com/rhidp/rhdh-plugin-catalog)). Lock refresh can take **>45 minutes** for a full multi-repo run; use `--scan` / `--dry-run` / `--no-refresh-locks` as needed.
 
 ```bash
 npx skills add redhat-developer/rhdh-skill --skill rhdh-bump-yarn

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ npx skills add redhat-developer/rhdh-skill --skill base-images-and-rpms
 
 Align Yarn Berry across the RHDH plugin/export/midstream/downstream trees via `yarn set version` + install (plus Containerfile / `ENV YARN=`).
 
-- **[rhdh-bump-yarn](./skills/rhdh-bump-yarn/SKILL.md)** — Bump Yarn (e.g. 4.12/4.14 → 4.17.1; rhdh-cli 3.8.6 with `--from 3.8.6`) in rhdh-plugins, rhdh, overlays, rhdh-cli, plus GitLab CEE midstream ([rhdh](https://gitlab.cee.redhat.com/rhidp/rhdh), [rhdh-plugin-catalog](https://gitlab.cee.redhat.com/rhidp/rhdh-plugin-catalog)). Lock refresh can take **>45 minutes** for a full multi-repo run; use `--scan` / `--dry-run` / `--no-refresh-locks` as needed.
+- **[rhdh-bump-yarn](./skills/rhdh-bump-yarn/SKILL.md)** — Bump Yarn (e.g. 4.12/4.14 → 4.17.1) in rhdh-plugins, rhdh, overlays, rhdh-cli, plus GitLab CEE midstream ([rhdh](https://gitlab.cee.redhat.com/rhidp/rhdh), [rhdh-plugin-catalog](https://gitlab.cee.redhat.com/rhidp/rhdh-plugin-catalog)). Lock refresh can take **>45 minutes** for a full multi-repo run; use `--scan` / `--dry-run` / `--no-refresh-locks` as needed.
 
 ```bash
 npx skills add redhat-developer/rhdh-skill --skill rhdh-bump-yarn

--- a/README.md
+++ b/README.md
@@ -90,6 +90,16 @@ Bump UBI / RHEC base image tags, refresh RPM lockfiles, and align node headers /
 npx skills add redhat-developer/rhdh-skill --skill base-images-and-rpms
 ```
 
+### Yarn
+
+Align Yarn Berry across the RHDH plugin/export/midstream/downstream trees (release binary, `yarnPath`, `packageManager`, Containerfile pins, and `yarn.lock` refresh).
+
+- **[rhdh-bump-yarn](./skills/rhdh-bump-yarn/SKILL.md)** — Bump Yarn (e.g. 4.12/4.14 → 4.17.1) in rhdh-plugins, rhdh, overlays, rhdh downstream, and rhdh-plugin-catalog. Defaults to refreshing lockfiles; use `--scan` / `--dry-run` / `--no-refresh-locks` as needed.
+
+```bash
+npx skills add redhat-developer/rhdh-skill --skill rhdh-bump-yarn
+```
+
 ### Local Testing
 
 Test plugins in a local RHDH instance before deploying.

--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ npx skills add redhat-developer/rhdh-skill --skill base-images-and-rpms
 
 ### Yarn
 
-Align Yarn Berry across the RHDH plugin/export/midstream/downstream trees via `yarn set version` (plus Containerfile / Fullsend / inherited lock refresh).
+Align Yarn Berry across the RHDH plugin/export/midstream/downstream trees via `yarn set version` + install (plus Containerfile / `ENV YARN=`).
 
-- **[rhdh-bump-yarn](./skills/rhdh-bump-yarn/SKILL.md)** — Bump Yarn (e.g. 4.12/4.14 → 4.17.1) in rhdh-plugins, rhdh, overlays, rhdh downstream, and rhdh-plugin-catalog. Workspaces use Yarn’s own bump; extras cover pins Yarn cannot see. Lock refresh can take **>45 minutes** for a full multi-repo run; use `--scan` / `--dry-run` / `--no-refresh-locks` as needed.
+- **[rhdh-bump-yarn](./skills/rhdh-bump-yarn/SKILL.md)** — Bump Yarn (e.g. 4.12/4.14 → 4.17.1) in rhdh-plugins, rhdh, overlays, rhdh downstream, and rhdh-plugin-catalog. Lock refresh can take **>45 minutes** for a full multi-repo run; use `--scan` / `--dry-run` / `--no-refresh-locks` as needed.
 
 ```bash
 npx skills add redhat-developer/rhdh-skill --skill rhdh-bump-yarn

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ npx skills add redhat-developer/rhdh-skill --skill base-images-and-rpms
 
 Align Yarn Berry across the RHDH plugin/export/midstream/downstream trees via `yarn set version` + install (plus Containerfile / `ENV YARN=`).
 
-- **[rhdh-bump-yarn](./skills/rhdh-bump-yarn/SKILL.md)** — Bump Yarn (e.g. 4.12/4.14 → 4.17.1) in rhdh-plugins, rhdh, overlays, rhdh downstream, and rhdh-plugin-catalog. Lock refresh can take **>45 minutes** for a full multi-repo run; use `--scan` / `--dry-run` / `--no-refresh-locks` as needed.
+- **[rhdh-bump-yarn](./skills/rhdh-bump-yarn/SKILL.md)** — Bump Yarn (e.g. 4.12/4.14 → 4.17.1; rhdh-cli 3.8.6 with `--from 3.8.6`) in rhdh-plugins, rhdh, overlays, rhdh-cli, rhdh downstream, and rhdh-plugin-catalog. Lock refresh can take **>45 minutes** for a full multi-repo run; use `--scan` / `--dry-run` / `--no-refresh-locks` as needed.
 
 ```bash
 npx skills add redhat-developer/rhdh-skill --skill rhdh-bump-yarn

--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ npx skills add redhat-developer/rhdh-skill --skill base-images-and-rpms
 
 ### Yarn
 
-Align Yarn Berry across the RHDH plugin/export/midstream/downstream trees (release binary, `yarnPath`, `packageManager`, Containerfile pins, and `yarn.lock` refresh).
+Align Yarn Berry across the RHDH plugin/export/midstream/downstream trees via `yarn set version` (plus Containerfile / Fullsend / inherited lock refresh).
 
-- **[rhdh-bump-yarn](./skills/rhdh-bump-yarn/SKILL.md)** — Bump Yarn (e.g. 4.12/4.14 → 4.17.1) in rhdh-plugins, rhdh, overlays, rhdh downstream, and rhdh-plugin-catalog. Defaults to refreshing lockfiles (can take **>45 minutes** for a full multi-repo run); use `--scan` / `--dry-run` / `--no-refresh-locks` as needed.
+- **[rhdh-bump-yarn](./skills/rhdh-bump-yarn/SKILL.md)** — Bump Yarn (e.g. 4.12/4.14 → 4.17.1) in rhdh-plugins, rhdh, overlays, rhdh downstream, and rhdh-plugin-catalog. Workspaces use Yarn’s own bump; extras cover pins Yarn cannot see. Lock refresh can take **>45 minutes** for a full multi-repo run; use `--scan` / `--dry-run` / `--no-refresh-locks` as needed.
 
 ```bash
 npx skills add redhat-developer/rhdh-skill --skill rhdh-bump-yarn

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ npx skills add redhat-developer/rhdh-skill --skill base-images-and-rpms
 
 Align Yarn Berry across the RHDH plugin/export/midstream/downstream trees (release binary, `yarnPath`, `packageManager`, Containerfile pins, and `yarn.lock` refresh).
 
-- **[rhdh-bump-yarn](./skills/rhdh-bump-yarn/SKILL.md)** — Bump Yarn (e.g. 4.12/4.14 → 4.17.1) in rhdh-plugins, rhdh, overlays, rhdh downstream, and rhdh-plugin-catalog. Defaults to refreshing lockfiles; use `--scan` / `--dry-run` / `--no-refresh-locks` as needed.
+- **[rhdh-bump-yarn](./skills/rhdh-bump-yarn/SKILL.md)** — Bump Yarn (e.g. 4.12/4.14 → 4.17.1) in rhdh-plugins, rhdh, overlays, rhdh downstream, and rhdh-plugin-catalog. Defaults to refreshing lockfiles (can take **>45 minutes** for a full multi-repo run); use `--scan` / `--dry-run` / `--no-refresh-locks` as needed.
 
 ```bash
 npx skills add redhat-developer/rhdh-skill --skill rhdh-bump-yarn

--- a/skills/rhdh-bump-yarn/SKILL.md
+++ b/skills/rhdh-bump-yarn/SKILL.md
@@ -48,7 +48,7 @@ node "$SKILL/scripts/bump-yarn.js" --to 4.17.1 \
 
 Defaults:
 - `--from 4.12.0,4.14.1` (versions RHIDP-16074 replaced). Versions **not** in `--from` (e.g. `4.8.1`, `4.9.2`, Yarn 3.x) stay put.
-- **Refresh `yarn.lock`** in every touched workspace that has one (`yarn install --mode=skip-build`). This is slow but matches Renovate lock metadata updates. Opt out with `--no-refresh-locks`.
+- **Refresh `yarn.lock`** in every touched workspace that has one (`yarn install --mode=skip-build`). This matches Renovate lock metadata updates. Regenerating locks across all five repos can take **>45 minutes**; opt out with `--no-refresh-locks` if you only need pins/binaries first.
 
 ### Useful modes
 
@@ -77,7 +77,7 @@ Source URL: `https://raw.githubusercontent.com/yarnpkg/berry/@yarnpkg/cli/<ver>/
    - `"packageManager": "yarn@<from>"` (also strips optional `+sha…` suffixes)
    - `yarn set version <from>`
    - `ENV YARN=…yarn-<from>.cjs`
-3. **yarn.lock** (default) — in dirs with a lockfile whose `package.json`, `.yarnrc.yml`, or release binary was updated, run `yarn install --mode=skip-build` so `__metadata` / builtin patch hashes update like Renovate.
+3. **yarn.lock** (default) — in dirs with a lockfile whose `package.json`, `.yarnrc.yml`, or release binary was updated, run `yarn install --mode=skip-build` so `__metadata` / builtin patch hashes update like Renovate. Expect **>45 minutes** when refreshing every workspace across the five-repo set.
 4. **Report** — remaining `--from` hits (should be none), binaries left alone, lock refresh results.
 
 ## What it does not do
@@ -90,7 +90,7 @@ Source URL: `https://raw.githubusercontent.com/yarnpkg/berry/@yarnpkg/cli/<ver>/
 1. Confirm `--to` / `--from` (or use defaults for a 4.12/4.14 → 4.17.1 style bump).
 2. Resolve local `--root` checkouts for the repos in scope (ask if paths unclear; `rhdh` config keys `plugins`, `rhdh`, `overlay`, `downstream`, `catalog` may help).
 3. `--scan` each root; note versions that will be left alone.
-4. Run the bump (prefer `--dry-run` first if the tree is dirty/unfamiliar). Expect lock refresh to take a while unless `--no-refresh-locks`.
+4. Run the bump (prefer `--dry-run` first if the tree is dirty/unfamiliar). Expect lock refresh to take **>45 minutes** for a full multi-repo run unless `--no-refresh-locks`.
 5. Re-scan or trust script “remaining from-versions: none”; note any failed lock refreshes.
 6. Summarize: binaries replaced, files updated, left-alone versions, lock refresh counts/failures.
 7. Only commit / open PR·MRs when the user requests; link Jira via `jira-pr-mr-link`.

--- a/skills/rhdh-bump-yarn/SKILL.md
+++ b/skills/rhdh-bump-yarn/SKILL.md
@@ -3,8 +3,8 @@ name: rhdh-bump-yarn
 description: >-
   Bumps Yarn Berry across RHDH-related repos (rhdh-plugins, rhdh midstream,
   rhdh-plugin-export-overlays, rhdh downstream, rhdh-plugin-catalog) using
-  `yarn set version` for workspaces, plus Containerfile / Fullsend / inherited
-  lock refresh. Use for RHIDP-16074-style upgrades or scanning yarn pins.
+  `yarn set version` + install, plus Containerfile / ENV YARN= extras.
+  Use for RHIDP-16074-style upgrades or scanning yarn pins.
 ---
 
 # RHDH multi-repo Yarn bump
@@ -15,27 +15,33 @@ Propagate a Yarn Berry bump (e.g. [rhdh-plugins#2918](https://github.com/redhat-
 
 | Repo | Notes |
 |------|--------|
-| `redhat-developer/rhdh-plugins` | root workspace + Fullsend helper |
+| `redhat-developer/rhdh-plugins` | root workspace (+ Fullsend if hardcoded) |
 | `redhat-developer/rhdh` | root + nested workspaces + Containerfile |
 | `redhat-developer/rhdh-plugin-export-overlays` | many `packageManager` pins |
-| `rhidp/rhdh` | distgit binary + `ENV YARN=` |
+| `rhidp/rhdh` | distgit binary + `ENV YARN=` (copy binary from GH bump) |
 | `rhidp/rhdh-plugin-catalog` | per-workspace pins + Containerfiles |
 
-## Prefer Yarn’s own bump
+## What actually changes
 
-Workspace `packageManager` / `yarnPath` / `.yarn/releases` are updated with:
+For each matching workspace:
 
 ```bash
-yarn set version <to>    # exact version, not `stable`
+yarn set version <to>                 # packageManager + yarnPath + .yarn/releases
+chmod +x .yarn/releases/yarn-<to>.cjs
 yarn install --mode=update-lockfile
 ```
 
-Do **not** hand-download Berry binaries or regex-rewrite `package.json` / `.yarnrc.yml` for normal workspaces. Use an exact `--to` so trees match the Renovate/reference PR.
+Plus pins Yarn cannot see: `ENV YARN=`, Containerfile / Dockerfile / embedded `yarn set version`.
+
+**No binary download.** Bump GitHub repos first (`yarn set version` produces `yarn-<to>.cjs`). For GitLab/distgit trees that only ship a checked-in release + `ENV YARN=`, copy that same `yarn-<to>.cjs` into `.yarn/releases/` (and remove the old `yarn-<from>.cjs`), then run the script so text pins update.
+
+Use an **exact** `--to` (not `stable`) so every repo matches the Renovate/reference PR.
 
 ## Script
 
 ```bash
-SKILL="skills/rhdh-bump-yarn"   # or installed skill root
+SKILL="skills/rhdh-bump-yarn"
+# GH first, then GL (after copying yarn-<to>.cjs into distgit if needed)
 node "$SKILL/scripts/bump-yarn.js" --to 4.17.1 \
   --root /path/to/rhdh-plugins \
   --root /path/to/rhdh \
@@ -45,11 +51,8 @@ node "$SKILL/scripts/bump-yarn.js" --to 4.17.1 \
 ```
 
 Defaults:
-- `--from 4.12.0,4.14.1` — only those move; `4.8.1` / `4.9.2` / Yarn 3.x / dcm `4.15.0` stay
-- For each matching `packageManager`: run `yarn set version <to>`
-- Rewrite **extra** pins Yarn cannot see: Containerfile / Dockerfile / `ENV YARN=` / embedded `yarn set version` / Fullsend `.fullsend/**/bin/yarn`
-- Replace orphan `.yarn/releases` binaries (e.g. distgit) with no `packageManager`
-- Refresh every `yarn.lock` that will run under `--to` (including inherited root pins); skip `dist-dynamic` and explicit older pins. Full five-repo regen can take **>45 minutes**; use `--no-refresh-locks` to skip
+- `--from 4.12.0,4.14.1` — only those move (`4.8.1` / `4.9.2` / Yarn 3.x / dcm `4.15.0` stay)
+- Lock refresh for every `yarn.lock` under `--to` (incl. inherited root pin); skip `dist-dynamic` and explicit older pins. Full five-repo regen can take **>45 minutes**; use `--no-refresh-locks` to skip
 
 ```bash
 node "$SKILL/scripts/bump-yarn.js" --scan --root /path/to/repo
@@ -57,23 +60,20 @@ node "$SKILL/scripts/bump-yarn.js" --to 4.17.1 --root /path/to/repo --dry-run
 node "$SKILL/scripts/bump-yarn.js" --to 4.17.1 --root /path/to/repo --no-refresh-locks
 ```
 
-### Fullsend (rhdh-plugins only)
-
-Prefer deriving the binary from `${FULLSEND_TARGET_REPO_DIR}/.yarnrc.yml` `yarnPath` ([rhdh-plugins#4199](https://github.com/redhat-developer/rhdh-plugins/pull/4199)). The script only rewrites leftover `yarn-<from>.cjs` hardcodes and warns.
-
 ## Agent workflow
 
 1. Confirm `--to` / `--from`.
-2. Resolve local `--root` checkouts.
-3. `--scan`, then bump (`--dry-run` first if unfamiliar).
-4. Summarize set-version dirs, extra files, orphan binaries, lock refresh.
-5. Commit / PR·MR only when the user asks ([`jira-pr-mr-link`](../jira-pr-mr-link/SKILL.md)).
+2. Resolve local `--root` checkouts; bump **GitHub** roots first.
+3. For GitLab/distgit: copy `yarn-<to>.cjs` from a GH bump into `.yarn/releases/` (drop old `--from` binary).
+4. `--scan`, then bump (`--dry-run` first if unfamiliar).
+5. Summarize set-version dirs, extras, lock refresh.
+6. Commit / PR·MR only when the user asks ([`jira-pr-mr-link`](../jira-pr-mr-link/SKILL.md)).
 
 ## Checklist
 
 - [ ] Exact `--to` matches the reference bump
 - [ ] `--from` covers intended versions only
-- [ ] `yarn set version` used for workspaces (not custom binary rewrite)
-- [ ] Containerfile / distgit / Fullsend extras checked
-- [ ] Inherited lock refresh done (or `--no-refresh-locks` intentional)
+- [ ] GH bumped before GL; distgit binary copied (no curl)
+- [ ] Containerfile / `ENV YARN=` extras checked
+- [ ] Lock refresh done (or `--no-refresh-locks` intentional)
 - [ ] New `yarn-*.cjs` binaries executable (`100755`)

--- a/skills/rhdh-bump-yarn/SKILL.md
+++ b/skills/rhdh-bump-yarn/SKILL.md
@@ -1,43 +1,41 @@
 ---
 name: rhdh-bump-yarn
 description: >-
-  Bumps Yarn Berry (release binary, yarnPath, packageManager, Containerfile pins,
-  and yarn.lock via install) across RHDH-related repos: rhdh-plugins, rhdh midstream,
-  rhdh-plugin-export-overlays, rhdh downstream, and rhdh-plugin-catalog. Use when
-  aligning Yarn versions (e.g. RHIDP-16074 / rhdh-plugins#2918 yarn 4.17.1), scanning
-  checkouts for yarn pins, or mirroring a Renovate yarn bump into midstream/downstream trees.
+  Bumps Yarn Berry across RHDH-related repos (rhdh-plugins, rhdh midstream,
+  rhdh-plugin-export-overlays, rhdh downstream, rhdh-plugin-catalog) using
+  `yarn set version` for workspaces, plus Containerfile / Fullsend / inherited
+  lock refresh. Use for RHIDP-16074-style upgrades or scanning yarn pins.
 ---
 
 # RHDH multi-repo Yarn bump
 
 ## Goal
 
-Propagate a Yarn Berry version bump (reference: [rhdh-plugins#2918](https://github.com/redhat-developer/rhdh-plugins/pull/2918), [RHIDP-16074](https://redhat.atlassian.net/browse/RHIDP-16074)) across the five related trees:
+Propagate a Yarn Berry bump (e.g. [rhdh-plugins#2918](https://github.com/redhat-developer/rhdh-plugins/pull/2918), [RHIDP-16074](https://redhat.atlassian.net/browse/RHIDP-16074)) across:
 
-| Repo | Host | Typical shape |
-|------|------|----------------|
-| `redhat-developer/rhdh-plugins` | GitHub | root `.yarn/releases` + `packageManager` + `yarnPath` |
-| `redhat-developer/rhdh` | GitHub | root + `.ci` + `dynamic-plugins` + `e2e-tests` + `build/containerfiles/Containerfile` |
-| `redhat-developer/rhdh-plugin-export-overlays` | GitHub | many `packageManager` pins (e2e/smoke/validate); few/no release binaries |
-| `rhidp/rhdh` | GitLab | `distgit/containers/rhdh-hub` binary + `Containerfile` `ENV YARN=` |
-| `rhidp/rhdh-plugin-catalog` | GitLab | per-workspace `.yarn/releases` + `builder.Containerfile` (`yarn set version`) + `overlay-repo` pins |
+| Repo | Notes |
+|------|--------|
+| `redhat-developer/rhdh-plugins` | root workspace + Fullsend helper |
+| `redhat-developer/rhdh` | root + nested workspaces + Containerfile |
+| `redhat-developer/rhdh-plugin-export-overlays` | many `packageManager` pins |
+| `rhidp/rhdh` | distgit binary + `ENV YARN=` |
+| `rhidp/rhdh-plugin-catalog` | per-workspace pins + Containerfiles |
 
-## Script location
+## Prefer Yarn’s own bump
 
-Scripts live under this skill’s `scripts/` directory. Resolve that path from the
-installed skill root (or this checkout):
+Workspace `packageManager` / `yarnPath` / `.yarn/releases` are updated with:
 
 ```bash
-SKILL="$(dirname "$(realpath "$0")")/.."   # when already in scripts/
-# or, from repo checkout:
-SKILL="skills/rhdh-bump-yarn"
+yarn set version <to>    # exact version, not `stable`
+yarn install --mode=update-lockfile
 ```
 
-**Execute** [scripts/bump-yarn.js](scripts/bump-yarn.js); do not reimplement the workflow inline.
+Do **not** hand-download Berry binaries or regex-rewrite `package.json` / `.yarnrc.yml` for normal workspaces. Use an exact `--to` so trees match the Renovate/reference PR.
 
-## Run the script (preferred)
+## Script
 
 ```bash
+SKILL="skills/rhdh-bump-yarn"   # or installed skill root
 node "$SKILL/scripts/bump-yarn.js" --to 4.17.1 \
   --root /path/to/rhdh-plugins \
   --root /path/to/rhdh \
@@ -47,73 +45,35 @@ node "$SKILL/scripts/bump-yarn.js" --to 4.17.1 \
 ```
 
 Defaults:
-- `--from 4.12.0,4.14.1` (versions RHIDP-16074 replaced). Versions **not** in `--from` (e.g. `4.8.1`, `4.9.2`, Yarn 3.x, `dcm`’s `4.15.0`) stay put.
-- **Refresh `yarn.lock`** with `yarn install --mode=update-lockfile` for **every** lock that will run under `--to` yarn — including nested workspaces that only inherit a root `yarnPath` / `packageManager` (this is what `yarn install --immutable` CI needs after a root-only Renovate bump). Skips `dist-dynamic/**` and dirs with an explicit pin outside `--from`/`--to`. Regenerating locks across all five repos can take **>45 minutes**; opt out with `--no-refresh-locks` if you only need pins/binaries first.
-- **Binaries** are written `chmod +x` (`100755`) so `yarnPath` stays runnable.
-
-### Useful modes
+- `--from 4.12.0,4.14.1` — only those move; `4.8.1` / `4.9.2` / Yarn 3.x / dcm `4.15.0` stay
+- For each matching `packageManager`: run `yarn set version <to>`
+- Rewrite **extra** pins Yarn cannot see: Containerfile / Dockerfile / `ENV YARN=` / embedded `yarn set version` / Fullsend `.fullsend/**/bin/yarn`
+- Replace orphan `.yarn/releases` binaries (e.g. distgit) with no `packageManager`
+- Refresh every `yarn.lock` that will run under `--to` (including inherited root pins); skip `dist-dynamic` and explicit older pins. Full five-repo regen can take **>45 minutes**; use `--no-refresh-locks` to skip
 
 ```bash
-# Inventory pins / binaries
 node "$SKILL/scripts/bump-yarn.js" --scan --root /path/to/repo
-
-# Preview pins/binaries only (does not run install)
 node "$SKILL/scripts/bump-yarn.js" --to 4.17.1 --root /path/to/repo --dry-run
-
-# Cache the Berry CLI binary only
-node "$SKILL/scripts/bump-yarn.js" --fetch-only --to 4.17.1
-
-# Skip lock refresh (pins + binaries only)
 node "$SKILL/scripts/bump-yarn.js" --to 4.17.1 --root /path/to/repo --no-refresh-locks
 ```
 
-Binary cache: `~/.cache/rhdh-bump-yarn/yarn-<ver>.cjs`  
-Source URL: `https://raw.githubusercontent.com/yarnpkg/berry/@yarnpkg/cli/<ver>/packages/yarnpkg-cli/bin/yarn.js`
+### Fullsend (rhdh-plugins only)
 
-## What the script changes
-
-1. **Binaries** — for each `.yarn/releases/yarn-<from>.cjs`, write `yarn-<to>.cjs` (mode `0755`) and remove the old file.
-2. **Text pins** in `package.json`, `.yarnrc.yml`, `Containerfile` / `*.Containerfile`, `Dockerfile`, `run-e2e.sh` (and similar):
-   - `yarnPath: …/yarn-<from>.cjs`
-   - `"packageManager": "yarn@<from>"` (also strips optional `+sha…` suffixes)
-   - `yarn set version <from>`
-   - `ENV YARN=…yarn-<from>.cjs`
-3. **yarn.lock** (default) — discover every `yarn.lock` under the root (except `dist-dynamic` / `node_modules`) whose effective Yarn is `--to` (local `packageManager`/`yarnPath` is `--to` or was in `--from`, **or** there is no local pin and the workspace inherits the bumped root). Run `yarn install --mode=update-lockfile` so `__metadata` (e.g. v8→v10) and builtin patch hashes update; without this, CI `yarn install --immutable` fails with YN0028. Expect **>45 minutes** when refreshing every workspace across the five-repo set.
-4. **Fullsend helper (rhdh-plugins)** — scan/bump `.fullsend/**/bin/yarn` (extensionless). If it still hardcodes `yarn-<from>.cjs`, rewrite to `yarn-<to>.cjs` as a safety net and warn that the durable pattern is **yarnPath derivation** (see below).
-5. **Report** — remaining `--from` hits (should be none), binaries left alone, lock refresh results, locks skipped for explicit older pins.
-
-### Fullsend (rhdh-plugins)
-
-`.fullsend/` in `redhat-developer/rhdh-plugins` is a **per-repo** Fullsend install for **rhdh-plugins only** — not for `redhat-developer/rhdh` (which has no `.fullsend`). The sandbox `FULLSEND_TARGET_REPO_DIR` is the rhdh-plugins checkout.
-
-After bumping Yarn on rhdh-plugins, verify [`.fullsend/rhdh/bin/yarn`](https://github.com/redhat-developer/rhdh-plugins/blob/main/.fullsend/rhdh/bin/yarn):
-
-- **Prefer** deriving the binary from `${FULLSEND_TARGET_REPO_DIR}/.yarnrc.yml` `yarnPath` (with a fallback only when there is exactly one `.yarn/releases/yarn-*.cjs`). See [rhdh-plugins#4199](https://github.com/redhat-developer/rhdh-plugins/pull/4199).
-- **Do not** reintroduce a hardcoded `yarn-X.Y.Z.cjs` path; that breaks Fullsend on the next Yarn filename bump.
-- The bump script will rewrite a leftover hardcode matching `--from` → `--to` and print a one-line warning recommending yarnPath derivation.
-
-## What it does not do
-
-- **Commits / PRs / MRs** — after the bump, commit and open with [`jira-pr-mr-link`](../jira-pr-mr-link/SKILL.md) when the user asks (cite the Jira key they name).
-- **rhdh-cli Yarn 3.x** — out of scope unless `--from` includes those versions.
+Prefer deriving the binary from `${FULLSEND_TARGET_REPO_DIR}/.yarnrc.yml` `yarnPath` ([rhdh-plugins#4199](https://github.com/redhat-developer/rhdh-plugins/pull/4199)). The script only rewrites leftover `yarn-<from>.cjs` hardcodes and warns.
 
 ## Agent workflow
 
-1. Confirm `--to` / `--from` (or use defaults for a 4.12/4.14 → 4.17.1 style bump).
-2. Resolve local `--root` checkouts for the repos in scope (ask if paths unclear; `rhdh` config keys `plugins`, `rhdh`, `overlay`, `downstream`, `catalog` may help).
-3. `--scan` each root; note versions that will be left alone.
-4. Run the bump (prefer `--dry-run` first if the tree is dirty/unfamiliar). Expect lock refresh to take **>45 minutes** for a full multi-repo run unless `--no-refresh-locks`.
-5. Re-scan or trust script “remaining from-versions: none”; note any failed lock refreshes.
-6. Summarize: binaries replaced, files updated, left-alone versions, lock refresh counts/failures.
-7. Only commit / open PR·MRs when the user requests; link Jira via `jira-pr-mr-link`.
+1. Confirm `--to` / `--from`.
+2. Resolve local `--root` checkouts.
+3. `--scan`, then bump (`--dry-run` first if unfamiliar).
+4. Summarize set-version dirs, extra files, orphan binaries, lock refresh.
+5. Commit / PR·MR only when the user asks ([`jira-pr-mr-link`](../jira-pr-mr-link/SKILL.md)).
 
 ## Checklist
 
-- [ ] `--to` matches the reference PR (e.g. 4.17.1).
-- [ ] `--from` covers every version intended to move; others stay put.
-- [ ] All in-scope roots scanned and bumped.
-- [ ] No unexpected remaining `--from` pins.
-- [ ] Lock refresh completed for inheriting workspaces too (or `--no-refresh-locks` was intentional); failures investigated.
-- [ ] New `yarn-*.cjs` binaries are executable (`100755`).
-- [ ] rhdh-plugins: Fullsend `.fullsend/rhdh/bin/yarn` uses yarnPath derivation (or at least matches `--to`).
-- [ ] PR/MR + Jira only after user asks.
+- [ ] Exact `--to` matches the reference bump
+- [ ] `--from` covers intended versions only
+- [ ] `yarn set version` used for workspaces (not custom binary rewrite)
+- [ ] Containerfile / distgit / Fullsend extras checked
+- [ ] Inherited lock refresh done (or `--no-refresh-locks` intentional)
+- [ ] New `yarn-*.cjs` binaries executable (`100755`)

--- a/skills/rhdh-bump-yarn/SKILL.md
+++ b/skills/rhdh-bump-yarn/SKILL.md
@@ -79,7 +79,18 @@ Source URL: `https://raw.githubusercontent.com/yarnpkg/berry/@yarnpkg/cli/<ver>/
    - `yarn set version <from>`
    - `ENV YARN=…yarn-<from>.cjs`
 3. **yarn.lock** (default) — discover every `yarn.lock` under the root (except `dist-dynamic` / `node_modules`) whose effective Yarn is `--to` (local `packageManager`/`yarnPath` is `--to` or was in `--from`, **or** there is no local pin and the workspace inherits the bumped root). Run `yarn install --mode=update-lockfile` so `__metadata` (e.g. v8→v10) and builtin patch hashes update; without this, CI `yarn install --immutable` fails with YN0028. Expect **>45 minutes** when refreshing every workspace across the five-repo set.
-4. **Report** — remaining `--from` hits (should be none), binaries left alone, lock refresh results, locks skipped for explicit older pins.
+4. **Fullsend helper (rhdh-plugins)** — scan/bump `.fullsend/**/bin/yarn` (extensionless). If it still hardcodes `yarn-<from>.cjs`, rewrite to `yarn-<to>.cjs` as a safety net and warn that the durable pattern is **yarnPath derivation** (see below).
+5. **Report** — remaining `--from` hits (should be none), binaries left alone, lock refresh results, locks skipped for explicit older pins.
+
+### Fullsend (rhdh-plugins)
+
+`.fullsend/` in `redhat-developer/rhdh-plugins` is a **per-repo** Fullsend install for **rhdh-plugins only** — not for `redhat-developer/rhdh` (which has no `.fullsend`). The sandbox `FULLSEND_TARGET_REPO_DIR` is the rhdh-plugins checkout.
+
+After bumping Yarn on rhdh-plugins, verify [`.fullsend/rhdh/bin/yarn`](https://github.com/redhat-developer/rhdh-plugins/blob/main/.fullsend/rhdh/bin/yarn):
+
+- **Prefer** deriving the binary from `${FULLSEND_TARGET_REPO_DIR}/.yarnrc.yml` `yarnPath` (with a fallback only when there is exactly one `.yarn/releases/yarn-*.cjs`). See [rhdh-plugins#4199](https://github.com/redhat-developer/rhdh-plugins/pull/4199).
+- **Do not** reintroduce a hardcoded `yarn-X.Y.Z.cjs` path; that breaks Fullsend on the next Yarn filename bump.
+- The bump script will rewrite a leftover hardcode matching `--from` → `--to` and print a one-line warning recommending yarnPath derivation.
 
 ## What it does not do
 
@@ -104,4 +115,5 @@ Source URL: `https://raw.githubusercontent.com/yarnpkg/berry/@yarnpkg/cli/<ver>/
 - [ ] No unexpected remaining `--from` pins.
 - [ ] Lock refresh completed for inheriting workspaces too (or `--no-refresh-locks` was intentional); failures investigated.
 - [ ] New `yarn-*.cjs` binaries are executable (`100755`).
+- [ ] rhdh-plugins: Fullsend `.fullsend/rhdh/bin/yarn` uses yarnPath derivation (or at least matches `--to`).
 - [ ] PR/MR + Jira only after user asks.

--- a/skills/rhdh-bump-yarn/SKILL.md
+++ b/skills/rhdh-bump-yarn/SKILL.md
@@ -18,7 +18,7 @@ Propagate a Yarn Berry bump (e.g. [rhdh-plugins#2918](https://github.com/redhat-
 | [`redhat-developer/rhdh-plugins`](https://github.com/redhat-developer/rhdh-plugins) | root workspace (+ Fullsend if hardcoded) |
 | [`redhat-developer/rhdh`](https://github.com/redhat-developer/rhdh) | root + nested workspaces + Containerfile |
 | [`redhat-developer/rhdh-plugin-export-overlays`](https://github.com/redhat-developer/rhdh-plugin-export-overlays) | many `packageManager` pins |
-| [`redhat-developer/rhdh-cli`](https://github.com/redhat-developer/rhdh-cli) | Yarn **3.8.6** → use `--from 3.8.6` (not in default `--from`) |
+| [`redhat-developer/rhdh-cli`](https://github.com/redhat-developer/rhdh-cli) | root `packageManager` / `yarnPath` (now Yarn 4.17.1) |
 | [`gitlab.cee.redhat.com/rhidp/rhdh`](https://gitlab.cee.redhat.com/rhidp/rhdh) | distgit binary + `ENV YARN=` (copy binary from GH bump) |
 | [`gitlab.cee.redhat.com/rhidp/rhdh-plugin-catalog`](https://gitlab.cee.redhat.com/rhidp/rhdh-plugin-catalog) | per-workspace pins + Containerfiles |
 
@@ -42,21 +42,18 @@ Use an **exact** `--to` (not `stable`) so every repo matches the Renovate/refere
 
 ```bash
 SKILL="skills/rhdh-bump-yarn"
-# GH first (4.12/4.14 defaults), then GL (after copying yarn-<to>.cjs into distgit if needed)
+# GH first (4.12/4.14 defaults), then GL CEE (after copying yarn-<to>.cjs into distgit if needed)
 node "$SKILL/scripts/bump-yarn.js" --to 4.17.1 \
   --root /path/to/rhdh-plugins \
   --root /path/to/rhdh \
   --root /path/to/overlays \
+  --root /path/to/rhdh-cli \
   --root /path/to/rhdh-downstream \
   --root /path/to/rhdh-plugin-catalog
-
-# rhdh-cli is still on Yarn 3.8.6 — pass --from explicitly
-node "$SKILL/scripts/bump-yarn.js" --to 4.17.1 --from 3.8.6 \
-  --root /path/to/rhdh-cli
 ```
 
 Defaults:
-- `--from 4.12.0,4.14.1` — only those move (`4.8.1` / `4.9.2` / dcm `4.15.0` stay). **`rhdh-cli` needs `--from 3.8.6`.**
+- `--from 4.12.0,4.14.1` — only those move (`4.8.1` / `4.9.2` / dcm `4.15.0` stay). Repos already on `--to` (e.g. rhdh-cli at 4.17.1) are no-ops.
 - Lock refresh for every `yarn.lock` under `--to` (incl. inherited root pin); skip `dist-dynamic` and explicit older pins. Full multi-repo regen can take **>45 minutes**; use `--no-refresh-locks` to skip
 
 ```bash
@@ -77,7 +74,7 @@ node "$SKILL/scripts/bump-yarn.js" --to 4.17.1 --root /path/to/repo --no-refresh
 ## Checklist
 
 - [ ] Exact `--to` matches the reference bump
-- [ ] `--from` covers intended versions only (`3.8.6` for rhdh-cli; default 4.12/4.14 otherwise)
+- [ ] `--from` covers intended versions only (default 4.12/4.14; add others only when needed)
 - [ ] GH bumped before GL CEE; distgit binary copied (no curl)
 - [ ] Containerfile / `ENV YARN=` extras checked
 - [ ] Lock refresh done (or `--no-refresh-locks` intentional)

--- a/skills/rhdh-bump-yarn/SKILL.md
+++ b/skills/rhdh-bump-yarn/SKILL.md
@@ -2,9 +2,9 @@
 name: rhdh-bump-yarn
 description: >-
   Bumps Yarn Berry across RHDH-related repos (rhdh-plugins, rhdh midstream,
-  rhdh-plugin-export-overlays, rhdh-cli, rhdh downstream, rhdh-plugin-catalog)
-  using `yarn set version` + install, plus Containerfile / ENV YARN= extras.
-  Use for RHIDP-16074-style upgrades or scanning yarn pins.
+  rhdh-plugin-export-overlays, rhdh-cli, GitLab CEE rhidp/rhdh +
+  rhdh-plugin-catalog) using `yarn set version` + install, plus Containerfile /
+  ENV YARN= extras. Use for RHIDP-16074-style upgrades or scanning yarn pins.
 ---
 
 # RHDH multi-repo Yarn bump
@@ -19,8 +19,8 @@ Propagate a Yarn Berry bump (e.g. [rhdh-plugins#2918](https://github.com/redhat-
 | `redhat-developer/rhdh` | root + nested workspaces + Containerfile |
 | `redhat-developer/rhdh-plugin-export-overlays` | many `packageManager` pins |
 | `redhat-developer/rhdh-cli` | Yarn **3.8.6** → use `--from 3.8.6` (not in default `--from`) |
-| `rhidp/rhdh` | distgit binary + `ENV YARN=` (copy binary from GH bump) |
-| `rhidp/rhdh-plugin-catalog` | per-workspace pins + Containerfiles |
+| [`gitlab.cee.redhat.com/rhidp/rhdh`](https://gitlab.cee.redhat.com/rhidp/rhdh) | distgit binary + `ENV YARN=` (copy binary from GH bump) |
+| [`gitlab.cee.redhat.com/rhidp/rhdh-plugin-catalog`](https://gitlab.cee.redhat.com/rhidp/rhdh-plugin-catalog) | per-workspace pins + Containerfiles |
 
 ## What actually changes
 
@@ -34,7 +34,7 @@ yarn install --mode=update-lockfile
 
 Plus pins Yarn cannot see: `ENV YARN=`, Containerfile / Dockerfile / embedded `yarn set version`.
 
-**No binary download.** Bump GitHub repos first (`yarn set version` produces `yarn-<to>.cjs`). For GitLab/distgit trees that only ship a checked-in release + `ENV YARN=`, copy that same `yarn-<to>.cjs` into `.yarn/releases/` (and remove the old `yarn-<from>.cjs`), then run the script so text pins update.
+**No binary download.** Bump GitHub repos first (`yarn set version` produces `yarn-<to>.cjs`). For **GitLab CEE** midstream/distgit trees (`gitlab.cee.redhat.com/rhidp/rhdh`, `…/rhdh-plugin-catalog`) that only ship a checked-in release + `ENV YARN=`, copy that same `yarn-<to>.cjs` into `.yarn/releases/` (and remove the old `yarn-<from>.cjs`), then run the script so text pins update. Use `glab` against `gitlab.cee.redhat.com` (not `gitlab.com`) when opening MRs for those roots.
 
 Use an **exact** `--to` (not `stable`) so every repo matches the Renovate/reference PR.
 
@@ -69,7 +69,7 @@ node "$SKILL/scripts/bump-yarn.js" --to 4.17.1 --root /path/to/repo --no-refresh
 
 1. Confirm `--to` / `--from`.
 2. Resolve local `--root` checkouts; bump **GitHub** roots first.
-3. For GitLab/distgit: copy `yarn-<to>.cjs` from a GH bump into `.yarn/releases/` (drop old `--from` binary).
+3. For GitLab CEE midstream/distgit (`gitlab.cee.redhat.com/rhidp/rhdh`, `…/rhdh-plugin-catalog`): copy `yarn-<to>.cjs` from a GH bump into `.yarn/releases/` (drop old `--from` binary).
 4. `--scan`, then bump (`--dry-run` first if unfamiliar).
 5. Summarize set-version dirs, extras, lock refresh.
 6. Commit / PR·MR only when the user asks ([`jira-pr-mr-link`](../jira-pr-mr-link/SKILL.md)).
@@ -78,7 +78,7 @@ node "$SKILL/scripts/bump-yarn.js" --to 4.17.1 --root /path/to/repo --no-refresh
 
 - [ ] Exact `--to` matches the reference bump
 - [ ] `--from` covers intended versions only (`3.8.6` for rhdh-cli; default 4.12/4.14 otherwise)
-- [ ] GH bumped before GL; distgit binary copied (no curl)
+- [ ] GH bumped before GL CEE; distgit binary copied (no curl)
 - [ ] Containerfile / `ENV YARN=` extras checked
 - [ ] Lock refresh done (or `--no-refresh-locks` intentional)
 - [ ] New `yarn-*.cjs` binaries executable (`100755`)

--- a/skills/rhdh-bump-yarn/SKILL.md
+++ b/skills/rhdh-bump-yarn/SKILL.md
@@ -15,10 +15,10 @@ Propagate a Yarn Berry bump (e.g. [rhdh-plugins#2918](https://github.com/redhat-
 
 | Repo | Notes |
 |------|--------|
-| `redhat-developer/rhdh-plugins` | root workspace (+ Fullsend if hardcoded) |
-| `redhat-developer/rhdh` | root + nested workspaces + Containerfile |
-| `redhat-developer/rhdh-plugin-export-overlays` | many `packageManager` pins |
-| `redhat-developer/rhdh-cli` | Yarn **3.8.6** → use `--from 3.8.6` (not in default `--from`) |
+| [`redhat-developer/rhdh-plugins`](https://github.com/redhat-developer/rhdh-plugins) | root workspace (+ Fullsend if hardcoded) |
+| [`redhat-developer/rhdh`](https://github.com/redhat-developer/rhdh) | root + nested workspaces + Containerfile |
+| [`redhat-developer/rhdh-plugin-export-overlays`](https://github.com/redhat-developer/rhdh-plugin-export-overlays) | many `packageManager` pins |
+| [`redhat-developer/rhdh-cli`](https://github.com/redhat-developer/rhdh-cli) | Yarn **3.8.6** → use `--from 3.8.6` (not in default `--from`) |
 | [`gitlab.cee.redhat.com/rhidp/rhdh`](https://gitlab.cee.redhat.com/rhidp/rhdh) | distgit binary + `ENV YARN=` (copy binary from GH bump) |
 | [`gitlab.cee.redhat.com/rhidp/rhdh-plugin-catalog`](https://gitlab.cee.redhat.com/rhidp/rhdh-plugin-catalog) | per-workspace pins + Containerfiles |
 

--- a/skills/rhdh-bump-yarn/SKILL.md
+++ b/skills/rhdh-bump-yarn/SKILL.md
@@ -47,8 +47,9 @@ node "$SKILL/scripts/bump-yarn.js" --to 4.17.1 \
 ```
 
 Defaults:
-- `--from 4.12.0,4.14.1` (versions RHIDP-16074 replaced). Versions **not** in `--from` (e.g. `4.8.1`, `4.9.2`, Yarn 3.x) stay put.
-- **Refresh `yarn.lock`** in every touched workspace that has one (`yarn install --mode=skip-build`). This matches Renovate lock metadata updates. Regenerating locks across all five repos can take **>45 minutes**; opt out with `--no-refresh-locks` if you only need pins/binaries first.
+- `--from 4.12.0,4.14.1` (versions RHIDP-16074 replaced). Versions **not** in `--from` (e.g. `4.8.1`, `4.9.2`, Yarn 3.x, `dcm`’s `4.15.0`) stay put.
+- **Refresh `yarn.lock`** with `yarn install --mode=update-lockfile` for **every** lock that will run under `--to` yarn — including nested workspaces that only inherit a root `yarnPath` / `packageManager` (this is what `yarn install --immutable` CI needs after a root-only Renovate bump). Skips `dist-dynamic/**` and dirs with an explicit pin outside `--from`/`--to`. Regenerating locks across all five repos can take **>45 minutes**; opt out with `--no-refresh-locks` if you only need pins/binaries first.
+- **Binaries** are written `chmod +x` (`100755`) so `yarnPath` stays runnable.
 
 ### Useful modes
 
@@ -71,14 +72,14 @@ Source URL: `https://raw.githubusercontent.com/yarnpkg/berry/@yarnpkg/cli/<ver>/
 
 ## What the script changes
 
-1. **Binaries** — for each `.yarn/releases/yarn-<from>.cjs`, write `yarn-<to>.cjs` and remove the old file.
+1. **Binaries** — for each `.yarn/releases/yarn-<from>.cjs`, write `yarn-<to>.cjs` (mode `0755`) and remove the old file.
 2. **Text pins** in `package.json`, `.yarnrc.yml`, `Containerfile` / `*.Containerfile`, `Dockerfile`, `run-e2e.sh` (and similar):
    - `yarnPath: …/yarn-<from>.cjs`
    - `"packageManager": "yarn@<from>"` (also strips optional `+sha…` suffixes)
    - `yarn set version <from>`
    - `ENV YARN=…yarn-<from>.cjs`
-3. **yarn.lock** (default) — in dirs with a lockfile whose `package.json`, `.yarnrc.yml`, or release binary was updated, run `yarn install --mode=skip-build` so `__metadata` / builtin patch hashes update like Renovate. Expect **>45 minutes** when refreshing every workspace across the five-repo set.
-4. **Report** — remaining `--from` hits (should be none), binaries left alone, lock refresh results.
+3. **yarn.lock** (default) — discover every `yarn.lock` under the root (except `dist-dynamic` / `node_modules`) whose effective Yarn is `--to` (local `packageManager`/`yarnPath` is `--to` or was in `--from`, **or** there is no local pin and the workspace inherits the bumped root). Run `yarn install --mode=update-lockfile` so `__metadata` (e.g. v8→v10) and builtin patch hashes update; without this, CI `yarn install --immutable` fails with YN0028. Expect **>45 minutes** when refreshing every workspace across the five-repo set.
+4. **Report** — remaining `--from` hits (should be none), binaries left alone, lock refresh results, locks skipped for explicit older pins.
 
 ## What it does not do
 
@@ -101,5 +102,6 @@ Source URL: `https://raw.githubusercontent.com/yarnpkg/berry/@yarnpkg/cli/<ver>/
 - [ ] `--from` covers every version intended to move; others stay put.
 - [ ] All in-scope roots scanned and bumped.
 - [ ] No unexpected remaining `--from` pins.
-- [ ] Lock refresh completed (or `--no-refresh-locks` was intentional); failures investigated.
+- [ ] Lock refresh completed for inheriting workspaces too (or `--no-refresh-locks` was intentional); failures investigated.
+- [ ] New `yarn-*.cjs` binaries are executable (`100755`).
 - [ ] PR/MR + Jira only after user asks.

--- a/skills/rhdh-bump-yarn/SKILL.md
+++ b/skills/rhdh-bump-yarn/SKILL.md
@@ -2,8 +2,8 @@
 name: rhdh-bump-yarn
 description: >-
   Bumps Yarn Berry across RHDH-related repos (rhdh-plugins, rhdh midstream,
-  rhdh-plugin-export-overlays, rhdh downstream, rhdh-plugin-catalog) using
-  `yarn set version` + install, plus Containerfile / ENV YARN= extras.
+  rhdh-plugin-export-overlays, rhdh-cli, rhdh downstream, rhdh-plugin-catalog)
+  using `yarn set version` + install, plus Containerfile / ENV YARN= extras.
   Use for RHIDP-16074-style upgrades or scanning yarn pins.
 ---
 
@@ -18,6 +18,7 @@ Propagate a Yarn Berry bump (e.g. [rhdh-plugins#2918](https://github.com/redhat-
 | `redhat-developer/rhdh-plugins` | root workspace (+ Fullsend if hardcoded) |
 | `redhat-developer/rhdh` | root + nested workspaces + Containerfile |
 | `redhat-developer/rhdh-plugin-export-overlays` | many `packageManager` pins |
+| `redhat-developer/rhdh-cli` | Yarn **3.8.6** → use `--from 3.8.6` (not in default `--from`) |
 | `rhidp/rhdh` | distgit binary + `ENV YARN=` (copy binary from GH bump) |
 | `rhidp/rhdh-plugin-catalog` | per-workspace pins + Containerfiles |
 
@@ -41,18 +42,22 @@ Use an **exact** `--to` (not `stable`) so every repo matches the Renovate/refere
 
 ```bash
 SKILL="skills/rhdh-bump-yarn"
-# GH first, then GL (after copying yarn-<to>.cjs into distgit if needed)
+# GH first (4.12/4.14 defaults), then GL (after copying yarn-<to>.cjs into distgit if needed)
 node "$SKILL/scripts/bump-yarn.js" --to 4.17.1 \
   --root /path/to/rhdh-plugins \
   --root /path/to/rhdh \
   --root /path/to/overlays \
   --root /path/to/rhdh-downstream \
   --root /path/to/rhdh-plugin-catalog
+
+# rhdh-cli is still on Yarn 3.8.6 — pass --from explicitly
+node "$SKILL/scripts/bump-yarn.js" --to 4.17.1 --from 3.8.6 \
+  --root /path/to/rhdh-cli
 ```
 
 Defaults:
-- `--from 4.12.0,4.14.1` — only those move (`4.8.1` / `4.9.2` / Yarn 3.x / dcm `4.15.0` stay)
-- Lock refresh for every `yarn.lock` under `--to` (incl. inherited root pin); skip `dist-dynamic` and explicit older pins. Full five-repo regen can take **>45 minutes**; use `--no-refresh-locks` to skip
+- `--from 4.12.0,4.14.1` — only those move (`4.8.1` / `4.9.2` / dcm `4.15.0` stay). **`rhdh-cli` needs `--from 3.8.6`.**
+- Lock refresh for every `yarn.lock` under `--to` (incl. inherited root pin); skip `dist-dynamic` and explicit older pins. Full multi-repo regen can take **>45 minutes**; use `--no-refresh-locks` to skip
 
 ```bash
 node "$SKILL/scripts/bump-yarn.js" --scan --root /path/to/repo
@@ -72,7 +77,7 @@ node "$SKILL/scripts/bump-yarn.js" --to 4.17.1 --root /path/to/repo --no-refresh
 ## Checklist
 
 - [ ] Exact `--to` matches the reference bump
-- [ ] `--from` covers intended versions only
+- [ ] `--from` covers intended versions only (`3.8.6` for rhdh-cli; default 4.12/4.14 otherwise)
 - [ ] GH bumped before GL; distgit binary copied (no curl)
 - [ ] Containerfile / `ENV YARN=` extras checked
 - [ ] Lock refresh done (or `--no-refresh-locks` intentional)

--- a/skills/rhdh-bump-yarn/SKILL.md
+++ b/skills/rhdh-bump-yarn/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: rhdh-bump-yarn
+description: >-
+  Bumps Yarn Berry (release binary, yarnPath, packageManager, Containerfile pins,
+  and yarn.lock via install) across RHDH-related repos: rhdh-plugins, rhdh midstream,
+  rhdh-plugin-export-overlays, rhdh downstream, and rhdh-plugin-catalog. Use when
+  aligning Yarn versions (e.g. RHIDP-16074 / rhdh-plugins#2918 yarn 4.17.1), scanning
+  checkouts for yarn pins, or mirroring a Renovate yarn bump into midstream/downstream trees.
+---
+
+# RHDH multi-repo Yarn bump
+
+## Goal
+
+Propagate a Yarn Berry version bump (reference: [rhdh-plugins#2918](https://github.com/redhat-developer/rhdh-plugins/pull/2918), [RHIDP-16074](https://redhat.atlassian.net/browse/RHIDP-16074)) across the five related trees:
+
+| Repo | Host | Typical shape |
+|------|------|----------------|
+| `redhat-developer/rhdh-plugins` | GitHub | root `.yarn/releases` + `packageManager` + `yarnPath` |
+| `redhat-developer/rhdh` | GitHub | root + `.ci` + `dynamic-plugins` + `e2e-tests` + `build/containerfiles/Containerfile` |
+| `redhat-developer/rhdh-plugin-export-overlays` | GitHub | many `packageManager` pins (e2e/smoke/validate); few/no release binaries |
+| `rhidp/rhdh` | GitLab | `distgit/containers/rhdh-hub` binary + `Containerfile` `ENV YARN=` |
+| `rhidp/rhdh-plugin-catalog` | GitLab | per-workspace `.yarn/releases` + `builder.Containerfile` (`yarn set version`) + `overlay-repo` pins |
+
+## Script location
+
+Scripts live under this skill’s `scripts/` directory. Resolve that path from the
+installed skill root (or this checkout):
+
+```bash
+SKILL="$(dirname "$(realpath "$0")")/.."   # when already in scripts/
+# or, from repo checkout:
+SKILL="skills/rhdh-bump-yarn"
+```
+
+**Execute** [scripts/bump-yarn.js](scripts/bump-yarn.js); do not reimplement the workflow inline.
+
+## Run the script (preferred)
+
+```bash
+node "$SKILL/scripts/bump-yarn.js" --to 4.17.1 \
+  --root /path/to/rhdh-plugins \
+  --root /path/to/rhdh \
+  --root /path/to/overlays \
+  --root /path/to/rhdh-downstream \
+  --root /path/to/rhdh-plugin-catalog
+```
+
+Defaults:
+- `--from 4.12.0,4.14.1` (versions RHIDP-16074 replaced). Versions **not** in `--from` (e.g. `4.8.1`, `4.9.2`, Yarn 3.x) stay put.
+- **Refresh `yarn.lock`** in every touched workspace that has one (`yarn install --mode=skip-build`). This is slow but matches Renovate lock metadata updates. Opt out with `--no-refresh-locks`.
+
+### Useful modes
+
+```bash
+# Inventory pins / binaries
+node "$SKILL/scripts/bump-yarn.js" --scan --root /path/to/repo
+
+# Preview pins/binaries only (does not run install)
+node "$SKILL/scripts/bump-yarn.js" --to 4.17.1 --root /path/to/repo --dry-run
+
+# Cache the Berry CLI binary only
+node "$SKILL/scripts/bump-yarn.js" --fetch-only --to 4.17.1
+
+# Skip lock refresh (pins + binaries only)
+node "$SKILL/scripts/bump-yarn.js" --to 4.17.1 --root /path/to/repo --no-refresh-locks
+```
+
+Binary cache: `~/.cache/rhdh-bump-yarn/yarn-<ver>.cjs`  
+Source URL: `https://raw.githubusercontent.com/yarnpkg/berry/@yarnpkg/cli/<ver>/packages/yarnpkg-cli/bin/yarn.js`
+
+## What the script changes
+
+1. **Binaries** — for each `.yarn/releases/yarn-<from>.cjs`, write `yarn-<to>.cjs` and remove the old file.
+2. **Text pins** in `package.json`, `.yarnrc.yml`, `Containerfile` / `*.Containerfile`, `Dockerfile`, `run-e2e.sh` (and similar):
+   - `yarnPath: …/yarn-<from>.cjs`
+   - `"packageManager": "yarn@<from>"` (also strips optional `+sha…` suffixes)
+   - `yarn set version <from>`
+   - `ENV YARN=…yarn-<from>.cjs`
+3. **yarn.lock** (default) — in dirs with a lockfile whose `package.json`, `.yarnrc.yml`, or release binary was updated, run `yarn install --mode=skip-build` so `__metadata` / builtin patch hashes update like Renovate.
+4. **Report** — remaining `--from` hits (should be none), binaries left alone, lock refresh results.
+
+## What it does not do
+
+- **Commits / PRs / MRs** — after the bump, commit and open with [`jira-pr-mr-link`](../jira-pr-mr-link/SKILL.md) when the user asks (cite the Jira key they name).
+- **rhdh-cli Yarn 3.x** — out of scope unless `--from` includes those versions.
+
+## Agent workflow
+
+1. Confirm `--to` / `--from` (or use defaults for a 4.12/4.14 → 4.17.1 style bump).
+2. Resolve local `--root` checkouts for the repos in scope (ask if paths unclear; `rhdh` config keys `plugins`, `rhdh`, `overlay`, `downstream`, `catalog` may help).
+3. `--scan` each root; note versions that will be left alone.
+4. Run the bump (prefer `--dry-run` first if the tree is dirty/unfamiliar). Expect lock refresh to take a while unless `--no-refresh-locks`.
+5. Re-scan or trust script “remaining from-versions: none”; note any failed lock refreshes.
+6. Summarize: binaries replaced, files updated, left-alone versions, lock refresh counts/failures.
+7. Only commit / open PR·MRs when the user requests; link Jira via `jira-pr-mr-link`.
+
+## Checklist
+
+- [ ] `--to` matches the reference PR (e.g. 4.17.1).
+- [ ] `--from` covers every version intended to move; others stay put.
+- [ ] All in-scope roots scanned and bumped.
+- [ ] No unexpected remaining `--from` pins.
+- [ ] Lock refresh completed (or `--no-refresh-locks` was intentional); failures investigated.
+- [ ] PR/MR + Jira only after user asks.

--- a/skills/rhdh-bump-yarn/scripts/bump-yarn.js
+++ b/skills/rhdh-bump-yarn/scripts/bump-yarn.js
@@ -7,9 +7,13 @@
     - replace matching .yarn/releases/yarn-<from>.cjs binaries
     - rewrite yarnPath / packageManager / "yarn set version" / ENV YARN= pins
 
-  By default, refreshes yarn.lock via `yarn install --mode=skip-build` in
-  touched workspaces (matches Renovate lock metadata bumps). A full
-  five-repo lock regen can take >45 minutes. Use --no-refresh-locks to skip.
+  By default, refreshes yarn.lock via `yarn install --mode=update-lockfile`
+  for every lock that will run under --to yarn — including nested workspaces
+  that inherit a root yarnPath / packageManager (not only dirs whose pins
+  were rewritten). Skips locks with an explicit pin outside --from/--to
+  (e.g. roadie 4.9.2, backstage 4.8.1, dcm 4.15.0) and dist-dynamic
+  artifacts. New yarn-*.cjs binaries are chmod +x (100755). A full five-repo
+  lock regen can take >45 minutes. Use --no-refresh-locks to skip.
 
   Usage:
     bump-yarn.js --to 4.17.1 [--from 4.12.0,4.14.1] --root PATH [--root PATH ...]
@@ -49,9 +53,9 @@ function usage(exitCode = 0) {
 
 Defaults:
   --from  ${DEFAULT_FROM.join(',')}
-  refresh yarn.lock in touched workspaces (>45 min possible for full set);
-  opt out with --no-refresh-locks
-  Binary cache: ${CACHE_DIR}
+  refresh yarn.lock for all workspaces using --to (incl. inherited root pin);
+  skip explicit older pins and dist-dynamic; opt out with --no-refresh-locks
+  binaries written mode 0755; Binary cache: ${CACHE_DIR}
 
 Examples (RHIDP-16074 five-repo set):
   node skills/rhdh-bump-yarn/scripts/bump-yarn.js --to 4.17.1 \\
@@ -163,18 +167,28 @@ function download(url, dest) {
   });
 }
 
+function makeExecutable(filePath) {
+  try {
+    fs.chmodSync(filePath, 0o755);
+  } catch (err) {
+    console.error(`warn: chmod +x failed for ${filePath}: ${err.message}`);
+  }
+}
+
 function ensureBinary(version, { force = false } = {}) {
   fs.mkdirSync(CACHE_DIR, { recursive: true });
   const dest = path.join(CACHE_DIR, `yarn-${version}.cjs`);
   if (!force && fs.existsSync(dest)) {
     const v = spawnSync(process.execPath, [dest, '-v'], { encoding: 'utf8' });
     if (v.status === 0 && String(v.stdout).trim() === version) {
+      makeExecutable(dest);
       return dest;
     }
   }
   const url = yarnReleaseUrl(version);
   console.log(`fetch: ${url}`);
   return download(url, dest).then(() => {
+    makeExecutable(dest);
     const v = spawnSync(process.execPath, [dest, '-v'], { encoding: 'utf8' });
     if (v.status !== 0 || String(v.stdout).trim() !== version) {
       throw new Error(
@@ -289,6 +303,77 @@ function bumpText(content, fromVersions, toVersion) {
   return next;
 }
 
+function readExplicitYarnPin(dir) {
+  // Only packageManager / yarnPath — avoid matching unrelated yarn@x.y.z deps.
+  const pkgPath = path.join(dir, 'package.json');
+  if (fs.existsSync(pkgPath)) {
+    try {
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+      const pm = pkg.packageManager;
+      if (typeof pm === 'string') {
+        const m = /^yarn@([0-9]+\.[0-9]+\.[0-9]+)/.exec(pm);
+        if (m) return m[1];
+      }
+    } catch {
+      // ignore malformed package.json
+    }
+  }
+  const rcPath = path.join(dir, '.yarnrc.yml');
+  if (fs.existsSync(rcPath)) {
+    try {
+      const text = fs.readFileSync(rcPath, 'utf8');
+      const m = /(?:^|\n)yarnPath:\s*.*yarn-([0-9]+\.[0-9]+\.[0-9]+)\.cjs/.exec(text);
+      if (m) return m[1];
+    } catch {
+      // ignore
+    }
+  }
+  return null;
+}
+
+function shouldSkipLockPath(lockPath) {
+  const parts = lockPath.split(path.sep);
+  if (parts.includes('node_modules')) return true;
+  if (parts.includes('dist-dynamic')) return true;
+  if (parts.includes('.git')) return true;
+  return false;
+}
+
+function collectLockRefreshDirs(root, { from, to }) {
+  const fromSet = new Set(from);
+  const dirs = [];
+  const skipped = [];
+  walk(root, (full, basename) => {
+    if (basename !== 'yarn.lock') return;
+    if (shouldSkipLockPath(full)) return;
+    const dir = path.dirname(full);
+    const pin = readExplicitYarnPin(dir);
+    // Explicit pin outside --from/--to → leave alone (roadie/backstage/dcm, etc.)
+    if (pin && pin !== to && !fromSet.has(pin)) {
+      skipped.push({ dir, pin });
+      return;
+    }
+    dirs.push(dir);
+  });
+  dirs.sort();
+  return { dirs, skipped };
+}
+
+function resolveYarnBin(dir, binaryPath, toVersion) {
+  const newName = `yarn-${toVersion}.cjs`;
+  const local = path.join(dir, '.yarn', 'releases', newName);
+  if (fs.existsSync(local)) return local;
+  let cur = dir;
+  for (let i = 0; i < 8; i += 1) {
+    const candidate = path.join(cur, '.yarn', 'releases', newName);
+    if (fs.existsSync(candidate)) return candidate;
+    const parent = path.dirname(cur);
+    if (parent === cur) break;
+    cur = parent;
+  }
+  return binaryPath;
+}
+
 function bumpRoot(root, { from, to, binaryPath, dryRun, refreshLocks }) {
   const summary = {
     root,
@@ -297,6 +382,7 @@ function bumpRoot(root, { from, to, binaryPath, dryRun, refreshLocks }) {
     skippedReleases: [],
     remaining: [],
     lockRefresh: [],
+    lockRefreshSkipped: [],
   };
 
   const fromSet = new Set(from);
@@ -315,13 +401,11 @@ function bumpRoot(root, { from, to, binaryPath, dryRun, refreshLocks }) {
     summary.binariesReplaced.push({ from: full, to: dest, version: ver });
     if (dryRun) return;
     fs.copyFileSync(binaryPath, dest);
+    makeExecutable(dest);
     if (path.resolve(full) !== path.resolve(dest)) fs.unlinkSync(full);
   });
 
-  // Ensure each releases dir that got a new binary (or still needs one after delete) is ok —
-  // also place binary when yarnPath points at missing to-version under a dir we touched via text.
   // 2) text pins
-  const lockCandidateDirs = new Set();
   walk(root, (full, basename) => {
     if (!isTextCandidate(full, basename)) return;
     let text;
@@ -334,16 +418,8 @@ function bumpRoot(root, { from, to, binaryPath, dryRun, refreshLocks }) {
     const next = bumpText(text, from, to);
     if (next === text) return;
     summary.filesUpdated.push(full);
-    if (basename === 'package.json' || basename === '.yarnrc.yml') {
-      lockCandidateDirs.add(path.dirname(full));
-    }
     if (!dryRun) fs.writeFileSync(full, next);
   });
-
-  for (const b of summary.binariesReplaced) {
-    // …/.yarn/releases/yarn-X.cjs → workspace root
-    lockCandidateDirs.add(path.dirname(path.dirname(path.dirname(b.to))));
-  }
 
   // 3) remaining inventory (from-set only) — skip on dry-run (tree unchanged)
   if (!dryRun) {
@@ -357,33 +433,19 @@ function bumpRoot(root, { from, to, binaryPath, dryRun, refreshLocks }) {
     }
   }
 
-  // 4) lock refresh (default on; --no-refresh-locks to skip)
+  // 4) lock refresh — every yarn.lock that will run under --to (incl. inherited root pin)
   if (refreshLocks && !dryRun) {
-    for (const dir of [...lockCandidateDirs].sort()) {
-      const lock = path.join(dir, 'yarn.lock');
-      if (!fs.existsSync(lock)) continue;
-      // Prefer local yarnPath binary if present
-      let yarnBin = binaryPath;
-      const local = path.join(dir, '.yarn', 'releases', newName);
-      if (fs.existsSync(local)) yarnBin = local;
-      else {
-        // walk up a few levels for a releases binary
-        let cur = dir;
-        for (let i = 0; i < 6; i += 1) {
-          const candidate = path.join(cur, '.yarn', 'releases', newName);
-          if (fs.existsSync(candidate)) {
-            yarnBin = candidate;
-            break;
-          }
-          const parent = path.dirname(cur);
-          if (parent === cur) break;
-          cur = parent;
-        }
-      }
+    const { dirs, skipped } = collectLockRefreshDirs(root, { from, to });
+    summary.lockRefreshSkipped = skipped;
+    for (const s of skipped) {
+      console.log(`refresh-locks: skip ${s.dir} (explicit pin ${s.pin})`);
+    }
+    for (const dir of dirs) {
+      const yarnBin = resolveYarnBin(dir, binaryPath, to);
       console.log(`refresh-locks: ${dir}`);
       const r = spawnSync(
         process.execPath,
-        [yarnBin, 'install', '--mode=skip-build'],
+        [yarnBin, 'install', '--mode=update-lockfile'],
         {
           cwd: dir,
           encoding: 'utf8',
@@ -391,6 +453,22 @@ function bumpRoot(root, { from, to, binaryPath, dryRun, refreshLocks }) {
           stdio: ['ignore', 'pipe', 'pipe'],
         },
       );
+      // Drop untracked .yarnrc.yml yarn may invent during "migration"
+      const rcPath = path.join(dir, '.yarnrc.yml');
+      if (fs.existsSync(rcPath)) {
+        const tracked = spawnSync('git', ['ls-files', '--error-unmatch', rcPath], {
+          cwd: root,
+          encoding: 'utf8',
+        });
+        if (tracked.status !== 0) {
+          try {
+            fs.unlinkSync(rcPath);
+            console.log(`refresh-locks: removed untracked ${rcPath}`);
+          } catch {
+            // ignore
+          }
+        }
+      }
       summary.lockRefresh.push({
         dir,
         status: r.status,
@@ -508,6 +586,15 @@ async function main() {
       const bad = summary.lockRefresh.filter((x) => x.status !== 0);
       console.log(`lock refresh: ${summary.lockRefresh.length} dirs (${bad.length} failed)`);
       if (bad.length) failed = true;
+    }
+    if (summary.lockRefreshSkipped?.length) {
+      console.log(`lock refresh skipped (explicit older pin): ${summary.lockRefreshSkipped.length}`);
+      for (const s of summary.lockRefreshSkipped.slice(0, 20)) {
+        console.log(`  ${s.pin}: ${path.relative(root, s.dir)}`);
+      }
+      if (summary.lockRefreshSkipped.length > 20) {
+        console.log(`  … +${summary.lockRefreshSkipped.length - 20} more`);
+      }
     }
   }
 

--- a/skills/rhdh-bump-yarn/scripts/bump-yarn.js
+++ b/skills/rhdh-bump-yarn/scripts/bump-yarn.js
@@ -8,7 +8,8 @@
  *   rewrite extras Yarn cannot see (ENV YARN= / Containerfile / embedded set version)
  *
  * No binary download. Bump GitHub workspaces first; copy yarn-<to>.cjs into
- * GitLab/distgit trees that only pin via ENV YARN= / checked-in releases.
+ * gitlab.cee.redhat.com midstream/distgit trees (rhidp/rhdh,
+ * rhidp/rhdh-plugin-catalog) that only pin via ENV YARN= / checked-in releases.
  *
  *   bump-yarn.js --to 4.17.1 --root PATH... [--from V1,V2] [--dry-run] [--no-refresh-locks]
  *   bump-yarn.js --scan --root PATH

--- a/skills/rhdh-bump-yarn/scripts/bump-yarn.js
+++ b/skills/rhdh-bump-yarn/scripts/bump-yarn.js
@@ -12,8 +12,10 @@
   that inherit a root yarnPath / packageManager (not only dirs whose pins
   were rewritten). Skips locks with an explicit pin outside --from/--to
   (e.g. roadie 4.9.2, backstage 4.8.1, dcm 4.15.0) and dist-dynamic
-  artifacts. New yarn-*.cjs binaries are chmod +x (100755). A full five-repo
-  lock regen can take >45 minutes. Use --no-refresh-locks to skip.
+  artifacts. New yarn-*.cjs binaries are chmod +x (100755). Also scans
+  .fullsend/<profile>/bin/yarn (rhdh-plugins Fullsend helper): rewrites leftover
+  yarn-<from>.cjs hardcodes and warns to prefer yarnPath derivation.
+  A full five-repo lock regen can take >45 minutes. Use --no-refresh-locks to skip.
 
   Usage:
     bump-yarn.js --to 4.17.1 [--from 4.12.0,4.14.1] --root PATH [--root PATH ...]
@@ -240,12 +242,20 @@ function walk(root, onFile) {
   }
 }
 
+function isFullsendYarnHelper(full, basename) {
+  // Extensionless helper: .fullsend/<profile>/bin/yarn (rhdh-plugins Fullsend)
+  if (basename !== 'yarn') return false;
+  const norm = full.split(path.sep).join('/');
+  return norm.includes('/.fullsend/') && norm.endsWith('/bin/yarn');
+}
+
 function isTextCandidate(full, basename) {
   if (TEXT_BASENAMES.has(basename)) return true;
   if (basename.endsWith('.Containerfile')) return true;
   if (basename.endsWith('.Dockerfile')) return true;
   // Embedded packageManager JSON snippets sometimes live in shell helpers
   if (basename.endsWith('.sh') && /e2e|yarn|packageManager/i.test(basename + full)) return true;
+  if (isFullsendYarnHelper(full, basename)) return true;
   return false;
 }
 
@@ -405,7 +415,7 @@ function bumpRoot(root, { from, to, binaryPath, dryRun, refreshLocks }) {
     if (path.resolve(full) !== path.resolve(dest)) fs.unlinkSync(full);
   });
 
-  // 2) text pins
+  // 2) text pins (incl. .fullsend/**/bin/yarn hardcodes)
   walk(root, (full, basename) => {
     if (!isTextCandidate(full, basename)) return;
     let text;
@@ -418,6 +428,13 @@ function bumpRoot(root, { from, to, binaryPath, dryRun, refreshLocks }) {
     const next = bumpText(text, from, to);
     if (next === text) return;
     summary.filesUpdated.push(full);
+    if (isFullsendYarnHelper(full, basename) && /yarn-[0-9]+\.[0-9]+\.[0-9]+\.cjs/.test(next)) {
+      console.warn(
+        `warn: ${full} still hardcodes a yarn-*.cjs path after bump; ` +
+          'prefer deriving yarnPath from ${FULLSEND_TARGET_REPO_DIR}/.yarnrc.yml ' +
+          '(see rhdh-plugins#4199)',
+      );
+    }
     if (!dryRun) fs.writeFileSync(full, next);
   });
 

--- a/skills/rhdh-bump-yarn/scripts/bump-yarn.js
+++ b/skills/rhdh-bump-yarn/scripts/bump-yarn.js
@@ -8,8 +8,8 @@
     - rewrite yarnPath / packageManager / "yarn set version" / ENV YARN= pins
 
   By default, refreshes yarn.lock via `yarn install --mode=skip-build` in
-  touched workspaces (slow; matches Renovate lock metadata bumps).
-  Use --no-refresh-locks to skip.
+  touched workspaces (matches Renovate lock metadata bumps). A full
+  five-repo lock regen can take >45 minutes. Use --no-refresh-locks to skip.
 
   Usage:
     bump-yarn.js --to 4.17.1 [--from 4.12.0,4.14.1] --root PATH [--root PATH ...]
@@ -49,7 +49,8 @@ function usage(exitCode = 0) {
 
 Defaults:
   --from  ${DEFAULT_FROM.join(',')}
-  refresh yarn.lock in touched workspaces (slow); opt out with --no-refresh-locks
+  refresh yarn.lock in touched workspaces (>45 min possible for full set);
+  opt out with --no-refresh-locks
   Binary cache: ${CACHE_DIR}
 
 Examples (RHIDP-16074 five-repo set):

--- a/skills/rhdh-bump-yarn/scripts/bump-yarn.js
+++ b/skills/rhdh-bump-yarn/scripts/bump-yarn.js
@@ -1,116 +1,100 @@
 #!/usr/bin/env node
-/*
-  RHDH Yarn bump orchestrator.
-
-  Workspaces: `yarn set version <to>` (+ lock refresh). That owns packageManager,
-  yarnPath, and .yarn/releases — do not reimplement those.
-
-  Extras Yarn cannot see: Containerfile / Dockerfile / ENV YARN / embedded
-  `yarn set version`, orphan release binaries (distgit), Fullsend helpers,
-  and yarn.lock under workspaces that only inherit a root pin.
-*/
-
+/**
+ * Bump Yarn across RHDH checkouts.
+ *
+ *   yarn set version <to>  → packageManager + yarnPath + binary
+ *   chmod +x
+ *   yarn install --mode=update-lockfile
+ *   rewrite extras Yarn cannot see (ENV YARN= / Containerfile / embedded set version)
+ *
+ * No binary download. Bump GitHub workspaces first; copy yarn-<to>.cjs into
+ * GitLab/distgit trees that only pin via ENV YARN= / checked-in releases.
+ *
+ *   bump-yarn.js --to 4.17.1 --root PATH... [--from V1,V2] [--dry-run] [--no-refresh-locks]
+ *   bump-yarn.js --scan --root PATH
+ */
 'use strict';
 
 const fs = require('node:fs');
 const path = require('node:path');
-const https = require('node:https');
-const http = require('node:http');
-const os = require('node:os');
 const { spawnSync } = require('node:child_process');
 
 const DEFAULT_FROM = ['4.12.0', '4.14.1'];
-const CACHE_DIR = path.join(os.homedir(), '.cache', 'rhdh-bump-yarn');
+const SKIP = new Set(['.git', 'node_modules', '.yarn', 'dist', 'coverage', '.turbo']);
+const YARN_BIN_RE = /^yarn-(\d{1,6}\.\d{1,6}\.\d{1,6})\.cjs$/;
+const YARN_PM_RE = /^yarn@(\d{1,6}\.\d{1,6}\.\d{1,6})/;
+const YARN_PATH_RE = /(?:^|\n)yarnPath:[^\n]*yarn-(\d{1,6}\.\d{1,6}\.\d{1,6})\.cjs/;
 
-function usage(code = 0) {
-  console.log(`Usage:
-  bump-yarn.js --to VERSION [--from V1,V2] --root PATH [--root PATH ...]
-  bump-yarn.js --scan --root PATH
-  bump-yarn.js --to VERSION --root PATH [--dry-run] [--no-refresh-locks]
-
-Defaults: --from ${DEFAULT_FROM.join(',')}
-Strategy: yarn set version <to> for matching packageManager dirs; rewrite
-Containerfile/Fullsend/orphan binaries; refresh inherited yarn.lock dirs.
-`);
-  process.exit(code);
+function cmpStr(a, b) {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
 }
 
 function parseArgs(argv) {
-  const args = {
-    from: [...DEFAULT_FROM],
-    roots: [],
-    to: null,
-    scan: false,
-    dryRun: false,
-    refreshLocks: true,
-  };
+  const a = { from: [...DEFAULT_FROM], roots: [], to: null, scan: false, dryRun: false, locks: true };
   for (let i = 0; i < argv.length; i += 1) {
-    const a = argv[i];
-    if (a === '-h' || a === '--help') usage(0);
-    else if (a === '--scan') args.scan = true;
-    else if (a === '--dry-run') args.dryRun = true;
-    else if (a === '--no-refresh-locks') args.refreshLocks = false;
-    else if (a === '--refresh-locks') args.refreshLocks = true;
-    else if (a === '--to') args.to = argv[++i];
-    else if (a === '--from') {
-      args.from = String(argv[++i] || '')
-        .split(',')
-        .map((s) => s.trim())
-        .filter(Boolean);
-    } else if (a === '--root') args.roots.push(path.resolve(argv[++i]));
+    const x = argv[i];
+    if (x === '-h' || x === '--help') {
+      console.log(`bump-yarn.js --to VER [--from ${DEFAULT_FROM}] --root PATH... [--scan|--dry-run|--no-refresh-locks]`);
+      process.exit(0);
+    }
+    if (x === '--scan') a.scan = true;
+    else if (x === '--dry-run') a.dryRun = true;
+    else if (x === '--no-refresh-locks') a.locks = false;
+    else if (x === '--to') a.to = argv[++i];
+    else if (x === '--from') a.from = String(argv[++i]).split(',').map((s) => s.trim()).filter(Boolean);
+    else if (x === '--root') a.roots.push(path.resolve(argv[++i]));
     else {
-      console.error(`Unknown arg: ${a}`);
-      usage(1);
+      console.error(`Unknown: ${x}`);
+      process.exit(1);
     }
   }
-  return args;
+  return a;
 }
 
-function esc(s) {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+function pushWalkDir(stack, full, name) {
+  if (!SKIP.has(name)) {
+    stack.push(full);
+    return;
+  }
+  if (name === '.yarn') {
+    const releases = path.join(full, 'releases');
+    if (fs.existsSync(releases)) stack.push(releases);
+  }
 }
 
-function skipDir(name) {
-  return (
-    name === '.git' ||
-    name === 'node_modules' ||
-    name === '.yarn' ||
-    name === 'dist' ||
-    name === 'coverage' ||
-    name === '.turbo'
-  );
+function walkEntry(stack, dir, e, fn) {
+  const full = path.join(dir, e.name);
+  if (e.isDirectory()) {
+    pushWalkDir(stack, full, e.name);
+    return;
+  }
+  if (e.isFile()) fn(full, e.name, dir);
 }
 
-function walk(root, onFile) {
+function walk(root, fn) {
   const stack = [root];
   while (stack.length) {
     const dir = stack.pop();
-    let entries;
+    let ents;
     try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
+      ents = fs.readdirSync(dir, { withFileTypes: true });
     } catch {
       continue;
     }
-    for (const ent of entries) {
-      const full = path.join(dir, ent.name);
-      if (ent.isDirectory()) {
-        if (skipDir(ent.name)) {
-          if (ent.name === '.yarn') {
-            const releases = path.join(full, 'releases');
-            if (fs.existsSync(releases)) stack.push(releases);
-          }
-          continue;
-        }
-        stack.push(full);
-      } else if (ent.isFile()) onFile(full, ent.name);
-    }
+    for (const e of ents) walkEntry(stack, dir, e, fn);
   }
+}
+
+function esc(s) {
+  return s.replaceAll(/[.*+?^${}()|[\]\\]/g, (ch) => `\\${ch}`);
 }
 
 function readPm(dir) {
   try {
-    const pm = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8')).packageManager;
-    const m = typeof pm === 'string' && /^yarn@([0-9]+\.[0-9]+\.[0-9]+)/.exec(pm);
+    const pm = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8')).packageManager || '';
+    const m = YARN_PM_RE.exec(pm);
     return m ? m[1] : null;
   } catch {
     return null;
@@ -119,443 +103,222 @@ function readPm(dir) {
 
 function readYarnPath(dir) {
   try {
-    const text = fs.readFileSync(path.join(dir, '.yarnrc.yml'), 'utf8');
-    const m = /(?:^|\n)yarnPath:\s*.*yarn-([0-9]+\.[0-9]+\.[0-9]+)\.cjs/.exec(text);
+    const m = YARN_PATH_RE.exec(fs.readFileSync(path.join(dir, '.yarnrc.yml'), 'utf8'));
     return m ? m[1] : null;
   } catch {
     return null;
   }
 }
 
-function explicitPin(dir) {
-  return readPm(dir) || readYarnPath(dir);
-}
-
-function isFullsend(full, basename) {
-  return (
-    basename === 'yarn' &&
-    full.split(path.sep).join('/').includes('/.fullsend/') &&
-    full.endsWith(`${path.sep}bin${path.sep}yarn`)
-  );
-}
-
-function isExtraText(full, basename) {
-  if (basename === 'package.json' || basename === '.yarnrc.yml') return false;
-  if (basename === 'Containerfile' || basename === 'Dockerfile' || basename === 'run-e2e.sh') {
-    return true;
-  }
-  if (basename.endsWith('.Containerfile') || basename.endsWith('.Dockerfile')) return true;
-  if (basename.endsWith('.sh') && /e2e|yarn|packageManager/i.test(basename + full)) return true;
-  return isFullsend(full, basename);
-}
-
-function localYarnBin(dir) {
-  const releases = path.join(dir, '.yarn', 'releases');
+function localBin(dir) {
   try {
-    const bins = fs
-      .readdirSync(releases)
-      .filter((n) => /^yarn-[0-9]+\.[0-9]+\.[0-9]+\.cjs$/.test(n))
-      .sort();
-    return bins.length ? path.join(releases, bins[bins.length - 1]) : null;
+    const rel = path.join(dir, '.yarn', 'releases');
+    const bins = fs.readdirSync(rel).filter((n) => YARN_BIN_RE.test(n)).toSorted(cmpStr);
+    return bins.length ? path.join(rel, bins.at(-1)) : null;
   } catch {
     return null;
   }
 }
 
+/** Yarn CLI must be executable for yarnPath / node yarn-*.cjs. */
 function chmodX(p) {
   try {
-    fs.chmodSync(p, 0o755);
-  } catch (err) {
-    console.error(`warn: chmod +x failed for ${p}: ${err.message}`);
+    fs.chmodSync(p, 0o755); // NOSONAR — intentional +x for Berry CLI binary
+  } catch {
+    /* ignore */
   }
 }
 
-function download(url, dest) {
-  return new Promise((resolve, reject) => {
-    const client = url.startsWith('https:') ? https : http;
-    client
-      .get(url, { headers: { 'User-Agent': 'rhdh-bump-yarn' } }, (res) => {
-        if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-          res.resume();
-          download(res.headers.location, dest).then(resolve, reject);
-          return;
-        }
-        if (res.statusCode !== 200) {
-          reject(new Error(`GET ${url} → ${res.statusCode}`));
-          res.resume();
-          return;
-        }
-        const tmp = `${dest}.partial`;
-        const out = fs.createWriteStream(tmp);
-        res.pipe(out);
-        out.on('finish', () => out.close(() => {
-          fs.renameSync(tmp, dest);
-          resolve(dest);
-        }));
-        out.on('error', reject);
-      })
-      .on('error', reject);
+function sh(cmd, args, cwd) {
+  return spawnSync(cmd, args, {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, YARN_ENABLE_IMMUTABLE_INSTALLS: 'false' },
+    stdio: ['ignore', 'pipe', 'pipe'],
   });
 }
 
-/** Only for orphan distgit binaries when no workspace produced yarn-<to>.cjs. */
-async function cachedBinary(version) {
-  fs.mkdirSync(CACHE_DIR, { recursive: true });
-  const dest = path.join(CACHE_DIR, `yarn-${version}.cjs`);
-  const ok = () => {
-    const v = spawnSync(process.execPath, [dest, '-v'], { encoding: 'utf8' });
-    return v.status === 0 && String(v.stdout).trim() === version;
-  };
-  if (fs.existsSync(dest) && ok()) {
-    chmodX(dest);
-    return dest;
+function setVersion(dir, to, dryRun) {
+  if (dryRun) {
+    console.log(`dry-run: set version ${to} @ ${dir}`);
+    return;
   }
-  const tag = encodeURIComponent(`@yarnpkg/cli/${version}`);
-  const url = `https://raw.githubusercontent.com/yarnpkg/berry/${tag}/packages/yarnpkg-cli/bin/yarn.js`;
-  console.log(`fetch (orphan fallback): ${url}`);
-  await download(url, dest);
-  chmodX(dest);
-  if (!ok()) throw new Error(`cached yarn binary mismatch for ${version}`);
-  return dest;
+  console.log(`yarn set version: ${dir}`);
+  const bin = localBin(dir);
+  const r = bin
+    ? sh(process.execPath, [bin, 'set', 'version', to], dir)
+    : sh('yarn', ['set', 'version', to], dir);
+  if (r.status) console.error(`warn: set version failed @ ${dir}`);
+  const out = path.join(dir, '.yarn', 'releases', `yarn-${to}.cjs`);
+  if (fs.existsSync(out)) chmodX(out);
 }
 
-function findToBin(root, to) {
-  let found = null;
-  walk(root, (full, basename) => {
-    if (!found && basename === `yarn-${to}.cjs` && full.includes(`${path.sep}.yarn${path.sep}releases${path.sep}`)) {
-      found = full;
-    }
-  });
-  return found;
+function isExtra(full, base) {
+  if (base === 'package.json' || base === '.yarnrc.yml') return false;
+  if (base === 'Containerfile' || base === 'Dockerfile' || base === 'run-e2e.sh') return true;
+  if (base.endsWith('.Containerfile') || base.endsWith('.Dockerfile')) return true;
+  if (base === 'yarn' && full.includes(`${path.sep}.fullsend${path.sep}`) && full.endsWith(`${path.sep}bin${path.sep}yarn`)) {
+    return true;
+  }
+  return base.endsWith('.sh') && /e2e|yarn/i.test(full);
 }
 
-function bumpExtraText(content, fromVersions, to) {
-  const alt = fromVersions.map(esc).join('|');
-  return content
-    .replace(new RegExp(`yarn-(?:${alt})\\.cjs`, 'g'), `yarn-${to}.cjs`)
-    .replace(new RegExp(`yarn set version (?:${alt})\\b`, 'g'), `yarn set version ${to}`)
-    .replace(
-      new RegExp(`"packageManager":\\s*"yarn@(?:${alt})(?:\\+[^"]+)?"`, 'g'),
-      `"packageManager": "yarn@${to}"`,
-    );
+function rewriteExtras(text, from, to) {
+  const alt = from.map(esc).join('|');
+  return text
+    .replace(new RegExp(String.raw`yarn-(?:${alt})\.cjs`, 'g'), `yarn-${to}.cjs`)
+    .replace(new RegExp(String.raw`yarn set version (?:${alt})\b`, 'g'), `yarn set version ${to}`);
 }
 
-function skipLock(p) {
-  const parts = p.split(path.sep);
-  return parts.includes('node_modules') || parts.includes('dist-dynamic') || parts.includes('.git');
-}
-
-function lockDirs(root, { from, to }) {
-  const fromSet = new Set(from);
-  const dirs = [];
-  const skipped = [];
-  walk(root, (full, basename) => {
-    if (basename !== 'yarn.lock' || skipLock(full)) return;
-    const dir = path.dirname(full);
-    const pin = explicitPin(dir);
-    if (pin && pin !== to && !fromSet.has(pin)) skipped.push({ dir, pin });
-    else dirs.push(dir);
-  });
-  return { dirs: dirs.sort(), skipped };
-}
-
-function resolveBin(dir, fallback, to) {
-  let cur = dir;
-  for (let i = 0; i < 8; i += 1) {
+function resolveToBin(dir, to) {
+  for (let cur = dir, i = 0; i < 8; i += 1) {
     const c = path.join(cur, '.yarn', 'releases', `yarn-${to}.cjs`);
     if (fs.existsSync(c)) return c;
     const parent = path.dirname(cur);
     if (parent === cur) break;
     cur = parent;
   }
-  return fallback;
+  return null;
 }
 
-function runSetVersion(dir, to, dryRun) {
-  const local = localYarnBin(dir);
-  if (dryRun) {
-    console.log(
-      `dry-run: ${dir}: ${local ? `node ${path.relative(dir, local)}` : 'yarn'} set version ${to}`,
-    );
-    return { status: 0 };
-  }
-  console.log(`yarn set version: ${dir}`);
-  const r = local
-    ? spawnSync(process.execPath, [local, 'set', 'version', to], {
-      cwd: dir,
-      encoding: 'utf8',
-      env: { ...process.env, YARN_ENABLE_IMMUTABLE_INSTALLS: 'false' },
-      stdio: ['ignore', 'pipe', 'pipe'],
-    })
-    : spawnSync('yarn', ['set', 'version', to], {
-      cwd: dir,
-      encoding: 'utf8',
-      env: { ...process.env, YARN_ENABLE_IMMUTABLE_INSTALLS: 'false' },
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-  if (r.status !== 0) {
-    console.error(
-      `warn: yarn set version failed in ${dir} (exit ${r.status})\n` +
-        (r.stderr || r.stdout || '').trim().split('\n').slice(-8).join('\n'),
-    );
-  }
-  const bin = path.join(dir, '.yarn', 'releases', `yarn-${to}.cjs`);
-  if (fs.existsSync(bin)) chmodX(bin);
-  return r;
+function bumpCount(map, key) {
+  map.set(key, (map.get(key) || 0) + 1);
 }
 
-function scanRoot(root) {
-  const releases = [];
-  const packageManagers = [];
-  const extraPins = [];
-  walk(root, (full, basename) => {
-    const m = /^yarn-([0-9]+\.[0-9]+\.[0-9]+)\.cjs$/.exec(basename);
-    if (m && full.includes(`${path.sep}.yarn${path.sep}releases${path.sep}`)) {
-      releases.push({ path: full, version: m[1] });
+function fmtCounts(map) {
+  return [...map.entries()].toSorted(([a], [b]) => cmpStr(a, b)).map(([v, n]) => `${v}×${n}`).join(', ') || '(none)';
+}
+
+function scan(root) {
+  const releases = new Map();
+  const pms = new Map();
+  walk(root, (_full, base, dir) => {
+    const m = YARN_BIN_RE.exec(base);
+    if (m) {
+      bumpCount(releases, m[1]);
       return;
     }
-    if (basename === 'package.json') {
-      const ver = readPm(path.dirname(full));
-      if (ver) packageManagers.push({ path: full, version: ver });
-      return;
-    }
-    if (!isExtraText(full, basename)) return;
-    let text;
-    try {
-      text = fs.readFileSync(full, 'utf8');
-    } catch {
-      return;
-    }
-    if (text.length > 2_000_000) return;
-    const found = new Set();
-    for (const re of [/yarn-([0-9]+\.[0-9]+\.[0-9]+)\.cjs/g, /yarn set version ([0-9]+\.[0-9]+\.[0-9]+)/g]) {
-      let match;
-      while ((match = re.exec(text))) found.add(match[1]);
-    }
-    if (found.size) extraPins.push({ path: full, versions: [...found].sort() });
+    if (base !== 'package.json') return;
+    const v = readPm(dir);
+    if (v) bumpCount(pms, v);
   });
-  return { releases, packageManagers, extraPins };
+  console.log(`\n=== scan ${root} ===\nreleases: ${fmtCounts(releases)}\npackageManager: ${fmtCounts(pms)}`);
 }
 
-function printScan(root) {
-  const { releases, packageManagers, extraPins } = scanRoot(root);
-  const count = (items, key) => {
-    const m = new Map();
-    for (const it of items) {
-      const vs = key ? it[key] : it.versions;
-      for (const v of Array.isArray(vs) ? vs : [vs]) m.set(v, (m.get(v) || 0) + 1);
-    }
-    return m;
-  };
-  console.log(`\n=== scan ${root} ===`);
-  console.log('releases:');
-  for (const [v, n] of [...count(releases, 'version')].sort()) console.log(`  yarn-${v}.cjs × ${n}`);
-  if (!releases.length) console.log('  (none)');
-  console.log('packageManager (yarn set version targets):');
-  for (const [v, n] of [...count(packageManagers, 'version')].sort()) console.log(`  yarn@${v} × ${n}`);
-  if (!packageManagers.length) console.log('  (none)');
-  console.log('extra pins (Containerfile / Fullsend / scripts):');
-  for (const [v, n] of [...count(extraPins)].sort()) console.log(`  ${v} × ${n} files`);
-  if (!extraPins.length) console.log('  (none)');
-}
-
-async function bumpRoot(root, { from, to, dryRun, refreshLocks }) {
-  const fromSet = new Set(from);
-  const summary = {
-    setVersionDirs: [],
-    setVersionFailed: [],
-    orphanBinaries: [],
-    extraFiles: [],
-    lockRefresh: [],
-    lockRefreshSkipped: [],
-    remaining: [],
-  };
-
+function collectPmDirs(root, fromSet) {
   const pmDirs = [];
-  walk(root, (full, basename) => {
-    if (basename !== 'package.json') return;
-    const dir = path.dirname(full);
-    const ver = readPm(dir);
-    if (ver && fromSet.has(ver)) pmDirs.push(dir);
+  walk(root, (_f, base, dir) => {
+    if (base === 'package.json' && fromSet.has(readPm(dir))) pmDirs.push(dir);
   });
-  pmDirs.sort();
+  return pmDirs.toSorted(cmpStr);
+}
 
-  const covered = new Set(pmDirs.map((d) => path.resolve(d)));
-  const orphans = [];
-  walk(root, (full, basename) => {
-    const m = /^yarn-([0-9]+\.[0-9]+\.[0-9]+)\.cjs$/.exec(basename);
-    if (!m || !fromSet.has(m[1])) return;
-    if (!full.includes(`${path.sep}.yarn${path.sep}releases${path.sep}`)) return;
-    const projectDir = path.dirname(path.dirname(path.dirname(full)));
-    if (!covered.has(path.resolve(projectDir))) {
-      orphans.push({ path: full, dir: projectDir });
-    }
-  });
-
-  for (const dir of pmDirs) {
-    summary.setVersionDirs.push(dir);
-    const r = runSetVersion(dir, to, dryRun);
-    if (!dryRun && r.status !== 0) summary.setVersionFailed.push(dir);
-  }
-
-  let fallback = null;
-  if (orphans.length) {
-    if (!dryRun) fallback = findToBin(root, to) || (await cachedBinary(to));
-    for (const o of orphans) {
-      const dest = path.join(path.dirname(o.path), `yarn-${to}.cjs`);
-      summary.orphanBinaries.push({ from: o.path, to: dest });
-      if (dryRun) {
-        console.log(`dry-run: orphan binary ${o.path} → ${dest}`);
-        continue;
-      }
-      fs.copyFileSync(fallback, dest);
-      chmodX(dest);
-      if (path.resolve(o.path) !== path.resolve(dest)) fs.unlinkSync(o.path);
-    }
-  }
-
-  walk(root, (full, basename) => {
-    if (!isExtraText(full, basename)) return;
+function applyExtras(root, from, to, dryRun) {
+  const extras = [];
+  walk(root, (full, base) => {
+    if (!isExtra(full, base)) return;
     let text;
     try {
       text = fs.readFileSync(full, 'utf8');
     } catch {
       return;
     }
-    if (text.length > 2_000_000) return;
-    const next = bumpExtraText(text, from, to);
+    if (text.length > 2e6) return;
+    const next = rewriteExtras(text, from, to);
     if (next === text) return;
-    summary.extraFiles.push(full);
-    if (isFullsend(full, basename) && /yarn-[0-9]+\.[0-9]+\.[0-9]+\.cjs/.test(next)) {
-      console.warn(
-        `warn: ${full} still hardcodes yarn-*.cjs; prefer yarnPath derivation (rhdh-plugins#4199)`,
-      );
-    }
-    if (dryRun) console.log(`dry-run: extra pin ${path.relative(root, full)}`);
+    const rel = path.relative(root, full);
+    extras.push(rel);
+    if (dryRun) console.log(`dry-run: extra ${rel}`);
     else fs.writeFileSync(full, next);
   });
-
-  if (!dryRun) {
-    const after = scanRoot(root);
-    for (const r of after.releases) {
-      if (fromSet.has(r.version)) summary.remaining.push(`release ${r.version}: ${r.path}`);
-    }
-    for (const p of after.packageManagers) {
-      if (fromSet.has(p.version)) summary.remaining.push(`packageManager ${p.version}: ${p.path}`);
-    }
-    for (const p of after.extraPins) {
-      const left = p.versions.filter((v) => fromSet.has(v));
-      if (left.length) summary.remaining.push(`${left.join(',')}: ${p.path}`);
-    }
-  }
-
-  if (refreshLocks && !dryRun) {
-    if (!fallback) fallback = findToBin(root, to) || (await cachedBinary(to));
-    const { dirs, skipped } = lockDirs(root, { from, to });
-    summary.lockRefreshSkipped = skipped;
-    for (const s of skipped) console.log(`refresh-locks: skip ${s.dir} (explicit pin ${s.pin})`);
-    for (const dir of dirs) {
-      const yarnBin = resolveBin(dir, fallback, to);
-      console.log(`refresh-locks: ${dir}`);
-      const r = spawnSync(process.execPath, [yarnBin, 'install', '--mode=update-lockfile'], {
-        cwd: dir,
-        encoding: 'utf8',
-        env: { ...process.env, YARN_ENABLE_IMMUTABLE_INSTALLS: 'false' },
-        stdio: ['ignore', 'pipe', 'pipe'],
-      });
-      const rcPath = path.join(dir, '.yarnrc.yml');
-      if (fs.existsSync(rcPath)) {
-        const tracked = spawnSync('git', ['ls-files', '--error-unmatch', rcPath], {
-          cwd: root,
-          encoding: 'utf8',
-        });
-        if (tracked.status !== 0) {
-          try {
-            fs.unlinkSync(rcPath);
-            console.log(`refresh-locks: removed untracked ${rcPath}`);
-          } catch {
-            // ignore
-          }
-        }
-      }
-      summary.lockRefresh.push({ dir, status: r.status });
-      if (r.status !== 0) console.error(`warn: yarn install failed in ${dir} (exit ${r.status})`);
-    }
-  }
-
-  return summary;
+  return extras;
 }
 
-async function main() {
+function shouldSkipLock(full) {
+  return full.split(path.sep).some((p) => p === 'node_modules' || p === 'dist-dynamic');
+}
+
+function dropUntrackedYarnrc(dir, root) {
+  const rc = path.join(dir, '.yarnrc.yml');
+  if (!fs.existsSync(rc)) return;
+  if (sh('git', ['ls-files', '--error-unmatch', rc], root).status === 0) return;
+  try {
+    fs.unlinkSync(rc);
+  } catch {
+    /* ignore */
+  }
+}
+
+function refreshOneLock(dir, to, root) {
+  const bin = resolveToBin(dir, to);
+  if (!bin) {
+    console.error(
+      `warn: no yarn-${to}.cjs for ${dir} (bump a GH workspace first, or copy the binary into .yarn/releases/)`,
+    );
+    return 'fail';
+  }
+  console.log(`locks: ${dir}`);
+  const failed = Boolean(sh(process.execPath, [bin, 'install', '--mode=update-lockfile'], dir).status);
+  if (failed) console.error(`warn: install failed @ ${dir}`);
+  dropUntrackedYarnrc(dir, root);
+  return failed ? 'fail' : 'ok';
+}
+
+function refreshLocks(root, { fromSet, to }) {
+  const stats = { ok: 0, skip: 0, fail: 0 };
+  const dirs = [];
+  walk(root, (full, base, dir) => {
+    if (base !== 'yarn.lock' || shouldSkipLock(full)) return;
+    const pin = readPm(dir) || readYarnPath(dir);
+    if (pin && pin !== to && !fromSet.has(pin)) {
+      stats.skip += 1;
+      console.log(`locks: skip ${dir} (${pin})`);
+      return;
+    }
+    dirs.push(dir);
+  });
+  for (const dir of dirs.toSorted(cmpStr)) {
+    stats[refreshOneLock(dir, to, root)] += 1;
+  }
+  return stats;
+}
+
+function bump(root, { from, to, dryRun, locks }) {
+  const fromSet = new Set(from);
+  const pmDirs = collectPmDirs(root, fromSet);
+  for (const d of pmDirs) setVersion(d, to, dryRun);
+
+  const extras = applyExtras(root, from, to, dryRun);
+  const lockStats = locks && !dryRun ? refreshLocks(root, { fromSet, to }) : null;
+
+  let summary = `\n=== ${root} ===\nset-version: ${pmDirs.length}  extras: ${extras.length}`;
+  if (extras.length) summary += `\n  ${extras.join('\n  ')}`;
+  if (lockStats) summary += `\nlocks ok/skip/fail: ${lockStats.ok}/${lockStats.skip}/${lockStats.fail}`;
+  console.log(summary);
+}
+
+function main() {
   const args = parseArgs(process.argv.slice(2));
   if (!args.roots.length) {
-    console.error('Provide at least one --root PATH');
-    usage(1);
+    console.error('Need --root PATH');
+    process.exit(1);
   }
-  for (const root of args.roots) {
-    if (!fs.existsSync(root)) {
-      console.error(`Missing root: ${root}`);
+  for (const r of args.roots) {
+    if (!fs.existsSync(r)) {
+      console.error(`Missing: ${r}`);
       process.exit(1);
     }
   }
   if (args.scan) {
-    for (const root of args.roots) printScan(root);
+    for (const r of args.roots) scan(r);
     return;
   }
   if (!args.to) {
-    console.error('--to VERSION is required (unless --scan)');
-    usage(1);
+    console.error('--to VERSION required (exact, not stable)');
+    process.exit(1);
   }
-  if (!args.from.length) {
-    console.error('--from must list at least one version');
-    usage(1);
-  }
-
-  console.log(`to: ${args.to}`);
-  console.log(`from: ${args.from.join(', ')}`);
-  console.log(`dry-run: ${args.dryRun}`);
-  console.log(`refresh-locks: ${args.refreshLocks}`);
-  console.log('strategy: yarn set version + extra pin rewrite');
-
-  let failed = false;
-  for (const root of args.roots) {
-    const s = await bumpRoot(root, {
-      from: args.from,
-      to: args.to,
-      dryRun: args.dryRun,
-      refreshLocks: args.refreshLocks,
-    });
-    console.log(`\n=== ${args.dryRun ? 'dry-run ' : ''}bump ${root} ===`);
-    console.log(`yarn set version dirs: ${s.setVersionDirs.length}`);
-    for (const d of s.setVersionDirs.slice(0, 40)) console.log(`  ${path.relative(root, d) || '.'}`);
-    if (s.setVersionDirs.length > 40) console.log(`  … +${s.setVersionDirs.length - 40} more`);
-    if (s.setVersionFailed.length) {
-      failed = true;
-      console.log(`yarn set version failed: ${s.setVersionFailed.length}`);
-    }
-    console.log(`orphan binaries: ${s.orphanBinaries.length}`);
-    for (const b of s.orphanBinaries) console.log(`  ${b.from} → ${b.to}`);
-    const extras = s.extraFiles.map((f) => path.relative(root, f)).sort();
-    console.log(`extra pin files: ${extras.length}`);
-    for (const f of extras) console.log(`  ${f}`);
-    if (s.remaining.length) {
-      failed = true;
-      console.log('REMAINING from-versions (unexpected):');
-      for (const line of s.remaining) console.log(`  ${line}`);
-    } else if (!args.dryRun) console.log('remaining from-versions: none');
-    if (s.lockRefresh.length) {
-      const bad = s.lockRefresh.filter((x) => x.status !== 0);
-      console.log(`lock refresh: ${s.lockRefresh.length} dirs (${bad.length} failed)`);
-      if (bad.length) failed = true;
-    }
-    if (s.lockRefreshSkipped.length) {
-      console.log(`lock refresh skipped (explicit older pin): ${s.lockRefreshSkipped.length}`);
-    }
-  }
-  if (failed) process.exit(2);
+  console.log(`to=${args.to} from=${args.from.join(',')} dry-run=${args.dryRun} locks=${args.locks}`);
+  for (const r of args.roots) bump(r, args);
 }
 
-main().catch((err) => {
-  console.error(err.stack || err);
-  process.exit(1);
-});
+main();

--- a/skills/rhdh-bump-yarn/scripts/bump-yarn.js
+++ b/skills/rhdh-bump-yarn/scripts/bump-yarn.js
@@ -1,78 +1,38 @@
 #!/usr/bin/env node
 /*
-  Bump Yarn Berry across one or more RHDH-related checkouts.
+  RHDH Yarn bump orchestrator.
 
-  Mirrors the RHIDP-16074 / rhdh-plugins#2918 pattern:
-    - download yarn-<to>.cjs from yarnpkg/berry
-    - replace matching .yarn/releases/yarn-<from>.cjs binaries
-    - rewrite yarnPath / packageManager / "yarn set version" / ENV YARN= pins
+  Workspaces: `yarn set version <to>` (+ lock refresh). That owns packageManager,
+  yarnPath, and .yarn/releases — do not reimplement those.
 
-  By default, refreshes yarn.lock via `yarn install --mode=update-lockfile`
-  for every lock that will run under --to yarn — including nested workspaces
-  that inherit a root yarnPath / packageManager (not only dirs whose pins
-  were rewritten). Skips locks with an explicit pin outside --from/--to
-  (e.g. roadie 4.9.2, backstage 4.8.1, dcm 4.15.0) and dist-dynamic
-  artifacts. New yarn-*.cjs binaries are chmod +x (100755). Also scans
-  .fullsend/<profile>/bin/yarn (rhdh-plugins Fullsend helper): rewrites leftover
-  yarn-<from>.cjs hardcodes and warns to prefer yarnPath derivation.
-  A full five-repo lock regen can take >45 minutes. Use --no-refresh-locks to skip.
-
-  Usage:
-    bump-yarn.js --to 4.17.1 [--from 4.12.0,4.14.1] --root PATH [--root PATH ...]
-    bump-yarn.js --scan --root PATH
-    bump-yarn.js --fetch-only --to 4.17.1
-    bump-yarn.js --to 4.17.1 --root PATH --dry-run
-    bump-yarn.js --to 4.17.1 --root PATH --no-refresh-locks
+  Extras Yarn cannot see: Containerfile / Dockerfile / ENV YARN / embedded
+  `yarn set version`, orphan release binaries (distgit), Fullsend helpers,
+  and yarn.lock under workspaces that only inherit a root pin.
 */
 
 'use strict';
 
 const fs = require('node:fs');
-const os = require('node:os');
 const path = require('node:path');
-const { spawnSync } = require('node:child_process');
 const https = require('node:https');
 const http = require('node:http');
+const os = require('node:os');
+const { spawnSync } = require('node:child_process');
 
 const DEFAULT_FROM = ['4.12.0', '4.14.1'];
 const CACHE_DIR = path.join(os.homedir(), '.cache', 'rhdh-bump-yarn');
 
-const TEXT_BASENAMES = new Set([
-  'package.json',
-  '.yarnrc.yml',
-  'Containerfile',
-  'Dockerfile',
-  'run-e2e.sh',
-]);
-
-function usage(exitCode = 0) {
+function usage(code = 0) {
   console.log(`Usage:
   bump-yarn.js --to VERSION [--from V1,V2] --root PATH [--root PATH ...]
-  bump-yarn.js --scan --root PATH [--root PATH ...]
-  bump-yarn.js --fetch-only --to VERSION
-  bump-yarn.js --to VERSION --root PATH --dry-run
-  bump-yarn.js --to VERSION --root PATH --no-refresh-locks
+  bump-yarn.js --scan --root PATH
+  bump-yarn.js --to VERSION --root PATH [--dry-run] [--no-refresh-locks]
 
-Defaults:
-  --from  ${DEFAULT_FROM.join(',')}
-  refresh yarn.lock for all workspaces using --to (incl. inherited root pin);
-  skip explicit older pins and dist-dynamic; opt out with --no-refresh-locks
-  binaries written mode 0755; Binary cache: ${CACHE_DIR}
-
-Examples (RHIDP-16074 five-repo set):
-  node skills/rhdh-bump-yarn/scripts/bump-yarn.js --to 4.17.1 \\
-    --root ~/path/rhdh-plugins --root ~/path/rhdh \\
-    --root ~/path/overlays --root ~/path/rhdh-downstream \\
-    --root ~/path/rhdh-plugin-catalog
-
-Known repo shapes (any checkout root works; discovery is recursive):
-  rhdh-plugins          root .yarn + packageManager + yarnPath
-  rhdh (GH midstream)   root/.ci/dynamic-plugins/e2e + Containerfile
-  overlays              packageManager pins (+ rare releases)
-  rhdh (GL downstream)  distgit/containers/rhdh-hub + Containerfile
-  rhdh-plugin-catalog   workspaces/*/.yarn + builder.Containerfile + overlay-repo
+Defaults: --from ${DEFAULT_FROM.join(',')}
+Strategy: yarn set version <to> for matching packageManager dirs; rewrite
+Containerfile/Fullsend/orphan binaries; refresh inherited yarn.lock dirs.
 `);
-  process.exit(exitCode);
+  process.exit(code);
 }
 
 function parseArgs(argv) {
@@ -81,132 +41,40 @@ function parseArgs(argv) {
     roots: [],
     to: null,
     scan: false,
-    fetchOnly: false,
     dryRun: false,
     refreshLocks: true,
   };
   for (let i = 0; i < argv.length; i += 1) {
     const a = argv[i];
     if (a === '-h' || a === '--help') usage(0);
-    if (a === '--scan') {
-      args.scan = true;
-      continue;
-    }
-    if (a === '--fetch-only') {
-      args.fetchOnly = true;
-      continue;
-    }
-    if (a === '--dry-run') {
-      args.dryRun = true;
-      continue;
-    }
-    if (a === '--no-refresh-locks') {
-      args.refreshLocks = false;
-      continue;
-    }
-    if (a === '--refresh-locks') {
-      // default; kept for explicit/compat
-      args.refreshLocks = true;
-      continue;
-    }
-    if (a === '--to') {
-      args.to = argv[++i];
-      continue;
-    }
-    if (a === '--from') {
+    else if (a === '--scan') args.scan = true;
+    else if (a === '--dry-run') args.dryRun = true;
+    else if (a === '--no-refresh-locks') args.refreshLocks = false;
+    else if (a === '--refresh-locks') args.refreshLocks = true;
+    else if (a === '--to') args.to = argv[++i];
+    else if (a === '--from') {
       args.from = String(argv[++i] || '')
         .split(',')
         .map((s) => s.trim())
         .filter(Boolean);
-      continue;
+    } else if (a === '--root') args.roots.push(path.resolve(argv[++i]));
+    else {
+      console.error(`Unknown arg: ${a}`);
+      usage(1);
     }
-    if (a === '--root') {
-      args.roots.push(path.resolve(argv[++i]));
-      continue;
-    }
-    console.error(`Unknown arg: ${a}`);
-    usage(1);
   }
   return args;
 }
 
-function escapeRegExp(s) {
+function esc(s) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-function yarnReleaseUrl(version) {
-  // Tag is @yarnpkg/cli/<version>; encode for raw.githubusercontent.com
-  const tag = encodeURIComponent(`@yarnpkg/cli/${version}`);
-  return `https://raw.githubusercontent.com/yarnpkg/berry/${tag}/packages/yarnpkg-cli/bin/yarn.js`;
-}
-
-function download(url, dest) {
-  return new Promise((resolve, reject) => {
-    const client = url.startsWith('https:') ? https : http;
-    const req = client.get(url, { headers: { 'User-Agent': 'rhdh-bump-yarn' } }, (res) => {
-      if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-        res.resume();
-        download(res.headers.location, dest).then(resolve, reject);
-        return;
-      }
-      if (res.statusCode !== 200) {
-        reject(new Error(`GET ${url} → ${res.statusCode}`));
-        res.resume();
-        return;
-      }
-      const tmp = `${dest}.partial`;
-      const out = fs.createWriteStream(tmp);
-      res.pipe(out);
-      out.on('finish', () => {
-        out.close(() => {
-          fs.renameSync(tmp, dest);
-          resolve(dest);
-        });
-      });
-      out.on('error', reject);
-    });
-    req.on('error', reject);
-  });
-}
-
-function makeExecutable(filePath) {
-  try {
-    fs.chmodSync(filePath, 0o755);
-  } catch (err) {
-    console.error(`warn: chmod +x failed for ${filePath}: ${err.message}`);
-  }
-}
-
-function ensureBinary(version, { force = false } = {}) {
-  fs.mkdirSync(CACHE_DIR, { recursive: true });
-  const dest = path.join(CACHE_DIR, `yarn-${version}.cjs`);
-  if (!force && fs.existsSync(dest)) {
-    const v = spawnSync(process.execPath, [dest, '-v'], { encoding: 'utf8' });
-    if (v.status === 0 && String(v.stdout).trim() === version) {
-      makeExecutable(dest);
-      return dest;
-    }
-  }
-  const url = yarnReleaseUrl(version);
-  console.log(`fetch: ${url}`);
-  return download(url, dest).then(() => {
-    makeExecutable(dest);
-    const v = spawnSync(process.execPath, [dest, '-v'], { encoding: 'utf8' });
-    if (v.status !== 0 || String(v.stdout).trim() !== version) {
-      throw new Error(
-        `Downloaded yarn binary version mismatch: got ${JSON.stringify(String(v.stdout).trim())} expected ${version}`,
-      );
-    }
-    console.log(`cached: ${dest} (${fs.statSync(dest).size} bytes)`);
-    return dest;
-  });
-}
-
-function shouldSkipDir(name) {
+function skipDir(name) {
   return (
     name === '.git' ||
     name === 'node_modules' ||
-    name === '.yarn' || // still walk releases via dedicated find
+    name === '.yarn' ||
     name === 'dist' ||
     name === 'coverage' ||
     name === '.turbo'
@@ -226,8 +94,7 @@ function walk(root, onFile) {
     for (const ent of entries) {
       const full = path.join(dir, ent.name);
       if (ent.isDirectory()) {
-        if (shouldSkipDir(ent.name)) {
-          // Still descend into .yarn/releases only
+        if (skipDir(ent.name)) {
           if (ent.name === '.yarn') {
             const releases = path.join(full, 'releases');
             if (fs.existsSync(releases)) stack.push(releases);
@@ -235,40 +102,224 @@ function walk(root, onFile) {
           continue;
         }
         stack.push(full);
-      } else if (ent.isFile()) {
-        onFile(full, ent.name);
-      }
+      } else if (ent.isFile()) onFile(full, ent.name);
     }
   }
 }
 
-function isFullsendYarnHelper(full, basename) {
-  // Extensionless helper: .fullsend/<profile>/bin/yarn (rhdh-plugins Fullsend)
-  if (basename !== 'yarn') return false;
-  const norm = full.split(path.sep).join('/');
-  return norm.includes('/.fullsend/') && norm.endsWith('/bin/yarn');
+function readPm(dir) {
+  try {
+    const pm = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8')).packageManager;
+    const m = typeof pm === 'string' && /^yarn@([0-9]+\.[0-9]+\.[0-9]+)/.exec(pm);
+    return m ? m[1] : null;
+  } catch {
+    return null;
+  }
 }
 
-function isTextCandidate(full, basename) {
-  if (TEXT_BASENAMES.has(basename)) return true;
-  if (basename.endsWith('.Containerfile')) return true;
-  if (basename.endsWith('.Dockerfile')) return true;
-  // Embedded packageManager JSON snippets sometimes live in shell helpers
+function readYarnPath(dir) {
+  try {
+    const text = fs.readFileSync(path.join(dir, '.yarnrc.yml'), 'utf8');
+    const m = /(?:^|\n)yarnPath:\s*.*yarn-([0-9]+\.[0-9]+\.[0-9]+)\.cjs/.exec(text);
+    return m ? m[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+function explicitPin(dir) {
+  return readPm(dir) || readYarnPath(dir);
+}
+
+function isFullsend(full, basename) {
+  return (
+    basename === 'yarn' &&
+    full.split(path.sep).join('/').includes('/.fullsend/') &&
+    full.endsWith(`${path.sep}bin${path.sep}yarn`)
+  );
+}
+
+function isExtraText(full, basename) {
+  if (basename === 'package.json' || basename === '.yarnrc.yml') return false;
+  if (basename === 'Containerfile' || basename === 'Dockerfile' || basename === 'run-e2e.sh') {
+    return true;
+  }
+  if (basename.endsWith('.Containerfile') || basename.endsWith('.Dockerfile')) return true;
   if (basename.endsWith('.sh') && /e2e|yarn|packageManager/i.test(basename + full)) return true;
-  if (isFullsendYarnHelper(full, basename)) return true;
-  return false;
+  return isFullsend(full, basename);
+}
+
+function localYarnBin(dir) {
+  const releases = path.join(dir, '.yarn', 'releases');
+  try {
+    const bins = fs
+      .readdirSync(releases)
+      .filter((n) => /^yarn-[0-9]+\.[0-9]+\.[0-9]+\.cjs$/.test(n))
+      .sort();
+    return bins.length ? path.join(releases, bins[bins.length - 1]) : null;
+  } catch {
+    return null;
+  }
+}
+
+function chmodX(p) {
+  try {
+    fs.chmodSync(p, 0o755);
+  } catch (err) {
+    console.error(`warn: chmod +x failed for ${p}: ${err.message}`);
+  }
+}
+
+function download(url, dest) {
+  return new Promise((resolve, reject) => {
+    const client = url.startsWith('https:') ? https : http;
+    client
+      .get(url, { headers: { 'User-Agent': 'rhdh-bump-yarn' } }, (res) => {
+        if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+          res.resume();
+          download(res.headers.location, dest).then(resolve, reject);
+          return;
+        }
+        if (res.statusCode !== 200) {
+          reject(new Error(`GET ${url} → ${res.statusCode}`));
+          res.resume();
+          return;
+        }
+        const tmp = `${dest}.partial`;
+        const out = fs.createWriteStream(tmp);
+        res.pipe(out);
+        out.on('finish', () => out.close(() => {
+          fs.renameSync(tmp, dest);
+          resolve(dest);
+        }));
+        out.on('error', reject);
+      })
+      .on('error', reject);
+  });
+}
+
+/** Only for orphan distgit binaries when no workspace produced yarn-<to>.cjs. */
+async function cachedBinary(version) {
+  fs.mkdirSync(CACHE_DIR, { recursive: true });
+  const dest = path.join(CACHE_DIR, `yarn-${version}.cjs`);
+  const ok = () => {
+    const v = spawnSync(process.execPath, [dest, '-v'], { encoding: 'utf8' });
+    return v.status === 0 && String(v.stdout).trim() === version;
+  };
+  if (fs.existsSync(dest) && ok()) {
+    chmodX(dest);
+    return dest;
+  }
+  const tag = encodeURIComponent(`@yarnpkg/cli/${version}`);
+  const url = `https://raw.githubusercontent.com/yarnpkg/berry/${tag}/packages/yarnpkg-cli/bin/yarn.js`;
+  console.log(`fetch (orphan fallback): ${url}`);
+  await download(url, dest);
+  chmodX(dest);
+  if (!ok()) throw new Error(`cached yarn binary mismatch for ${version}`);
+  return dest;
+}
+
+function findToBin(root, to) {
+  let found = null;
+  walk(root, (full, basename) => {
+    if (!found && basename === `yarn-${to}.cjs` && full.includes(`${path.sep}.yarn${path.sep}releases${path.sep}`)) {
+      found = full;
+    }
+  });
+  return found;
+}
+
+function bumpExtraText(content, fromVersions, to) {
+  const alt = fromVersions.map(esc).join('|');
+  return content
+    .replace(new RegExp(`yarn-(?:${alt})\\.cjs`, 'g'), `yarn-${to}.cjs`)
+    .replace(new RegExp(`yarn set version (?:${alt})\\b`, 'g'), `yarn set version ${to}`)
+    .replace(
+      new RegExp(`"packageManager":\\s*"yarn@(?:${alt})(?:\\+[^"]+)?"`, 'g'),
+      `"packageManager": "yarn@${to}"`,
+    );
+}
+
+function skipLock(p) {
+  const parts = p.split(path.sep);
+  return parts.includes('node_modules') || parts.includes('dist-dynamic') || parts.includes('.git');
+}
+
+function lockDirs(root, { from, to }) {
+  const fromSet = new Set(from);
+  const dirs = [];
+  const skipped = [];
+  walk(root, (full, basename) => {
+    if (basename !== 'yarn.lock' || skipLock(full)) return;
+    const dir = path.dirname(full);
+    const pin = explicitPin(dir);
+    if (pin && pin !== to && !fromSet.has(pin)) skipped.push({ dir, pin });
+    else dirs.push(dir);
+  });
+  return { dirs: dirs.sort(), skipped };
+}
+
+function resolveBin(dir, fallback, to) {
+  let cur = dir;
+  for (let i = 0; i < 8; i += 1) {
+    const c = path.join(cur, '.yarn', 'releases', `yarn-${to}.cjs`);
+    if (fs.existsSync(c)) return c;
+    const parent = path.dirname(cur);
+    if (parent === cur) break;
+    cur = parent;
+  }
+  return fallback;
+}
+
+function runSetVersion(dir, to, dryRun) {
+  const local = localYarnBin(dir);
+  if (dryRun) {
+    console.log(
+      `dry-run: ${dir}: ${local ? `node ${path.relative(dir, local)}` : 'yarn'} set version ${to}`,
+    );
+    return { status: 0 };
+  }
+  console.log(`yarn set version: ${dir}`);
+  const r = local
+    ? spawnSync(process.execPath, [local, 'set', 'version', to], {
+      cwd: dir,
+      encoding: 'utf8',
+      env: { ...process.env, YARN_ENABLE_IMMUTABLE_INSTALLS: 'false' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    : spawnSync('yarn', ['set', 'version', to], {
+      cwd: dir,
+      encoding: 'utf8',
+      env: { ...process.env, YARN_ENABLE_IMMUTABLE_INSTALLS: 'false' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  if (r.status !== 0) {
+    console.error(
+      `warn: yarn set version failed in ${dir} (exit ${r.status})\n` +
+        (r.stderr || r.stdout || '').trim().split('\n').slice(-8).join('\n'),
+    );
+  }
+  const bin = path.join(dir, '.yarn', 'releases', `yarn-${to}.cjs`);
+  if (fs.existsSync(bin)) chmodX(bin);
+  return r;
 }
 
 function scanRoot(root) {
   const releases = [];
-  const pins = [];
+  const packageManagers = [];
+  const extraPins = [];
   walk(root, (full, basename) => {
     const m = /^yarn-([0-9]+\.[0-9]+\.[0-9]+)\.cjs$/.exec(basename);
     if (m && full.includes(`${path.sep}.yarn${path.sep}releases${path.sep}`)) {
       releases.push({ path: full, version: m[1] });
       return;
     }
-    if (!isTextCandidate(full, basename)) return;
+    if (basename === 'package.json') {
+      const ver = readPm(path.dirname(full));
+      if (ver) packageManagers.push({ path: full, version: ver });
+      return;
+    }
+    if (!isExtraText(full, basename)) return;
     let text;
     try {
       text = fs.readFileSync(full, 'utf8');
@@ -277,147 +328,94 @@ function scanRoot(root) {
     }
     if (text.length > 2_000_000) return;
     const found = new Set();
-    for (const re of [
-      /yarn@([0-9]+\.[0-9]+\.[0-9]+)/g,
-      /yarn-([0-9]+\.[0-9]+\.[0-9]+)\.cjs/g,
-      /yarn set version ([0-9]+\.[0-9]+\.[0-9]+)/g,
-    ]) {
+    for (const re of [/yarn-([0-9]+\.[0-9]+\.[0-9]+)\.cjs/g, /yarn set version ([0-9]+\.[0-9]+\.[0-9]+)/g]) {
       let match;
       while ((match = re.exec(text))) found.add(match[1]);
     }
-    if (found.size) pins.push({ path: full, versions: [...found].sort() });
+    if (found.size) extraPins.push({ path: full, versions: [...found].sort() });
   });
-  return { releases, pins };
+  return { releases, packageManagers, extraPins };
 }
 
-function bumpText(content, fromVersions, toVersion) {
-  const fromAlt = fromVersions.map(escapeRegExp).join('|');
-  let next = content;
-  next = next.replace(
-    new RegExp(`yarn-(?:${fromAlt})\\.cjs`, 'g'),
-    `yarn-${toVersion}.cjs`,
-  );
-  next = next.replace(
-    new RegExp(`"packageManager":\\s*"yarn@(?:${fromAlt})"`, 'g'),
-    `"packageManager": "yarn@${toVersion}"`,
-  );
-  // Corepack form with integrity suffix
-  next = next.replace(
-    new RegExp(`"packageManager":\\s*"yarn@(?:${fromAlt})\\+[^"]+"`, 'g'),
-    `"packageManager": "yarn@${toVersion}"`,
-  );
-  next = next.replace(
-    new RegExp(`yarn set version (?:${fromAlt})\\b`, 'g'),
-    `yarn set version ${toVersion}`,
-  );
-  return next;
-}
-
-function readExplicitYarnPin(dir) {
-  // Only packageManager / yarnPath — avoid matching unrelated yarn@x.y.z deps.
-  const pkgPath = path.join(dir, 'package.json');
-  if (fs.existsSync(pkgPath)) {
-    try {
-      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
-      const pm = pkg.packageManager;
-      if (typeof pm === 'string') {
-        const m = /^yarn@([0-9]+\.[0-9]+\.[0-9]+)/.exec(pm);
-        if (m) return m[1];
-      }
-    } catch {
-      // ignore malformed package.json
+function printScan(root) {
+  const { releases, packageManagers, extraPins } = scanRoot(root);
+  const count = (items, key) => {
+    const m = new Map();
+    for (const it of items) {
+      const vs = key ? it[key] : it.versions;
+      for (const v of Array.isArray(vs) ? vs : [vs]) m.set(v, (m.get(v) || 0) + 1);
     }
-  }
-  const rcPath = path.join(dir, '.yarnrc.yml');
-  if (fs.existsSync(rcPath)) {
-    try {
-      const text = fs.readFileSync(rcPath, 'utf8');
-      const m = /(?:^|\n)yarnPath:\s*.*yarn-([0-9]+\.[0-9]+\.[0-9]+)\.cjs/.exec(text);
-      if (m) return m[1];
-    } catch {
-      // ignore
-    }
-  }
-  return null;
+    return m;
+  };
+  console.log(`\n=== scan ${root} ===`);
+  console.log('releases:');
+  for (const [v, n] of [...count(releases, 'version')].sort()) console.log(`  yarn-${v}.cjs × ${n}`);
+  if (!releases.length) console.log('  (none)');
+  console.log('packageManager (yarn set version targets):');
+  for (const [v, n] of [...count(packageManagers, 'version')].sort()) console.log(`  yarn@${v} × ${n}`);
+  if (!packageManagers.length) console.log('  (none)');
+  console.log('extra pins (Containerfile / Fullsend / scripts):');
+  for (const [v, n] of [...count(extraPins)].sort()) console.log(`  ${v} × ${n} files`);
+  if (!extraPins.length) console.log('  (none)');
 }
 
-function shouldSkipLockPath(lockPath) {
-  const parts = lockPath.split(path.sep);
-  if (parts.includes('node_modules')) return true;
-  if (parts.includes('dist-dynamic')) return true;
-  if (parts.includes('.git')) return true;
-  return false;
-}
-
-function collectLockRefreshDirs(root, { from, to }) {
+async function bumpRoot(root, { from, to, dryRun, refreshLocks }) {
   const fromSet = new Set(from);
-  const dirs = [];
-  const skipped = [];
-  walk(root, (full, basename) => {
-    if (basename !== 'yarn.lock') return;
-    if (shouldSkipLockPath(full)) return;
-    const dir = path.dirname(full);
-    const pin = readExplicitYarnPin(dir);
-    // Explicit pin outside --from/--to → leave alone (roadie/backstage/dcm, etc.)
-    if (pin && pin !== to && !fromSet.has(pin)) {
-      skipped.push({ dir, pin });
-      return;
-    }
-    dirs.push(dir);
-  });
-  dirs.sort();
-  return { dirs, skipped };
-}
-
-function resolveYarnBin(dir, binaryPath, toVersion) {
-  const newName = `yarn-${toVersion}.cjs`;
-  const local = path.join(dir, '.yarn', 'releases', newName);
-  if (fs.existsSync(local)) return local;
-  let cur = dir;
-  for (let i = 0; i < 8; i += 1) {
-    const candidate = path.join(cur, '.yarn', 'releases', newName);
-    if (fs.existsSync(candidate)) return candidate;
-    const parent = path.dirname(cur);
-    if (parent === cur) break;
-    cur = parent;
-  }
-  return binaryPath;
-}
-
-function bumpRoot(root, { from, to, binaryPath, dryRun, refreshLocks }) {
   const summary = {
-    root,
-    binariesReplaced: [],
-    filesUpdated: [],
-    skippedReleases: [],
-    remaining: [],
+    setVersionDirs: [],
+    setVersionFailed: [],
+    orphanBinaries: [],
+    extraFiles: [],
     lockRefresh: [],
     lockRefreshSkipped: [],
+    remaining: [],
   };
 
-  const fromSet = new Set(from);
-  const newName = `yarn-${to}.cjs`;
+  const pmDirs = [];
+  walk(root, (full, basename) => {
+    if (basename !== 'package.json') return;
+    const dir = path.dirname(full);
+    const ver = readPm(dir);
+    if (ver && fromSet.has(ver)) pmDirs.push(dir);
+  });
+  pmDirs.sort();
 
-  // 1) binaries
+  const covered = new Set(pmDirs.map((d) => path.resolve(d)));
+  const orphans = [];
   walk(root, (full, basename) => {
     const m = /^yarn-([0-9]+\.[0-9]+\.[0-9]+)\.cjs$/.exec(basename);
-    if (!m || !full.includes(`${path.sep}.yarn${path.sep}releases${path.sep}`)) return;
-    const ver = m[1];
-    if (!fromSet.has(ver)) {
-      if (ver !== to) summary.skippedReleases.push({ path: full, version: ver });
-      return;
+    if (!m || !fromSet.has(m[1])) return;
+    if (!full.includes(`${path.sep}.yarn${path.sep}releases${path.sep}`)) return;
+    const projectDir = path.dirname(path.dirname(path.dirname(full)));
+    if (!covered.has(path.resolve(projectDir))) {
+      orphans.push({ path: full, dir: projectDir });
     }
-    const dest = path.join(path.dirname(full), newName);
-    summary.binariesReplaced.push({ from: full, to: dest, version: ver });
-    if (dryRun) return;
-    fs.copyFileSync(binaryPath, dest);
-    makeExecutable(dest);
-    if (path.resolve(full) !== path.resolve(dest)) fs.unlinkSync(full);
   });
 
-  // 2) text pins (incl. .fullsend/**/bin/yarn hardcodes)
+  for (const dir of pmDirs) {
+    summary.setVersionDirs.push(dir);
+    const r = runSetVersion(dir, to, dryRun);
+    if (!dryRun && r.status !== 0) summary.setVersionFailed.push(dir);
+  }
+
+  let fallback = null;
+  if (orphans.length) {
+    if (!dryRun) fallback = findToBin(root, to) || (await cachedBinary(to));
+    for (const o of orphans) {
+      const dest = path.join(path.dirname(o.path), `yarn-${to}.cjs`);
+      summary.orphanBinaries.push({ from: o.path, to: dest });
+      if (dryRun) {
+        console.log(`dry-run: orphan binary ${o.path} → ${dest}`);
+        continue;
+      }
+      fs.copyFileSync(fallback, dest);
+      chmodX(dest);
+      if (path.resolve(o.path) !== path.resolve(dest)) fs.unlinkSync(o.path);
+    }
+  }
+
   walk(root, (full, basename) => {
-    if (!isTextCandidate(full, basename)) return;
+    if (!isExtraText(full, basename)) return;
     let text;
     try {
       text = fs.readFileSync(full, 'utf8');
@@ -425,52 +423,46 @@ function bumpRoot(root, { from, to, binaryPath, dryRun, refreshLocks }) {
       return;
     }
     if (text.length > 2_000_000) return;
-    const next = bumpText(text, from, to);
+    const next = bumpExtraText(text, from, to);
     if (next === text) return;
-    summary.filesUpdated.push(full);
-    if (isFullsendYarnHelper(full, basename) && /yarn-[0-9]+\.[0-9]+\.[0-9]+\.cjs/.test(next)) {
+    summary.extraFiles.push(full);
+    if (isFullsend(full, basename) && /yarn-[0-9]+\.[0-9]+\.[0-9]+\.cjs/.test(next)) {
       console.warn(
-        `warn: ${full} still hardcodes a yarn-*.cjs path after bump; ` +
-          'prefer deriving yarnPath from ${FULLSEND_TARGET_REPO_DIR}/.yarnrc.yml ' +
-          '(see rhdh-plugins#4199)',
+        `warn: ${full} still hardcodes yarn-*.cjs; prefer yarnPath derivation (rhdh-plugins#4199)`,
       );
     }
-    if (!dryRun) fs.writeFileSync(full, next);
+    if (dryRun) console.log(`dry-run: extra pin ${path.relative(root, full)}`);
+    else fs.writeFileSync(full, next);
   });
 
-  // 3) remaining inventory (from-set only) — skip on dry-run (tree unchanged)
   if (!dryRun) {
     const after = scanRoot(root);
     for (const r of after.releases) {
       if (fromSet.has(r.version)) summary.remaining.push(`release ${r.version}: ${r.path}`);
     }
-    for (const p of after.pins) {
-      const leftover = p.versions.filter((v) => fromSet.has(v));
-      if (leftover.length) summary.remaining.push(`${leftover.join(',')}: ${p.path}`);
+    for (const p of after.packageManagers) {
+      if (fromSet.has(p.version)) summary.remaining.push(`packageManager ${p.version}: ${p.path}`);
+    }
+    for (const p of after.extraPins) {
+      const left = p.versions.filter((v) => fromSet.has(v));
+      if (left.length) summary.remaining.push(`${left.join(',')}: ${p.path}`);
     }
   }
 
-  // 4) lock refresh — every yarn.lock that will run under --to (incl. inherited root pin)
   if (refreshLocks && !dryRun) {
-    const { dirs, skipped } = collectLockRefreshDirs(root, { from, to });
+    if (!fallback) fallback = findToBin(root, to) || (await cachedBinary(to));
+    const { dirs, skipped } = lockDirs(root, { from, to });
     summary.lockRefreshSkipped = skipped;
-    for (const s of skipped) {
-      console.log(`refresh-locks: skip ${s.dir} (explicit pin ${s.pin})`);
-    }
+    for (const s of skipped) console.log(`refresh-locks: skip ${s.dir} (explicit pin ${s.pin})`);
     for (const dir of dirs) {
-      const yarnBin = resolveYarnBin(dir, binaryPath, to);
+      const yarnBin = resolveBin(dir, fallback, to);
       console.log(`refresh-locks: ${dir}`);
-      const r = spawnSync(
-        process.execPath,
-        [yarnBin, 'install', '--mode=update-lockfile'],
-        {
-          cwd: dir,
-          encoding: 'utf8',
-          env: { ...process.env, YARN_ENABLE_IMMUTABLE_INSTALLS: 'false' },
-          stdio: ['ignore', 'pipe', 'pipe'],
-        },
-      );
-      // Drop untracked .yarnrc.yml yarn may invent during "migration"
+      const r = spawnSync(process.execPath, [yarnBin, 'install', '--mode=update-lockfile'], {
+        cwd: dir,
+        encoding: 'utf8',
+        env: { ...process.env, YARN_ENABLE_IMMUTABLE_INSTALLS: 'false' },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
       const rcPath = path.join(dir, '.yarnrc.yml');
       if (fs.existsSync(rcPath)) {
         const tracked = spawnSync('git', ['ls-files', '--error-unmatch', rcPath], {
@@ -486,51 +478,16 @@ function bumpRoot(root, { from, to, binaryPath, dryRun, refreshLocks }) {
           }
         }
       }
-      summary.lockRefresh.push({
-        dir,
-        status: r.status,
-        stderr: (r.stderr || '').split('\n').slice(-5).join('\n'),
-      });
-      if (r.status !== 0) {
-        console.error(`warn: yarn install failed in ${dir} (exit ${r.status})`);
-      }
+      summary.lockRefresh.push({ dir, status: r.status });
+      if (r.status !== 0) console.error(`warn: yarn install failed in ${dir} (exit ${r.status})`);
     }
   }
 
   return summary;
 }
 
-function printScan(root) {
-  const { releases, pins } = scanRoot(root);
-  const byVer = new Map();
-  for (const r of releases) {
-    byVer.set(r.version, (byVer.get(r.version) || 0) + 1);
-  }
-  console.log(`\n=== scan ${root} ===`);
-  console.log('releases:');
-  for (const [v, n] of [...byVer.entries()].sort()) console.log(`  yarn-${v}.cjs × ${n}`);
-  if (!releases.length) console.log('  (none)');
-  console.log('text pins (packageManager / yarnPath / yarn set version):');
-  const pinByVer = new Map();
-  for (const p of pins) {
-    for (const v of p.versions) pinByVer.set(v, (pinByVer.get(v) || 0) + 1);
-  }
-  for (const [v, n] of [...pinByVer.entries()].sort()) console.log(`  ${v} × ${n} files`);
-  if (!pins.length) console.log('  (none)');
-}
-
 async function main() {
   const args = parseArgs(process.argv.slice(2));
-
-  if (args.fetchOnly) {
-    if (!args.to) {
-      console.error('--fetch-only requires --to');
-      usage(1);
-    }
-    await ensureBinary(args.to, { force: true });
-    return;
-  }
-
   if (!args.roots.length) {
     console.error('Provide at least one --root PATH');
     usage(1);
@@ -541,12 +498,10 @@ async function main() {
       process.exit(1);
     }
   }
-
   if (args.scan) {
     for (const root of args.roots) printScan(root);
     return;
   }
-
   if (!args.to) {
     console.error('--to VERSION is required (unless --scan)');
     usage(1);
@@ -556,65 +511,47 @@ async function main() {
     usage(1);
   }
 
-  const binaryPath = await ensureBinary(args.to);
   console.log(`to: ${args.to}`);
   console.log(`from: ${args.from.join(', ')}`);
   console.log(`dry-run: ${args.dryRun}`);
   console.log(`refresh-locks: ${args.refreshLocks}`);
+  console.log('strategy: yarn set version + extra pin rewrite');
 
   let failed = false;
   for (const root of args.roots) {
-    const summary = bumpRoot(root, {
+    const s = await bumpRoot(root, {
       from: args.from,
       to: args.to,
-      binaryPath,
       dryRun: args.dryRun,
       refreshLocks: args.refreshLocks,
     });
     console.log(`\n=== ${args.dryRun ? 'dry-run ' : ''}bump ${root} ===`);
-    console.log(`binaries: ${summary.binariesReplaced.length}`);
-    for (const b of summary.binariesReplaced.slice(0, 30)) {
-      console.log(`  ${b.version} → ${b.to}`);
+    console.log(`yarn set version dirs: ${s.setVersionDirs.length}`);
+    for (const d of s.setVersionDirs.slice(0, 40)) console.log(`  ${path.relative(root, d) || '.'}`);
+    if (s.setVersionDirs.length > 40) console.log(`  … +${s.setVersionDirs.length - 40} more`);
+    if (s.setVersionFailed.length) {
+      failed = true;
+      console.log(`yarn set version failed: ${s.setVersionFailed.length}`);
     }
-    if (summary.binariesReplaced.length > 30) {
-      console.log(`  … +${summary.binariesReplaced.length - 30} more`);
-    }
-    const relFiles = summary.filesUpdated
-      .map((f) => path.relative(root, f))
-      .sort();
-    console.log(`files: ${relFiles.length}`);
-    for (const f of relFiles) console.log(`  ${f}`);
-    if (summary.skippedReleases.length) {
-      console.log(`left alone (not in --from):`);
-      const counts = new Map();
-      for (const s of summary.skippedReleases) {
-        counts.set(s.version, (counts.get(s.version) || 0) + 1);
-      }
-      for (const [v, n] of [...counts.entries()].sort()) console.log(`  yarn-${v}.cjs × ${n}`);
-    }
-    if (summary.remaining.length) {
+    console.log(`orphan binaries: ${s.orphanBinaries.length}`);
+    for (const b of s.orphanBinaries) console.log(`  ${b.from} → ${b.to}`);
+    const extras = s.extraFiles.map((f) => path.relative(root, f)).sort();
+    console.log(`extra pin files: ${extras.length}`);
+    for (const f of extras) console.log(`  ${f}`);
+    if (s.remaining.length) {
       failed = true;
       console.log('REMAINING from-versions (unexpected):');
-      for (const line of summary.remaining) console.log(`  ${line}`);
-    } else {
-      console.log('remaining from-versions: none');
-    }
-    if (summary.lockRefresh.length) {
-      const bad = summary.lockRefresh.filter((x) => x.status !== 0);
-      console.log(`lock refresh: ${summary.lockRefresh.length} dirs (${bad.length} failed)`);
+      for (const line of s.remaining) console.log(`  ${line}`);
+    } else if (!args.dryRun) console.log('remaining from-versions: none');
+    if (s.lockRefresh.length) {
+      const bad = s.lockRefresh.filter((x) => x.status !== 0);
+      console.log(`lock refresh: ${s.lockRefresh.length} dirs (${bad.length} failed)`);
       if (bad.length) failed = true;
     }
-    if (summary.lockRefreshSkipped?.length) {
-      console.log(`lock refresh skipped (explicit older pin): ${summary.lockRefreshSkipped.length}`);
-      for (const s of summary.lockRefreshSkipped.slice(0, 20)) {
-        console.log(`  ${s.pin}: ${path.relative(root, s.dir)}`);
-      }
-      if (summary.lockRefreshSkipped.length > 20) {
-        console.log(`  … +${summary.lockRefreshSkipped.length - 20} more`);
-      }
+    if (s.lockRefreshSkipped.length) {
+      console.log(`lock refresh skipped (explicit older pin): ${s.lockRefreshSkipped.length}`);
     }
   }
-
   if (failed) process.exit(2);
 }
 

--- a/skills/rhdh-bump-yarn/scripts/bump-yarn.js
+++ b/skills/rhdh-bump-yarn/scripts/bump-yarn.js
@@ -1,0 +1,519 @@
+#!/usr/bin/env node
+/*
+  Bump Yarn Berry across one or more RHDH-related checkouts.
+
+  Mirrors the RHIDP-16074 / rhdh-plugins#2918 pattern:
+    - download yarn-<to>.cjs from yarnpkg/berry
+    - replace matching .yarn/releases/yarn-<from>.cjs binaries
+    - rewrite yarnPath / packageManager / "yarn set version" / ENV YARN= pins
+
+  By default, refreshes yarn.lock via `yarn install --mode=skip-build` in
+  touched workspaces (slow; matches Renovate lock metadata bumps).
+  Use --no-refresh-locks to skip.
+
+  Usage:
+    bump-yarn.js --to 4.17.1 [--from 4.12.0,4.14.1] --root PATH [--root PATH ...]
+    bump-yarn.js --scan --root PATH
+    bump-yarn.js --fetch-only --to 4.17.1
+    bump-yarn.js --to 4.17.1 --root PATH --dry-run
+    bump-yarn.js --to 4.17.1 --root PATH --no-refresh-locks
+*/
+
+'use strict';
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const https = require('node:https');
+const http = require('node:http');
+
+const DEFAULT_FROM = ['4.12.0', '4.14.1'];
+const CACHE_DIR = path.join(os.homedir(), '.cache', 'rhdh-bump-yarn');
+
+const TEXT_BASENAMES = new Set([
+  'package.json',
+  '.yarnrc.yml',
+  'Containerfile',
+  'Dockerfile',
+  'run-e2e.sh',
+]);
+
+function usage(exitCode = 0) {
+  console.log(`Usage:
+  bump-yarn.js --to VERSION [--from V1,V2] --root PATH [--root PATH ...]
+  bump-yarn.js --scan --root PATH [--root PATH ...]
+  bump-yarn.js --fetch-only --to VERSION
+  bump-yarn.js --to VERSION --root PATH --dry-run
+  bump-yarn.js --to VERSION --root PATH --no-refresh-locks
+
+Defaults:
+  --from  ${DEFAULT_FROM.join(',')}
+  refresh yarn.lock in touched workspaces (slow); opt out with --no-refresh-locks
+  Binary cache: ${CACHE_DIR}
+
+Examples (RHIDP-16074 five-repo set):
+  node skills/rhdh-bump-yarn/scripts/bump-yarn.js --to 4.17.1 \\
+    --root ~/path/rhdh-plugins --root ~/path/rhdh \\
+    --root ~/path/overlays --root ~/path/rhdh-downstream \\
+    --root ~/path/rhdh-plugin-catalog
+
+Known repo shapes (any checkout root works; discovery is recursive):
+  rhdh-plugins          root .yarn + packageManager + yarnPath
+  rhdh (GH midstream)   root/.ci/dynamic-plugins/e2e + Containerfile
+  overlays              packageManager pins (+ rare releases)
+  rhdh (GL downstream)  distgit/containers/rhdh-hub + Containerfile
+  rhdh-plugin-catalog   workspaces/*/.yarn + builder.Containerfile + overlay-repo
+`);
+  process.exit(exitCode);
+}
+
+function parseArgs(argv) {
+  const args = {
+    from: [...DEFAULT_FROM],
+    roots: [],
+    to: null,
+    scan: false,
+    fetchOnly: false,
+    dryRun: false,
+    refreshLocks: true,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === '-h' || a === '--help') usage(0);
+    if (a === '--scan') {
+      args.scan = true;
+      continue;
+    }
+    if (a === '--fetch-only') {
+      args.fetchOnly = true;
+      continue;
+    }
+    if (a === '--dry-run') {
+      args.dryRun = true;
+      continue;
+    }
+    if (a === '--no-refresh-locks') {
+      args.refreshLocks = false;
+      continue;
+    }
+    if (a === '--refresh-locks') {
+      // default; kept for explicit/compat
+      args.refreshLocks = true;
+      continue;
+    }
+    if (a === '--to') {
+      args.to = argv[++i];
+      continue;
+    }
+    if (a === '--from') {
+      args.from = String(argv[++i] || '')
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+      continue;
+    }
+    if (a === '--root') {
+      args.roots.push(path.resolve(argv[++i]));
+      continue;
+    }
+    console.error(`Unknown arg: ${a}`);
+    usage(1);
+  }
+  return args;
+}
+
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function yarnReleaseUrl(version) {
+  // Tag is @yarnpkg/cli/<version>; encode for raw.githubusercontent.com
+  const tag = encodeURIComponent(`@yarnpkg/cli/${version}`);
+  return `https://raw.githubusercontent.com/yarnpkg/berry/${tag}/packages/yarnpkg-cli/bin/yarn.js`;
+}
+
+function download(url, dest) {
+  return new Promise((resolve, reject) => {
+    const client = url.startsWith('https:') ? https : http;
+    const req = client.get(url, { headers: { 'User-Agent': 'rhdh-bump-yarn' } }, (res) => {
+      if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+        res.resume();
+        download(res.headers.location, dest).then(resolve, reject);
+        return;
+      }
+      if (res.statusCode !== 200) {
+        reject(new Error(`GET ${url} → ${res.statusCode}`));
+        res.resume();
+        return;
+      }
+      const tmp = `${dest}.partial`;
+      const out = fs.createWriteStream(tmp);
+      res.pipe(out);
+      out.on('finish', () => {
+        out.close(() => {
+          fs.renameSync(tmp, dest);
+          resolve(dest);
+        });
+      });
+      out.on('error', reject);
+    });
+    req.on('error', reject);
+  });
+}
+
+function ensureBinary(version, { force = false } = {}) {
+  fs.mkdirSync(CACHE_DIR, { recursive: true });
+  const dest = path.join(CACHE_DIR, `yarn-${version}.cjs`);
+  if (!force && fs.existsSync(dest)) {
+    const v = spawnSync(process.execPath, [dest, '-v'], { encoding: 'utf8' });
+    if (v.status === 0 && String(v.stdout).trim() === version) {
+      return dest;
+    }
+  }
+  const url = yarnReleaseUrl(version);
+  console.log(`fetch: ${url}`);
+  return download(url, dest).then(() => {
+    const v = spawnSync(process.execPath, [dest, '-v'], { encoding: 'utf8' });
+    if (v.status !== 0 || String(v.stdout).trim() !== version) {
+      throw new Error(
+        `Downloaded yarn binary version mismatch: got ${JSON.stringify(String(v.stdout).trim())} expected ${version}`,
+      );
+    }
+    console.log(`cached: ${dest} (${fs.statSync(dest).size} bytes)`);
+    return dest;
+  });
+}
+
+function shouldSkipDir(name) {
+  return (
+    name === '.git' ||
+    name === 'node_modules' ||
+    name === '.yarn' || // still walk releases via dedicated find
+    name === 'dist' ||
+    name === 'coverage' ||
+    name === '.turbo'
+  );
+}
+
+function walk(root, onFile) {
+  const stack = [root];
+  while (stack.length) {
+    const dir = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const ent of entries) {
+      const full = path.join(dir, ent.name);
+      if (ent.isDirectory()) {
+        if (shouldSkipDir(ent.name)) {
+          // Still descend into .yarn/releases only
+          if (ent.name === '.yarn') {
+            const releases = path.join(full, 'releases');
+            if (fs.existsSync(releases)) stack.push(releases);
+          }
+          continue;
+        }
+        stack.push(full);
+      } else if (ent.isFile()) {
+        onFile(full, ent.name);
+      }
+    }
+  }
+}
+
+function isTextCandidate(full, basename) {
+  if (TEXT_BASENAMES.has(basename)) return true;
+  if (basename.endsWith('.Containerfile')) return true;
+  if (basename.endsWith('.Dockerfile')) return true;
+  // Embedded packageManager JSON snippets sometimes live in shell helpers
+  if (basename.endsWith('.sh') && /e2e|yarn|packageManager/i.test(basename + full)) return true;
+  return false;
+}
+
+function scanRoot(root) {
+  const releases = [];
+  const pins = [];
+  walk(root, (full, basename) => {
+    const m = /^yarn-([0-9]+\.[0-9]+\.[0-9]+)\.cjs$/.exec(basename);
+    if (m && full.includes(`${path.sep}.yarn${path.sep}releases${path.sep}`)) {
+      releases.push({ path: full, version: m[1] });
+      return;
+    }
+    if (!isTextCandidate(full, basename)) return;
+    let text;
+    try {
+      text = fs.readFileSync(full, 'utf8');
+    } catch {
+      return;
+    }
+    if (text.length > 2_000_000) return;
+    const found = new Set();
+    for (const re of [
+      /yarn@([0-9]+\.[0-9]+\.[0-9]+)/g,
+      /yarn-([0-9]+\.[0-9]+\.[0-9]+)\.cjs/g,
+      /yarn set version ([0-9]+\.[0-9]+\.[0-9]+)/g,
+    ]) {
+      let match;
+      while ((match = re.exec(text))) found.add(match[1]);
+    }
+    if (found.size) pins.push({ path: full, versions: [...found].sort() });
+  });
+  return { releases, pins };
+}
+
+function bumpText(content, fromVersions, toVersion) {
+  const fromAlt = fromVersions.map(escapeRegExp).join('|');
+  let next = content;
+  next = next.replace(
+    new RegExp(`yarn-(?:${fromAlt})\\.cjs`, 'g'),
+    `yarn-${toVersion}.cjs`,
+  );
+  next = next.replace(
+    new RegExp(`"packageManager":\\s*"yarn@(?:${fromAlt})"`, 'g'),
+    `"packageManager": "yarn@${toVersion}"`,
+  );
+  // Corepack form with integrity suffix
+  next = next.replace(
+    new RegExp(`"packageManager":\\s*"yarn@(?:${fromAlt})\\+[^"]+"`, 'g'),
+    `"packageManager": "yarn@${toVersion}"`,
+  );
+  next = next.replace(
+    new RegExp(`yarn set version (?:${fromAlt})\\b`, 'g'),
+    `yarn set version ${toVersion}`,
+  );
+  return next;
+}
+
+function bumpRoot(root, { from, to, binaryPath, dryRun, refreshLocks }) {
+  const summary = {
+    root,
+    binariesReplaced: [],
+    filesUpdated: [],
+    skippedReleases: [],
+    remaining: [],
+    lockRefresh: [],
+  };
+
+  const fromSet = new Set(from);
+  const newName = `yarn-${to}.cjs`;
+
+  // 1) binaries
+  walk(root, (full, basename) => {
+    const m = /^yarn-([0-9]+\.[0-9]+\.[0-9]+)\.cjs$/.exec(basename);
+    if (!m || !full.includes(`${path.sep}.yarn${path.sep}releases${path.sep}`)) return;
+    const ver = m[1];
+    if (!fromSet.has(ver)) {
+      if (ver !== to) summary.skippedReleases.push({ path: full, version: ver });
+      return;
+    }
+    const dest = path.join(path.dirname(full), newName);
+    summary.binariesReplaced.push({ from: full, to: dest, version: ver });
+    if (dryRun) return;
+    fs.copyFileSync(binaryPath, dest);
+    if (path.resolve(full) !== path.resolve(dest)) fs.unlinkSync(full);
+  });
+
+  // Ensure each releases dir that got a new binary (or still needs one after delete) is ok —
+  // also place binary when yarnPath points at missing to-version under a dir we touched via text.
+  // 2) text pins
+  const lockCandidateDirs = new Set();
+  walk(root, (full, basename) => {
+    if (!isTextCandidate(full, basename)) return;
+    let text;
+    try {
+      text = fs.readFileSync(full, 'utf8');
+    } catch {
+      return;
+    }
+    if (text.length > 2_000_000) return;
+    const next = bumpText(text, from, to);
+    if (next === text) return;
+    summary.filesUpdated.push(full);
+    if (basename === 'package.json' || basename === '.yarnrc.yml') {
+      lockCandidateDirs.add(path.dirname(full));
+    }
+    if (!dryRun) fs.writeFileSync(full, next);
+  });
+
+  for (const b of summary.binariesReplaced) {
+    // …/.yarn/releases/yarn-X.cjs → workspace root
+    lockCandidateDirs.add(path.dirname(path.dirname(path.dirname(b.to))));
+  }
+
+  // 3) remaining inventory (from-set only) — skip on dry-run (tree unchanged)
+  if (!dryRun) {
+    const after = scanRoot(root);
+    for (const r of after.releases) {
+      if (fromSet.has(r.version)) summary.remaining.push(`release ${r.version}: ${r.path}`);
+    }
+    for (const p of after.pins) {
+      const leftover = p.versions.filter((v) => fromSet.has(v));
+      if (leftover.length) summary.remaining.push(`${leftover.join(',')}: ${p.path}`);
+    }
+  }
+
+  // 4) lock refresh (default on; --no-refresh-locks to skip)
+  if (refreshLocks && !dryRun) {
+    for (const dir of [...lockCandidateDirs].sort()) {
+      const lock = path.join(dir, 'yarn.lock');
+      if (!fs.existsSync(lock)) continue;
+      // Prefer local yarnPath binary if present
+      let yarnBin = binaryPath;
+      const local = path.join(dir, '.yarn', 'releases', newName);
+      if (fs.existsSync(local)) yarnBin = local;
+      else {
+        // walk up a few levels for a releases binary
+        let cur = dir;
+        for (let i = 0; i < 6; i += 1) {
+          const candidate = path.join(cur, '.yarn', 'releases', newName);
+          if (fs.existsSync(candidate)) {
+            yarnBin = candidate;
+            break;
+          }
+          const parent = path.dirname(cur);
+          if (parent === cur) break;
+          cur = parent;
+        }
+      }
+      console.log(`refresh-locks: ${dir}`);
+      const r = spawnSync(
+        process.execPath,
+        [yarnBin, 'install', '--mode=skip-build'],
+        {
+          cwd: dir,
+          encoding: 'utf8',
+          env: { ...process.env, YARN_ENABLE_IMMUTABLE_INSTALLS: 'false' },
+          stdio: ['ignore', 'pipe', 'pipe'],
+        },
+      );
+      summary.lockRefresh.push({
+        dir,
+        status: r.status,
+        stderr: (r.stderr || '').split('\n').slice(-5).join('\n'),
+      });
+      if (r.status !== 0) {
+        console.error(`warn: yarn install failed in ${dir} (exit ${r.status})`);
+      }
+    }
+  }
+
+  return summary;
+}
+
+function printScan(root) {
+  const { releases, pins } = scanRoot(root);
+  const byVer = new Map();
+  for (const r of releases) {
+    byVer.set(r.version, (byVer.get(r.version) || 0) + 1);
+  }
+  console.log(`\n=== scan ${root} ===`);
+  console.log('releases:');
+  for (const [v, n] of [...byVer.entries()].sort()) console.log(`  yarn-${v}.cjs × ${n}`);
+  if (!releases.length) console.log('  (none)');
+  console.log('text pins (packageManager / yarnPath / yarn set version):');
+  const pinByVer = new Map();
+  for (const p of pins) {
+    for (const v of p.versions) pinByVer.set(v, (pinByVer.get(v) || 0) + 1);
+  }
+  for (const [v, n] of [...pinByVer.entries()].sort()) console.log(`  ${v} × ${n} files`);
+  if (!pins.length) console.log('  (none)');
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (args.fetchOnly) {
+    if (!args.to) {
+      console.error('--fetch-only requires --to');
+      usage(1);
+    }
+    await ensureBinary(args.to, { force: true });
+    return;
+  }
+
+  if (!args.roots.length) {
+    console.error('Provide at least one --root PATH');
+    usage(1);
+  }
+  for (const root of args.roots) {
+    if (!fs.existsSync(root)) {
+      console.error(`Missing root: ${root}`);
+      process.exit(1);
+    }
+  }
+
+  if (args.scan) {
+    for (const root of args.roots) printScan(root);
+    return;
+  }
+
+  if (!args.to) {
+    console.error('--to VERSION is required (unless --scan)');
+    usage(1);
+  }
+  if (!args.from.length) {
+    console.error('--from must list at least one version');
+    usage(1);
+  }
+
+  const binaryPath = await ensureBinary(args.to);
+  console.log(`to: ${args.to}`);
+  console.log(`from: ${args.from.join(', ')}`);
+  console.log(`dry-run: ${args.dryRun}`);
+  console.log(`refresh-locks: ${args.refreshLocks}`);
+
+  let failed = false;
+  for (const root of args.roots) {
+    const summary = bumpRoot(root, {
+      from: args.from,
+      to: args.to,
+      binaryPath,
+      dryRun: args.dryRun,
+      refreshLocks: args.refreshLocks,
+    });
+    console.log(`\n=== ${args.dryRun ? 'dry-run ' : ''}bump ${root} ===`);
+    console.log(`binaries: ${summary.binariesReplaced.length}`);
+    for (const b of summary.binariesReplaced.slice(0, 30)) {
+      console.log(`  ${b.version} → ${b.to}`);
+    }
+    if (summary.binariesReplaced.length > 30) {
+      console.log(`  … +${summary.binariesReplaced.length - 30} more`);
+    }
+    const relFiles = summary.filesUpdated
+      .map((f) => path.relative(root, f))
+      .sort();
+    console.log(`files: ${relFiles.length}`);
+    for (const f of relFiles) console.log(`  ${f}`);
+    if (summary.skippedReleases.length) {
+      console.log(`left alone (not in --from):`);
+      const counts = new Map();
+      for (const s of summary.skippedReleases) {
+        counts.set(s.version, (counts.get(s.version) || 0) + 1);
+      }
+      for (const [v, n] of [...counts.entries()].sort()) console.log(`  yarn-${v}.cjs × ${n}`);
+    }
+    if (summary.remaining.length) {
+      failed = true;
+      console.log('REMAINING from-versions (unexpected):');
+      for (const line of summary.remaining) console.log(`  ${line}`);
+    } else {
+      console.log('remaining from-versions: none');
+    }
+    if (summary.lockRefresh.length) {
+      const bad = summary.lockRefresh.filter((x) => x.status !== 0);
+      console.log(`lock refresh: ${summary.lockRefresh.length} dirs (${bad.length} failed)`);
+      if (bad.length) failed = true;
+    }
+  }
+
+  if (failed) process.exit(2);
+}
+
+main().catch((err) => {
+  console.error(err.stack || err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add `rhdh-bump-yarn` skill + `scripts/bump-yarn.js` to bump Yarn Berry (binaries, yarnPath/packageManager/Containerfile pins) across rhdh-plugins, rhdh, overlays, rhdh downstream, and rhdh-plugin-catalog
- Default refreshes `yarn.lock` via `yarn install --mode=skip-build` (opt out with `--no-refresh-locks`)
- Document the skill in README under a new Yarn section

## Test plan
- [ ] `node skills/rhdh-bump-yarn/scripts/bump-yarn.js --help`
- [ ] `--scan --root <repo>` on at least one checkout
- [ ] `--dry-run --to 4.17.1 --root <repo>` shows expected binaries/files
- [ ] Optional: real bump on a throwaway clone with/without `--no-refresh-locks`

Generated-by: cursor

Ref: https://redhat.atlassian.net/browse/RHIDP-16074
