### PR TITLE
feat(skills): add rhdh-plugin-midstream-propagate three-step chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ Manage plugins in the [rhdh-plugin-export-overlays](https://github.com/redhat-de
 
 - **[overlay](./skills/overlay/SKILL.md)** — Onboard new plugins, update versions, fix CI failures, triage and analyze PRs, trigger `/publish`. Covers both plugin-owner and core-team workflows.
 
+### Plugin midstream propagate
+
+Move a published `rhdh-plugins` workspace bump through overlays into catalog midstream (surgical MR preferred over full `sync-midstream.sh --force-clone`).
+
+- **[rhdh-plugin-midstream-propagate](./skills/rhdh-plugin-midstream-propagate/SKILL.md)** — (1) rhdh-plugins change + changeset → wait for Version Packages + npm, (2) overlays `source.json` → Version Packages SHA + metadata, (3) catalog `overlay-repo/` + `workspaces/` + `.tekton` PLR tags (`2.0.0--0.0.3`). See [catalog-surgical-update](./skills/rhdh-plugin-midstream-propagate/references/catalog-surgical-update.md).
+
+```bash
+npx skills add redhat-developer/rhdh-skill --skill rhdh-plugin-midstream-propagate
+```
+
 ### Konflux / Tekton
 
 Update Konflux task digests and apply `MIGRATION.md` pipeline changes in [rhdh-plugin-catalog](https://gitlab.cee.redhat.com/rhidp/rhdh-plugin-catalog) or [rhdh](https://gitlab.cee.redhat.com/rhidp/rhdh) midstream.

--- a/skills/konflux-tekton-updates/SKILL.md
+++ b/skills/konflux-tekton-updates/SKILL.md
@@ -25,8 +25,8 @@ After a **minor** Konflux task tag bump, update `.tekton` pipelines and generato
 | `updateDigests.sh` | `--no-push` / `--nopush` (`-p`) | Commit locally; no push/PR |
 | `updateDigests.sh` | `--minor` | Disables push; use with `--no-push` for clarity |
 | `updateDigests.sh` | `--no-commit` / `-n` | Preview only |
-| `generatePipelineRunsForPlugins.sh` | `--nopush` | Commit locally; no push |
-| `generatePipelineRunsForPlugins.sh` | `--nocommit` | Write YAML only |
+| `updatePLRs.sh` | `--nopush` | Commit locally; no push |
+| `updatePLRs.sh` | `--nocommit` | Write YAML only |
 
 `generatePipelineRuns.sh` does not commit or push.
 
@@ -36,7 +36,7 @@ After a **minor** Konflux task tag bump, update `.tekton` pipelines and generato
 
 | Marker in repo | Read |
 |----------------|------|
-| `.tekton/generatePipelineRunsForPlugins.sh` | [references/plugin-catalog.md](references/plugin-catalog.md) |
+| `.tekton/updatePLRs.sh` | [references/plugin-catalog.md](references/plugin-catalog.md) |
 | `.tekton-templates/rhdh-pipeline.yaml` | [references/rhdh-midstream.md](references/rhdh-midstream.md) — **variant A** (unified) |
 | `.tekton-templates/rhdh-hub.yaml` (no `rhdh-pipeline.yaml`) | [references/rhdh-midstream.md](references/rhdh-midstream.md) — **variant B** (1.9 shared build-pipeline) |
 
@@ -118,4 +118,4 @@ Use live `MIGRATION.md` as source of truth. Common cases:
 - Editing only PLRs when templates or `build-pipeline-*.yaml` are the source of truth.
 - Adding `verify_*` guards that fail on the next Konflux bump.
 - Dropping `image-expires-after` from PLRs only because `build-image-index` no longer uses it.
-- Hardcoding `1-` in `generatePipelineRunsForPlugins.sh` Containerfile comments; use `${RHDH_XY_VERSION}` so `1.10.0` becomes `1-10`, not `1`.
+- Hardcoding `1-` in `updatePLRs.sh` Containerfile comments; use `${RHDH_XY_VERSION}` so `1.10.0` becomes `1-10`, not `1`.

--- a/skills/konflux-tekton-updates/references/plugin-catalog.md
+++ b/skills/konflux-tekton-updates/references/plugin-catalog.md
@@ -9,7 +9,7 @@
 | `.tekton/plugin-catalog-builder-*-{push,pull}.yaml` | Inline `pipelineSpec` (catalog builder) |
 | `.tekton/*-push.yaml` (many components) | Usually `spec.params` only when migration adds pipeline params |
 | `.tekton/*-pull.yaml` | Same when present |
-| `.tekton/generatePipelineRunsForPlugins.sh` | Heredoc for regenerated PLRs + `*.Containerfile` |
+| `.tekton/updatePLRs.sh` | Heredoc for regenerated PLRs + `*.Containerfile` |
 | `.tekton/updateToStableBranch.py` | Version renames only — not Konflux migrations |
 
 Plugin PLRs with `pipelineRef: oci-plugin-build-pipeline` inherit task wiring from the shared pipeline; add PLR `spec.params` when migrations require explicit pipeline parameters.
@@ -18,7 +18,7 @@ Plugin PLRs with `pipelineRef: oci-plugin-build-pipeline` inherit task wiring fr
 
 ```bash
 cd .tekton
-./generatePipelineRunsForPlugins.sh -v <x.y.z> --nopush
+./updatePLRs.sh -v <x.y.z> --nopush
 ```
 
 ## Generator: new pipeline params
@@ -34,7 +34,7 @@ Do not embed full `pipelineSpec` in the generator.
 
 ## Version naming (x.y.z → x-y)
 
-`generatePipelineRunsForPlugins.sh` derives `RHDH_XY_VERSION` from `-v x.y.z` (e.g. `1.10.0` → `1-10`). Use it everywhere; never hardcode `1-` in generated paths.
+`updatePLRs.sh` derives `RHDH_XY_VERSION` from `-v x.y.z` (e.g. `1.10.0` → `1-10`). Use it everywhere; never hardcode `1-` in generated paths.
 
 | Pattern | Example for 1.10.0 |
 |---------|-------------------|

--- a/skills/rhdh-plugin-midstream-propagate/SKILL.md
+++ b/skills/rhdh-plugin-midstream-propagate/SKILL.md
@@ -24,13 +24,13 @@ Prefer a **surgical** catalog MR over `build/ci/sync-midstream.sh --force-clone 
 
 | Step | Repo | Config key |
 |------|------|------------|
-| 1 | [`redhat-developer/rhdh-plugins`](https://github.com/redhat-developer/rhdh-plugins) | `plugins` |
-| 2 | [`redhat-developer/rhdh-plugin-export-overlays`](https://github.com/redhat-developer/rhdh-plugin-export-overlays) | `overlay` |
-| 3 | [`gitlab.cee.redhat.com/rhidp/rhdh-plugin-catalog`](https://gitlab.cee.redhat.com/rhidp/rhdh-plugin-catalog) | `catalog` |
+| 1 | [`redhat-developer/rhdh-plugins`](https://github.com/redhat-developer/rhdh-plugins) | `repos.plugins` |
+| 2 | [`redhat-developer/rhdh-plugin-export-overlays`](https://github.com/redhat-developer/rhdh-plugin-export-overlays) | `repos.overlay` |
+| 3 | [`gitlab.cee.redhat.com/rhidp/rhdh-plugin-catalog`](https://gitlab.cee.redhat.com/rhidp/rhdh-plugin-catalog) | `repos.catalog` |
 
-Resolve checkouts via `$RHDH config get <key>` when set. Use `glab` against **`gitlab.cee.redhat.com`** for catalog MRs (not `gitlab.com`).
+Resolve checkouts with `$RHDH --json config get repos.<key> | jq -r '.data.value'` (dot-notation; see [`references/catalog-surgical-update.md`](references/catalog-surgical-update.md)). Use `glab` against **`gitlab.cee.redhat.com`** for catalog MRs (not `gitlab.com`).
 
-Confirm a Jira key before opening PRs/MRs; use `jira-pr-mr-web-link` / `create-pr-mr.js`.
+Confirm a Jira key before opening PRs/MRs. Prefer [`jira-pr-mr-link`](../jira-pr-mr-link/SKILL.md) / `scripts/create-pr-mr.js` when that skill is installed; otherwise `gh`/`glab` plus [`raise-pr`](../raise-pr/SKILL.md) remotelink.
 
 ---
 
@@ -50,41 +50,31 @@ After npm is live, follow [Metadata synchronization](https://github.com/redhat-d
 
 Merge the overlays PR before catalog work. Catalog midstream must target overlays `main` (or your release branch) after this lands.
 
-**Note:** [`overlay` update-plugin](../overlay/workflows/update-plugin.md) covers generic `source.json` bumps; this propagate chain requires the Version Packages SHA specifically.
+**Note:** [`overlay` update-plugin](../overlay/workflows/update-plugin.md) covers generic `source.json` bumps; this propagate chain requires the Version Packages SHA specifically. Prefer this skill over update-plugin when the ask mentions Version Packages, promote-to-catalog, or midstream.
 
 ---
 
 ## Step 3 — catalog surgical midstream MR
 
-**Read** [`references/catalog-surgical-update.md`](references/catalog-surgical-update.md) before editing.
+**Read** [`references/catalog-surgical-update.md`](references/catalog-surgical-update.md) before editing (SSOT for paths, config capture, PLR regen, and scoped sync flags).
 
 Goal: same file set `sync-midstream.sh --force-clone '<ws>'` would refresh for **one** workspace, without cloning every workspace.
 
 ### Preferred (surgical)
 
 1. Sync `overlay-repo/workspaces/<ws>/` from overlays main (`source.json`, `plugins-list.yaml`, `metadata/`, overlays/patches if present).
-2. Apply upstream deltas at `$SHA` into `workspaces/<ws>/` — at minimum `package.json`, `yarn.lock`, and any plugin `package.json` version bumps; expand to plugin sources when the Version Packages change is not lock/metadata-only.
+2. Apply upstream deltas at `$SHA` into `workspaces/<ws>/` — at minimum root `package.json` / `yarn.lock` (the tree that owns the lockfile) and any plugin `package.json` version bumps; expand to plugin sources when the Version Packages change is not lock/metadata-only. Do not apply lock/resolution pins only under `plugins/<name>/`.
 3. Align `plugin_builds/<ws>/*.json` `registryReference` tags (`quay.io/rhdh/...:<rhdh>--<pluginVer>`, e.g. `2.0.0--0.0.3`).
 4. Bump associated `.tekton/` PLRs / Containerfiles:
    - `konflux.additional-tags` → `<xy>--<ver>,<x.y.z>--<ver>` (e.g. `2.0--0.0.3,2.0.0--0.0.3`)
    - `DESCRIPTION` plugin version fragment
    - `UPSTREAM_REPO` overlays tree SHA when known
-   - Or regenerate with `.tekton/generatePipelineRunsForPlugins.sh -v <rhdh> --path '<ws>/plugins/<plugin>'` / `--package` (after `package.json` versions are updated).
-5. Open a catalog MR via `create-pr-mr.js` (CEE GitLab). Cite sibling package versions in the body.
+   - Or regenerate via `.tekton/updatePLRs.sh` (see reference: nested `--path '<ws>/plugins/<plugin>'` vs flat `--package`; gate on `source.json` `repo-flat`). Basic full-stream regen: [`konflux-tekton-updates`](../konflux-tekton-updates/references/plugin-catalog.md).
+5. Open a catalog MR via `create-pr-mr.js` or `glab` (CEE GitLab). Cite sibling package versions in the body.
 
 ### Fallback (scoped sync)
 
-When export / annotations / `update-workspace.js` transforms are required:
-
-```bash
-# From catalog checkout — still scope to one workspace; do not --always-clone
-./build/ci/sync-midstream.sh --debug --no --nopush \
-  --force-clone '<ws>' \
-  --skip-clone 'workspaces/'
-# Review diff, then commit / open MR yourself
-```
-
-`--force-clone` alone still walks every `source.json`; pair with skip/force so only the target workspace is re-cloned. Prefer surgical when the delta is known (pin, lock, versions).
+When export / annotations / `update-workspace.js` transforms are required, use the command in [`references/catalog-surgical-update.md`](references/catalog-surgical-update.md#scoped-sync-midstream-fallback) (do not invent alternate flag sets here). Prefer surgical when the delta is known (pin, lock, versions).
 
 ---
 
@@ -94,7 +84,7 @@ When export / annotations / `update-workspace.js` transforms are required:
 - [ ] npm packages published; `gitHead` == Version Packages SHA
 - [ ] overlays `repo-ref` + metadata versions/OCI tags updated and merged
 - [ ] catalog `overlay-repo/workspaces/<ws>/` matches overlays
-- [ ] catalog `workspaces/<ws>/` reflects `$SHA` (lock/resolutions/versions as needed)
+- [ ] catalog `workspaces/<ws>/` reflects `$SHA` at the yarn.lock-owning root (lock/resolutions/versions as needed)
 - [ ] `plugin_builds/` + `.tekton/` tags match new plugin versions (`x.y.z--<pluginVer>`)
 - [ ] Catalog MR on CEE GitLab; Jira linked
 
@@ -104,4 +94,4 @@ When export / annotations / `update-workspace.js` transforms are required:
 |------|----------|
 | 1 | rhdh-plugins fix + changeset → Version Packages → `@…/app-defaults@0.0.3` (`gitHead` `18f4229…`) |
 | 2 | overlays PR bumping `workspaces/app-defaults/source.json` + metadata |
-| 3 | catalog MR syncing `overlay-repo/…/app-defaults` + workspace lock pin (surgical; no `--force-clone`) |
+| 3 | catalog MR syncing `overlay-repo/…/app-defaults` + workspace **root** lock pin (surgical; no `--force-clone`) |

--- a/skills/rhdh-plugin-midstream-propagate/SKILL.md
+++ b/skills/rhdh-plugin-midstream-propagate/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: rhdh-plugin-midstream-propagate
+description: >-
+  Propagates an rhdh-plugins workspace change through overlays and
+  rhdh-plugin-catalog (midstream): changeset + npm publish, overlays source.json
+  to the Version Packages SHA, then a surgical catalog MR (overlay-repo/,
+  workspaces/, plugin_builds/, .tekton PLR tags like 2.0.0--0.0.3) without a full
+  sync-midstream --force-clone. Use when promoting plugin versions, waiting on
+  npm @red-hat-developer-hub packages, bumping overlays repo-ref, or midstream
+  Hermeto/lock/PLR updates for one workspace.
+---
+
+# RHDH plugin → overlays → catalog propagate
+
+Three-step chain after a fix or feature in [`redhat-developer/rhdh-plugins`](https://github.com/redhat-developer/rhdh-plugins):
+
+1. Update **rhdh-plugins** with the change, including a **changeset**; wait until merged and new package(s) are published to npmjs.com (e.g. [`@red-hat-developer-hub/backstage-plugin-app-defaults`](https://www.npmjs.com/package/@red-hat-developer-hub/backstage-plugin-app-defaults) `0.0.3` and other packages published at the same time).
+2. Update the **overlays** repo (`rhdh-plugin-export-overlays`) to fetch the commit SHA for the **Version Packages** PR related to the above change.
+3. Grab the specific changes from that SHA and push them into **rhdh-plugin-catalog**, updating `overlay-repo/`, `workspaces/`, and other paths that `sync-midstream.sh` would touch for a full clone of **just that workspace**; open an MR that applies the updated files and bumps associated PLR(s) in `.tekton/` to the appropriate tags (e.g. `2.0.0--0.0.3`).
+
+Prefer a **surgical** catalog MR over `build/ci/sync-midstream.sh --force-clone <workspace>` (minutes vs a long full re-clone/export). Fall back to scoped `--force-clone` only when export / `plugin_builds` annotations / workspace transform must be regenerated.
+
+## Repos and config
+
+| Step | Repo | Config key |
+|------|------|------------|
+| 1 | [`redhat-developer/rhdh-plugins`](https://github.com/redhat-developer/rhdh-plugins) | `plugins` |
+| 2 | [`redhat-developer/rhdh-plugin-export-overlays`](https://github.com/redhat-developer/rhdh-plugin-export-overlays) | `overlay` |
+| 3 | [`gitlab.cee.redhat.com/rhidp/rhdh-plugin-catalog`](https://gitlab.cee.redhat.com/rhidp/rhdh-plugin-catalog) | `catalog` |
+
+Resolve checkouts via `$RHDH config get <key>` when set. Use `glab` against **`gitlab.cee.redhat.com`** for catalog MRs (not `gitlab.com`).
+
+Confirm a Jira key before opening PRs/MRs; use `jira-pr-mr-web-link` / `create-pr-mr.js`.
+
+---
+
+## Step 1 — rhdh-plugins (+ changeset → npm)
+
+1. Implement the change in `workspaces/<ws>/` (resolutions, sources, lock refresh as needed).
+2. Add a **changeset** under `workspaces/<ws>/.changeset/` so Changesets opens a **Version Packages** PR. A merge without a changeset will not bump/publish packages.
+3. Open/merge the fix PR, then wait for the bot **Version Packages** PR to merge.
+4. Confirm npm publish for every package in that release:
+
+```bash
+npm view @red-hat-developer-hub/backstage-plugin-<name> version
+npm view @red-hat-developer-hub/backstage-plugin-<name>@<ver> gitHead
+# Sibling packages often publish together — list from the Version Packages PR / changeset
+```
+
+Gate: npm versions match the Version Packages bump; `gitHead` equals the Version Packages merge commit SHA.
+
+Optional: chain [`raise-pr`](../raise-pr/SKILL.md) for build/changeset/PR on rhdh-plugins.
+
+---
+
+## Step 2 — overlays (`source.json` → Version Packages SHA)
+
+After npm is live:
+
+1. Resolve SHA (prefer npm `gitHead`; cross-check Version Packages merge commit):
+
+```bash
+SHA=$(npm view @red-hat-developer-hub/backstage-plugin-<name>@<ver> gitHead)
+gh pr view <version-packages-pr> --repo redhat-developer/rhdh-plugins \
+  --json mergeCommit --jq .mergeCommit.oid
+```
+
+2. In overlays `workspaces/<ws>/`:
+   - Set `source.json` `repo-ref` to that full SHA.
+   - Keep `repo-backstage-version` aligned with upstream at that commit.
+   - Bump `metadata/*.yaml` `spec.version` and `dynamicArtifact` OCI tags (`bs_<bs>__<pluginVer>`) for every package published in the same Version Packages PR.
+
+3. Open/merge the overlays PR. Catalog midstream must wait until this lands on overlays `main` (or the release branch you target).
+
+See [`overlay` update-plugin](../overlay/workflows/update-plugin.md) for the generic source.json pattern; this skill requires the SHA to be the **Version Packages** commit (not the earlier fix commit).
+
+---
+
+## Step 3 — catalog surgical midstream MR
+
+**Read** [`references/catalog-surgical-update.md`](references/catalog-surgical-update.md) before editing.
+
+Goal: same file set `sync-midstream.sh --force-clone '<ws>'` would refresh for **one** workspace, without cloning every workspace.
+
+### Preferred (surgical)
+
+1. Sync `overlay-repo/workspaces/<ws>/` from overlays main (`source.json`, `plugins-list.yaml`, `metadata/`, overlays/patches if present).
+2. Apply upstream deltas at `$SHA` into `workspaces/<ws>/` — at minimum `package.json`, `yarn.lock`, and any plugin `package.json` version bumps; expand to plugin sources when the Version Packages change is not lock/metadata-only.
+3. Align `plugin_builds/<ws>/*.json` `registryReference` tags (`quay.io/rhdh/...:<rhdh>--<pluginVer>`, e.g. `2.0.0--0.0.3`).
+4. Bump associated `.tekton/` PLRs / Containerfiles:
+   - `konflux.additional-tags` → `<xy>--<ver>,<x.y.z>--<ver>` (e.g. `2.0--0.0.3,2.0.0--0.0.3`)
+   - `DESCRIPTION` plugin version fragment
+   - `UPSTREAM_REPO` overlays tree SHA when known
+   - Or regenerate with `.tekton/generatePipelineRunsForPlugins.sh -v <rhdh> --path '<ws>/plugins/<plugin>'` / `--package` (after `package.json` versions are updated).
+5. Open a catalog MR via `create-pr-mr.js` (CEE GitLab). Cite sibling package versions in the body.
+
+### Fallback (scoped sync)
+
+When export / annotations / `update-workspace.js` transforms are required:
+
+```bash
+# From catalog checkout — still scope to one workspace; do not --always-clone
+./build/ci/sync-midstream.sh --debug --no --nopush \
+  --force-clone '<ws>' \
+  --skip-clone 'workspaces/'
+# Review diff, then commit / open MR yourself
+```
+
+`--force-clone` alone still walks every `source.json`; pair with skip/force so only the target workspace is re-cloned. Prefer surgical when the delta is known (pin, lock, versions).
+
+---
+
+## Checklist
+
+- [ ] rhdh-plugins change includes a changeset; Version Packages merged
+- [ ] npm packages published; `gitHead` == Version Packages SHA
+- [ ] overlays `repo-ref` + metadata versions/OCI tags updated and merged
+- [ ] catalog `overlay-repo/workspaces/<ws>/` matches overlays
+- [ ] catalog `workspaces/<ws>/` reflects `$SHA` (lock/resolutions/versions as needed)
+- [ ] `plugin_builds/` + `.tekton/` tags match new plugin versions (`x.y.z--<pluginVer>`)
+- [ ] Catalog MR on CEE GitLab; Jira linked
+
+## Example (RHIDP-16097 / app-defaults)
+
+| Step | Artifact |
+|------|----------|
+| 1 | rhdh-plugins fix + changeset → Version Packages → `@…/app-defaults@0.0.3` (`gitHead` `18f4229…`) |
+| 2 | overlays PR bumping `workspaces/app-defaults/source.json` + metadata |
+| 3 | catalog MR syncing `overlay-repo/…/app-defaults` + workspace lock pin (surgical; no `--force-clone`) |

--- a/skills/rhdh-plugin-midstream-propagate/SKILL.md
+++ b/skills/rhdh-plugin-midstream-propagate/SKILL.md
@@ -36,18 +36,9 @@ Confirm a Jira key before opening PRs/MRs; use `jira-pr-mr-web-link` / `create-p
 
 ## Step 1 — rhdh-plugins (+ changeset → npm)
 
-1. Implement the change in `workspaces/<ws>/` (resolutions, sources, lock refresh as needed).
-2. Add a **changeset** under `workspaces/<ws>/.changeset/` so Changesets opens a **Version Packages** PR. A merge without a changeset will not bump/publish packages.
-3. Open/merge the fix PR, then wait for the bot **Version Packages** PR to merge.
-4. Confirm npm publish for every package in that release:
+Follow [Creating changesets](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets): land the fix with a changeset, merge the bot **Version Packages** PR, and wait until every package in that release is on npmjs.com.
 
-```bash
-npm view @red-hat-developer-hub/backstage-plugin-<name> version
-npm view @red-hat-developer-hub/backstage-plugin-<name>@<ver> gitHead
-# Sibling packages often publish together — list from the Version Packages PR / changeset
-```
-
-Gate: npm versions match the Version Packages bump; `gitHead` equals the Version Packages merge commit SHA.
+**Gate before Step 2:** published npm versions match the Version Packages bump; `npm view <pkg>@<ver> gitHead` equals the Version Packages merge SHA.
 
 Optional: chain [`raise-pr`](../raise-pr/SKILL.md) for build/changeset/PR on rhdh-plugins.
 
@@ -55,24 +46,11 @@ Optional: chain [`raise-pr`](../raise-pr/SKILL.md) for build/changeset/PR on rhd
 
 ## Step 2 — overlays (`source.json` → Version Packages SHA)
 
-After npm is live:
+After npm is live, follow [Metadata synchronization](https://github.com/redhat-developer/rhdh-plugin-export-overlays/blob/main/user-guide/04-metadata-synchronization.md) in `workspaces/<ws>/`: set `source.json` `repo-ref` to the **Version Packages** merge SHA (not the earlier fix commit), align `repo-backstage-version`, and bump `metadata/*.yaml` versions and `dynamicArtifact` OCI tags for every package published in the same release.
 
-1. Resolve SHA (prefer npm `gitHead`; cross-check Version Packages merge commit):
+Merge the overlays PR before catalog work. Catalog midstream must target overlays `main` (or your release branch) after this lands.
 
-```bash
-SHA=$(npm view @red-hat-developer-hub/backstage-plugin-<name>@<ver> gitHead)
-gh pr view <version-packages-pr> --repo redhat-developer/rhdh-plugins \
-  --json mergeCommit --jq .mergeCommit.oid
-```
-
-2. In overlays `workspaces/<ws>/`:
-   - Set `source.json` `repo-ref` to that full SHA.
-   - Keep `repo-backstage-version` aligned with upstream at that commit.
-   - Bump `metadata/*.yaml` `spec.version` and `dynamicArtifact` OCI tags (`bs_<bs>__<pluginVer>`) for every package published in the same Version Packages PR.
-
-3. Open/merge the overlays PR. Catalog midstream must wait until this lands on overlays `main` (or the release branch you target).
-
-See [`overlay` update-plugin](../overlay/workflows/update-plugin.md) for the generic source.json pattern; this skill requires the SHA to be the **Version Packages** commit (not the earlier fix commit).
+**Note:** [`overlay` update-plugin](../overlay/workflows/update-plugin.md) covers generic `source.json` bumps; this propagate chain requires the Version Packages SHA specifically.
 
 ---
 

--- a/skills/rhdh-plugin-midstream-propagate/references/catalog-surgical-update.md
+++ b/skills/rhdh-plugin-midstream-propagate/references/catalog-surgical-update.md
@@ -19,12 +19,13 @@ Root overlay files (`overlay-repo/versions.json`, package lists) change only whe
 
 ## Sync overlay-repo slice
 
-From a local overlays checkout on the merged branch:
+From a local overlays checkout on the merged branch. Resolve paths with **dot-notation** keys and JSON (shorthand like `overlay` works for `config set` only; bare `$($RHDH config get overlay)` captures a JSON blob or errors):
 
 ```bash
 WS=app-defaults
-OVERLAY="$($RHDH config get overlay)"   # or absolute path
-CATALOG="$($RHDH config get catalog)"
+OVERLAY="$($RHDH --json config get repos.overlay | jq -r '.data.value')"
+CATALOG="$($RHDH --json config get repos.catalog | jq -r '.data.value')"
+# Or set OVERLAY=/CATALOG to absolute checkouts if config is unset
 
 mkdir -p "$CATALOG/overlay-repo/workspaces/$WS"
 cp -a "$OVERLAY/workspaces/$WS/source.json" \
@@ -44,7 +45,7 @@ Resolve `SHA` from npm `gitHead` / Version Packages merge.
 **Lock / resolutions / package versions only** (common for pins):
 
 1. Diff upstream `workspaces/<ws>/{package.json,yarn.lock}` and plugin `package.json` files between catalog’s previous `repo-ref` and `$SHA`.
-2. Apply the same edits under `workspaces/<ws>/` (catalog may already have midstream transforms — preserve existing `update-workspace.js` outcomes; do not blindly overwrite the whole tree with a raw upstream sparse clone unless you re-run transforms).
+2. Apply the same edits under `workspaces/<ws>/` at the **workspace root that owns `yarn.lock`** (not under `plugins/<name>/` alone — that reintroduces the RHIDP-16097 pin footgun). Catalog may already have midstream transforms — preserve existing `update-workspace.js` outcomes; do not blindly overwrite the whole tree with a raw upstream sparse clone unless you re-run transforms.
 
 **Larger source churn:** prefer scoped sync (below) or sparse-checkout upstream at `$SHA`, copy plugin trees, then re-run the workspace transform/export pieces you need.
 
@@ -54,9 +55,18 @@ Verify Hermeto-sensitive pins:
 rg -n 'electron-to-chromium|resolutions' workspaces/<ws>/package.json workspaces/<ws>/yarn.lock
 ```
 
+## Nested vs flat workspaces
+
+Read `overlay-repo/workspaces/<ws>/source.json` `repo-flat`:
+
+| `repo-flat` | Layout | `pluginVersion` / generator path |
+|-------------|--------|----------------------------------|
+| `false` (nested) | `workspaces/<ws>/plugins/<name>/` | `plugins/<name>/package.json`; `--path '<ws>/plugins/<name>'` |
+| `true` (flat) | packages at workspace root | root / package `package.json`; prefer `--package '<name>'` (no `plugins/` segment) |
+
 ## PLR / Containerfile tag bumps
 
-Tag shape (from `.tekton/generatePipelineRunsForPlugins.sh`):
+Tag shape (from `.tekton/updatePLRs.sh`):
 
 ```text
 konflux.additional-tags="<xy>--<pluginVersion>,<x.y.z>--<pluginVersion>"
@@ -69,20 +79,22 @@ Also update:
 - `plugin_builds/.../registryReference` → `quay.io/rhdh/<image>:2.0.0--0.0.3`
 - Optional: `UPSTREAM_REPO="…/rhdh-plugin-export-overlays/tree/main @ <overlays-sha>"`
 
-`pluginVersion` comes from each plugin’s `workspaces/<ws>/plugins/<name>/package.json` `version` (same source the generator uses).
-
-Regenerate instead of hand-editing when many plugins in the workspace versioned together:
+For a simple full-stream regen, follow [`konflux-tekton-updates`](../../konflux-tekton-updates/references/plugin-catalog.md) (`-v <x.y.z> --nopush`). For a **scoped** regen after surgical version bumps, use flags from `.tekton/updatePLRs.sh --help` (they include `--next`, `--package`/`--path`, `--nopush`; do not invent others):
 
 ```bash
 cd "$CATALOG"
-.tekton/generatePipelineRunsForPlugins.sh -v 2.0.0 --next --nopush --clean \
+# nested example (repo-flat: false); drop --next unless targeting main/next stream
+.tekton/updatePLRs.sh -v 2.0.0 --next --nopush \
   --package 'app-defaults|app-auth|app-integrations'
 # or: --path 'app-defaults/plugins/app-defaults'
+# flat (repo-flat: true): use --package '<name>', not --path '.../plugins/...'
 ```
 
 Commit PLR churn with the midstream content change (or a follow-up commit on the same MR). Commit messages can include `[skip-gitlab]` to save running a full sync-midstream pipeline.
 
 ## Scoped sync-midstream fallback
+
+**SSOT for the fallback invocation** (SKILL.md links here — do not diverge):
 
 ```bash
 ./build/ci/sync-midstream.sh --nopush \
@@ -91,7 +103,9 @@ Commit PLR churn with the midstream content change (or a follow-up commit on the
 ```
 
 - `--nopush`: review locally; agent opens the MR.
+- Optional: `--no` / `--nocommit` to skip the local commit as well; `--debug` for verbose logs.
 - Full `--always-clone` is almost never wanted for a single-workspace promote.
+- `--force-clone` alone still walks every `source.json`; pair with skip/force so only the target workspace is re-cloned.
 
 ## Prior art
 

--- a/skills/rhdh-plugin-midstream-propagate/references/catalog-surgical-update.md
+++ b/skills/rhdh-plugin-midstream-propagate/references/catalog-surgical-update.md
@@ -1,0 +1,103 @@
+# Catalog surgical update (one workspace)
+
+How to approximate `sync-midstream.sh --force-clone '<ws>'` for a **single** workspace without a full midstream sync.
+
+## Paths sync-midstream touches (per workspace)
+
+| Path | Role |
+|------|------|
+| `overlay-repo/workspaces/<ws>/source.json` | Upstream repo + `repo-ref` SHA |
+| `overlay-repo/workspaces/<ws>/plugins-list.yaml` | Plugins to export |
+| `overlay-repo/workspaces/<ws>/metadata/*.yaml` | Package versions + OCI `dynamicArtifact` |
+| `overlay-repo/workspaces/<ws>/` overlays/patches | Applied onto clone when present |
+| `workspaces/<ws>/` | Sparse-ish clone of upstream at `repo-ref`, then transform/export |
+| `plugin_builds/<ws>/*.json` | `registryReference`, `io.backstage.dynamic-packages` |
+| `.tekton/rhdh-bsp-*-<stream>-push.{yaml,Containerfile}` | PLRs; tags from plugin `package.json` version |
+| `catalog-index/` | Usually regen only on full sync / index jobs — skip unless asked |
+
+Root overlay files (`overlay-repo/versions.json`, package lists) change only when overlays root changes — not required for a single-workspace version bump.
+
+## Sync overlay-repo slice
+
+From a local overlays checkout on the merged branch:
+
+```bash
+WS=app-defaults
+OVERLAY="$($RHDH config get overlay)"   # or absolute path
+CATALOG="$($RHDH config get catalog)"
+
+mkdir -p "$CATALOG/overlay-repo/workspaces/$WS"
+cp -a "$OVERLAY/workspaces/$WS/source.json" \
+      "$OVERLAY/workspaces/$WS/plugins-list.yaml" \
+      "$CATALOG/overlay-repo/workspaces/$WS/"
+rm -rf "$CATALOG/overlay-repo/workspaces/$WS/metadata"
+cp -a "$OVERLAY/workspaces/$WS/metadata" "$CATALOG/overlay-repo/workspaces/$WS/"
+# Also copy overlay/ / patches/ trees if the workspace has them
+```
+
+Or pull from GitHub `main` at the overlays merge SHA if no local checkout.
+
+## Apply upstream SHA into `workspaces/<ws>/`
+
+Resolve `SHA` from npm `gitHead` / Version Packages merge.
+
+**Lock / resolutions / package versions only** (common for pins):
+
+1. Diff upstream `workspaces/<ws>/{package.json,yarn.lock}` and plugin `package.json` files between catalog’s previous `repo-ref` and `$SHA`.
+2. Apply the same edits under `workspaces/<ws>/` (catalog may already have midstream transforms — preserve existing `update-workspace.js` outcomes; do not blindly overwrite the whole tree with a raw upstream sparse clone unless you re-run transforms).
+
+**Larger source churn:** prefer scoped sync (below) or sparse-checkout upstream at `$SHA`, copy plugin trees, then re-run the workspace transform/export pieces you need.
+
+Verify Hermeto-sensitive pins:
+
+```bash
+rg -n 'electron-to-chromium|resolutions' workspaces/<ws>/package.json workspaces/<ws>/yarn.lock
+```
+
+## PLR / Containerfile tag bumps
+
+Tag shape (from `.tekton/generatePipelineRunsForPlugins.sh`):
+
+```text
+konflux.additional-tags="<xy>--<pluginVersion>,<x.y.z>--<pluginVersion>"
+# e.g. 2.0--0.0.3,2.0.0--0.0.3
+```
+
+Also update:
+
+- `DESCRIPTION="… plugin <short-name> <pluginVersion>"`
+- `plugin_builds/.../registryReference` → `quay.io/rhdh/<image>:2.0.0--0.0.3`
+- Optional: `UPSTREAM_REPO="…/rhdh-plugin-export-overlays/tree/main @ <overlays-sha>"`
+
+`pluginVersion` comes from each plugin’s `workspaces/<ws>/plugins/<name>/package.json` `version` (same source the generator uses).
+
+Regenerate instead of hand-editing when many plugins in the workspace versioned together:
+
+```bash
+cd "$CATALOG"
+.tekton/generatePipelineRunsForPlugins.sh -v 2.0.0 --next --nopush --clean \
+  --package 'app-defaults|app-auth|app-integrations'
+# or: --path 'app-defaults/plugins/app-defaults'
+```
+
+Commit PLR churn with the midstream content change (or a follow-up commit on the same MR). Commit messages can include `[skip-gitlab]` to save running a full sync-midstream pipeline.
+
+## Scoped sync-midstream fallback
+
+```bash
+./build/ci/sync-midstream.sh --nopush \
+  --force-clone 'app-defaults' \
+  --skip-clone 'workspaces/'
+```
+
+- `--nopush`: review locally; agent opens the MR.
+- Full `--always-clone` is almost never wanted for a single-workspace promote.
+
+## Prior art
+
+| MR | Pattern |
+|----|---------|
+| [catalog !824](https://gitlab.cee.redhat.com/rhidp/rhdh-plugin-catalog/-/merge_requests/824) | Surgical overlay-repo sync + workspace lock pin (no force-clone) |
+| !806 / !762 | Same surgical pin style |
+
+When versions bump (not only a lock pin), include `plugin_builds` + `.tekton` tag updates in the same MR so Konflux retags `2.0.0--<new>`.

--- a/skills/rhdh/SKILL.md
+++ b/skills/rhdh/SKILL.md
@@ -216,6 +216,14 @@ What would you like to do?
 
 **To route:** Read `../backstage-upgrade/SKILL.md` and follow its intake process.
 
+### Midstream propagate Routes
+
+| Response | Skill |
+|----------|-------|
+| "propagate plugin", "Version Packages", "midstream sync", "surgical catalog", "bump overlays source.json", "plugin_builds PLR", "2.0.0--", "promote to catalog" | Route to `rhdh-plugin-midstream-propagate` skill |
+
+**To route:** Read `../rhdh-plugin-midstream-propagate/SKILL.md` and follow its three-step chain.
+
 ### General Routes
 
 | Response | Action |
@@ -359,6 +367,7 @@ Todos must be **self-contained**—a new session should understand the task with
 | Skill | Purpose | Path |
 |-------|---------|------|
 | overlay | Manage plugins in rhdh-plugin-export-overlays | `../overlay/SKILL.md` |
+| rhdh-plugin-midstream-propagate | Promote rhdh-plugins → overlays → catalog (npm, Version Packages SHA, surgical PLR bump) | `../rhdh-plugin-midstream-propagate/SKILL.md` |
 | create-plugin | Create, export, package, and wire RHDH dynamic plugins | `../create-plugin/SKILL.md` |
 | rhdh-local | Enable/disable/test plugins in local RHDH | `../rhdh-local/SKILL.md` |
 | rhdh-pr-review | PR code review and live cluster testing | `../rhdh-pr-review/SKILL.md` |

--- a/skills/rhdh/SKILL.md
+++ b/skills/rhdh/SKILL.md
@@ -152,13 +152,23 @@ What would you like to do?
 
 **Always check this first.**
 
+### Midstream propagate Routes
+
+Match these **before** Overlay routes. Broad overlay tokens (`"update"`, `"plugin"`, `"overlay"`) must not win when the ask is a Version Packages → catalog promote.
+
+| Response | Skill |
+|----------|-------|
+| "propagate plugin", "Version Packages", "midstream sync", "surgical catalog", "bump overlays source.json", "plugin_builds PLR", "2.0.0--", "promote to catalog" | Route to `rhdh-plugin-midstream-propagate` skill |
+
+**To route:** Read `../rhdh-plugin-midstream-propagate/SKILL.md` and follow its three-step chain.
+
 ### Overlay Repository Routes
 
 | Response | Skill |
 |----------|-------|
 | 1-5, "onboard", "update", "fix", "triage", "PR", "overlay", "plugin", "workspace" | Route to `@overlay` skill |
 
-**To route:** Read `../overlay/SKILL.md` and follow its intake process.
+**To route:** Read `../overlay/SKILL.md` and follow its intake process. If the request is promote / Version Packages SHA / catalog midstream, use Midstream propagate above instead of overlay `update-plugin`.
 
 ### Plugin Creation Routes
 
@@ -215,14 +225,6 @@ What would you like to do?
 | "upgrade backstage", "bump backstage", "update @backstage", "backstage version", "align deps", "versions:bump" | Route to `backstage-upgrade` skill |
 
 **To route:** Read `../backstage-upgrade/SKILL.md` and follow its intake process.
-
-### Midstream propagate Routes
-
-| Response | Skill |
-|----------|-------|
-| "propagate plugin", "Version Packages", "midstream sync", "surgical catalog", "bump overlays source.json", "plugin_builds PLR", "2.0.0--", "promote to catalog" | Route to `rhdh-plugin-midstream-propagate` skill |
-
-**To route:** Read `../rhdh-plugin-midstream-propagate/SKILL.md` and follow its three-step chain.
 
 ### General Routes
 


### PR DESCRIPTION
## Summary
- Add `rhdh-plugin-midstream-propagate` skill documenting the plugins → overlays → catalog promote chain (changeset/npm, Version Packages SHA, surgical catalog MR + PLR tags).
- Wire into README and `rhdh` skill routing/index; prefer surgical midstream over full `sync-midstream.sh --force-clone`.

Encodes the workflow from RHIDP-16097 (app-defaults pin promote) and complements midstream work around RHIDP-16074 (Yarn / catalog trees).

## Test plan
- [ ] Skill loads / description discovers for “Version Packages”, “midstream sync”, “promote to catalog”
- [ ] Paths in `references/catalog-surgical-update.md` match catalog layout

Ref: https://redhat.atlassian.net/browse/RHIDP-16097
Ref: https://redhat.atlassian.net/browse/RHIDP-16074

Generated-by: cursor
