### PR TITLE
Harden rhdh-pr-review draft craft and require humanizer

### DIFF
--- a/skills/rhdh-pr-review/SKILL.md
+++ b/skills/rhdh-pr-review/SKILL.md
@@ -68,7 +68,7 @@ For cluster testing: deploy the full PR bundle/manifests, not just the operator 
 | Response | Workflow |
 |----------|----------|
 | 1, "review", "review PR", "code review", a PR URL or number | `workflows/fetch-github.md` → `workflows/review-code.md` → `workflows/post-to-github.md` |
-| 2, "analyze", "analysis only", "review locally" | `workflows/fetch-github.md` → `workflows/review-code.md` (stop after findings) |
+| 2, "analyze", "analysis only", "review locally" | `workflows/fetch-github.md` → `workflows/review-code.md` (stop after humanized draft; no post) |
 | 3, "test", "cluster", "deploy", "operator PR", "test on cluster" | `workflows/fetch-github.md` → `workflows/review-operator-pr.md` |
 | 4, "full", "full review", "both" | `workflows/fetch-github.md` → `workflows/review-code.md` → `workflows/post-to-github.md` → `workflows/review-operator-pr.md` |
 
@@ -141,8 +141,8 @@ findings artifact
 ├── event: "COMMENT" | "APPROVE" | "REQUEST_CHANGES"
 └── findings[]
     ├── path, line, start_line
-    ├── type: "suggestion" | "question" | "observation"
-    └── body: "comment text"
+    ├── type: "question" | "observation" | "fix"
+    └── body: "comment text (optional GitHub suggestion fence when allowed)"
 ```
 
 </artifact_contracts>
@@ -173,11 +173,11 @@ findings artifact
 
 - [ ] PR context fetched (metadata, diff, linked issues, existing comments)
 - [ ] User asked which specialist skills (if any) to invoke; "None" accepted
-- [ ] Review perspectives chosen based on PR content
+- [ ] Review perspectives chosen after that ask (reference is a thin router, not auto-pick-only)
 - [ ] Findings verified against actual code at HEAD
-- [ ] False positives dropped with reasoning shown
+- [ ] False positives dropped; Step 3 inventory is triage labels only (not draft prose)
 - [ ] Humanizer gate passed (`setup.py --humanizer-only`); draft humanized before show-user
-- [ ] Review draft presented to user with event type choice (top-level = merge blockers, not inline roll-up)
+- [ ] Humanized review draft presented (top-level = merge blockers, not inline roll-up); event type asked only when posting
 - [ ] Review posted to forge (if posting route selected)
 
 ### Cluster testing

--- a/skills/rhdh-pr-review/SKILL.md
+++ b/skills/rhdh-pr-review/SKILL.md
@@ -24,8 +24,16 @@ Reviews follow a three-layer pipeline: **fetch** (forge-specific) → **analyze*
 Reviewers will produce false positives. Verify every finding against actual code at HEAD before including it. Drop findings that reference non-existent code, duplicate existing comments, misread the code, or conflict with codebase conventions.
 </principle>
 
+<principle name="draft_craft">
+Prefer inlines over top-level duplication. Top-level is for important merge blockers, not a roll-up of inlines. Guide, don't dictate — ask why before alternatives when design is unclear. Use GitHub `suggestion` blocks only for small, obvious one-hunk fixes. No performative praise.
+</principle>
+
+<principle name="humanizer_required">
+Every `review-code.md` draft path (including analysis-only) hard-requires the `humanizer` skill. Load `references/humanizer.md` → Humanizer prerequisite (`setup.py --humanizer-only`), then invoke humanizer on top-level + inlines before presenting the draft. Do not re-implement humanizer here.
+</principle>
+
 <principle name="user_confirms_before_posting">
-Present the full review draft — summary, inline comments with file:line, and event type — to the user before posting. Proceed only after confirmation.
+Present the full **humanized** review draft — summary, inline comments with file:line, and event type — to the user before posting. Proceed only after confirmation.
 </principle>
 
 <principle name="deploy_full_bundle">
@@ -79,6 +87,25 @@ When GitLab support is added: `fetch-gitlab.md` and `post-to-gitlab.md` will slo
 
 </routing>
 
+## Prerequisites
+
+Run `scripts/setup.py` to verify the humanizer skill is available:
+
+```bash
+python scripts/setup.py --humanizer-only --json
+```
+
+### Humanizer skill gate (all review-code drafts)
+
+Load `references/humanizer.md` → Humanizer prerequisite. Every `review-code.md` path (including analysis-only) hard-requires humanizer before presenting a draft. Full install dialogue and invoke criterion live only in `humanizer.md`. Cluster-testing-only routes that never draft review prose do not need this gate.
+
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `scripts/setup.py` | Detect humanizer skill. `--json` for structured output. `--humanizer-only` for the review-code draft gate (exit non-zero if humanizer missing). |
+| `scripts/fetch_pr_context.py` | Fetch GitHub PR context into the context artifact. |
+
 <artifact_contracts>
 
 ## Context artifact (fetch → analyze / cluster test)
@@ -124,7 +151,8 @@ findings artifact
 
 | Reference | Purpose | Load when... | Path |
 |-----------|---------|--------------|------|
-| review-perspectives | Review perspective examples and signal hints | Running `review-code.md` | `references/review-perspectives.md` |
+| humanizer | Humanizer prereq (SSOT) + invoke before show-user | Running `review-code.md` (any draft path) | `references/humanizer.md` |
+| review-perspectives | Perspective router; always ask which specialist skills | Running `review-code.md` | `references/review-perspectives.md` |
 | operator-pr-images | CI image extraction and validation | Running `review-operator-pr.md` | `references/operator-pr-images.md` |
 | github-reference | gh CLI patterns, PR queries | Running any GitHub workflow | `../rhdh/references/github-reference.md` (if available) |
 | rhdh-repos | RHDH ecosystem repository map | Cluster testing | `../rhdh/references/rhdh-repos.md` (if available) |
@@ -144,10 +172,12 @@ findings artifact
 ### Code review
 
 - [ ] PR context fetched (metadata, diff, linked issues, existing comments)
+- [ ] User asked which specialist skills (if any) to invoke; "None" accepted
 - [ ] Review perspectives chosen based on PR content
 - [ ] Findings verified against actual code at HEAD
 - [ ] False positives dropped with reasoning shown
-- [ ] Review draft presented to user with event type choice
+- [ ] Humanizer gate passed (`setup.py --humanizer-only`); draft humanized before show-user
+- [ ] Review draft presented to user with event type choice (top-level = merge blockers, not inline roll-up)
 - [ ] Review posted to forge (if posting route selected)
 
 ### Cluster testing

--- a/skills/rhdh-pr-review/references/humanizer.md
+++ b/skills/rhdh-pr-review/references/humanizer.md
@@ -9,7 +9,7 @@ Before drafting or presenting any review draft (top-level summary + inlines):
 1. Run `python scripts/setup.py --humanizer-only --json` and check `humanizer_found`.
 2. If missing: hard-stop. State that the `humanizer` skill is required before presenting review prose. Ask for confirmation, then install the minimal command from the setup output (`minimal_install`). Prefer recommending the recommended install when the user wants a fuller setup. Re-run the check. Continue only when `humanizer_found` is true.
 3. The setup script detects only — it does not install. Confirm + install are owned by this skill.
-4. Use `--humanizer-only` so the gate message stays humanizer-specific.
+4. Pass `--humanizer-only` (required by the CLI). This script only checks humanizer.
 
 ## When to invoke
 

--- a/skills/rhdh-pr-review/references/humanizer.md
+++ b/skills/rhdh-pr-review/references/humanizer.md
@@ -1,0 +1,22 @@
+# Humanizer Gate
+
+Shared prerequisite for every `review-code.md` draft path (including analysis-only). Do not re-implement humanizer here — invoke the installed skill.
+
+## Humanizer prerequisite
+
+Before drafting or presenting any review draft (top-level summary + inlines):
+
+1. Run `python scripts/setup.py --humanizer-only --json` and check `humanizer_found`.
+2. If missing: hard-stop. State that the `humanizer` skill is required before presenting review prose. Ask for confirmation, then install the minimal command from the setup output (`minimal_install`). Prefer recommending the recommended install when the user wants a fuller setup. Re-run the check. Continue only when `humanizer_found` is true.
+3. The setup script detects only — it does not install. Confirm + install are owned by this skill.
+4. Use `--humanizer-only` so the gate message stays humanizer-specific.
+
+## When to invoke
+
+After the review draft exists (top-level + inline bodies) and **before** presenting it to the user for event-type choice / confirmation:
+
+1. Invoke the installed `humanizer` skill (read its SKILL.md and follow it; `/humanizer` if the host supports slash-commands).
+2. Run it on **both** the top-level summary and every inline comment body.
+3. Present the humanized draft to the user — never show pre-humanizer prose as the draft.
+
+Applies to all `review-code.md` routes, including analysis-only (route 2). Cluster-testing-only routes that never draft review prose do not need this gate.

--- a/skills/rhdh-pr-review/references/review-perspectives.md
+++ b/skills/rhdh-pr-review/references/review-perspectives.md
@@ -1,6 +1,12 @@
 # Code Review Perspectives
 
-Examples of review perspectives and the signals that suggest them. These are starting points, not a fixed roster — choose perspectives that fit the PR's actual content. Invent new ones when the PR calls for it (e.g., devil's advocate, agile coach, skill expert, domain specialist).
+Thin router for review focus. Examples of perspectives and the signals that suggest them — starting points, not a fixed roster. Choose perspectives that fit the PR's actual content. Invent new ones when the PR calls for it.
+
+**Do not hardcode specialist skill names here.** Specialist domain knowledge lives in whatever skill the user names when asked.
+
+## Specialist skills (always ask)
+
+Early in the review — after fetch/context, before deep analysis — **always ask** the user which installed skills (if any) to invoke for this review. "None" is a valid answer. Then invoke only what they named; do not invent a default specialist list.
 
 ## Common perspectives
 

--- a/skills/rhdh-pr-review/scripts/setup.py
+++ b/skills/rhdh-pr-review/scripts/setup.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Detect the humanizer skill for rhdh-pr-review draft gates."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+MINIMAL_HUMANIZER_INSTALL = "npx skills@latest add blader/humanizer -g -y"
+RECOMMENDED_HUMANIZER_INSTALL = "npx skills@latest add blader/humanizer --global"
+HUMANIZER_SKILL_RELATIVE = Path("humanizer") / "SKILL.md"
+
+
+def humanizer_search_paths(home=None, cwd=None):
+    """Return candidate paths for humanizer/SKILL.md (user + project-local)."""
+    home = Path.home() if home is None else Path(home)
+    cwd = Path.cwd() if cwd is None else Path(cwd)
+    return [
+        home / ".claude" / "skills" / HUMANIZER_SKILL_RELATIVE,
+        home / ".agents" / "skills" / HUMANIZER_SKILL_RELATIVE,
+        home / ".cursor" / "skills" / HUMANIZER_SKILL_RELATIVE,
+        cwd / ".claude" / "skills" / HUMANIZER_SKILL_RELATIVE,
+        cwd / ".agents" / "skills" / HUMANIZER_SKILL_RELATIVE,
+        cwd / ".cursor" / "skills" / HUMANIZER_SKILL_RELATIVE,
+    ]
+
+
+def find_humanizer(home=None, cwd=None):
+    """Return the first existing humanizer/SKILL.md path, or None."""
+    for path in humanizer_search_paths(home=home, cwd=cwd):
+        if path.is_file():
+            return path.resolve()
+    return None
+
+
+def check_humanizer(home=None, cwd=None):
+    """Build a results dict for humanizer skill detection."""
+    found = find_humanizer(home=home, cwd=cwd)
+    return {
+        "humanizer_found": found is not None,
+        "humanizer_path": str(found) if found else None,
+        "minimal_install": MINIMAL_HUMANIZER_INSTALL,
+        "recommended_install": RECOMMENDED_HUMANIZER_INSTALL,
+        "overall": "pass" if found else "fail",
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description=(
+            "Detect the humanizer skill (required before presenting review drafts). "
+            "Use --humanizer-only from review-code paths."
+        )
+    )
+    parser.add_argument("--json", action="store_true", help="Output results as JSON")
+    parser.add_argument(
+        "--humanizer-only",
+        action="store_true",
+        help=(
+            "Only check for the humanizer skill. "
+            "Exit non-zero if humanizer is missing. Use this from review-code paths."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    if args.humanizer_only:
+        results = check_humanizer()
+        _output_humanizer(results, args.json)
+        sys.exit(0 if results["overall"] == "pass" else 1)
+
+    # Default mode: same detection as --humanizer-only (this skill has no other prereqs).
+    results = check_humanizer()
+    _output_humanizer(results, args.json)
+    sys.exit(0 if results["overall"] == "pass" else 1)
+
+
+def _output_humanizer(results, as_json):
+    """Print humanizer-only results in JSON or human-readable format."""
+    if as_json:
+        json.dump(results, sys.stdout, indent=2)
+        print()
+        return
+
+    print("=" * 50)
+    print("RHDH PR Review Humanizer Check")
+    print("=" * 50)
+    print()
+    print("Hard prerequisite for review-code drafts: the `humanizer` skill.")
+    print("Used to strip AI tells from top-level and inline review prose.")
+    print()
+
+    if results["humanizer_found"]:
+        print(f"  [PASS] humanizer found: {results['humanizer_path']}")
+    else:
+        print("  [FAIL] humanizer skill not found")
+        print("         Looked for humanizer/SKILL.md under:")
+        print("           ~/.claude/skills/")
+        print("           ~/.agents/skills/")
+        print("           ~/.cursor/skills/")
+        print("           <cwd>/.claude/skills/")
+        print("           <cwd>/.agents/skills/")
+        print("           <cwd>/.cursor/skills/")
+        print()
+        print("  Install (after user confirms — this script does not install):")
+        print(f"    Minimal (gate installs this): {results['minimal_install']}")
+        print(f"    Recommended: {results['recommended_install']}")
+
+    print()
+    print(f"Overall: {results['overall'].upper()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/rhdh-pr-review/scripts/setup.py
+++ b/skills/rhdh-pr-review/scripts/setup.py
@@ -49,26 +49,21 @@ def main(argv=None):
     parser = argparse.ArgumentParser(
         description=(
             "Detect the humanizer skill (required before presenting review drafts). "
-            "Use --humanizer-only from review-code paths."
+            "Pass --humanizer-only from review-code paths."
         )
     )
     parser.add_argument("--json", action="store_true", help="Output results as JSON")
     parser.add_argument(
         "--humanizer-only",
         action="store_true",
+        required=True,
         help=(
-            "Only check for the humanizer skill. "
+            "Check for the humanizer skill (required). "
             "Exit non-zero if humanizer is missing. Use this from review-code paths."
         ),
     )
     args = parser.parse_args(argv)
 
-    if args.humanizer_only:
-        results = check_humanizer()
-        _output_humanizer(results, args.json)
-        sys.exit(0 if results["overall"] == "pass" else 1)
-
-    # Default mode: same detection as --humanizer-only (this skill has no other prereqs).
     results = check_humanizer()
     _output_humanizer(results, args.json)
     sys.exit(0 if results["overall"] == "pass" else 1)

--- a/skills/rhdh-pr-review/workflows/review-code.md
+++ b/skills/rhdh-pr-review/workflows/review-code.md
@@ -2,21 +2,27 @@
 
 Platform-agnostic code analysis. Consumes a **context artifact** (from `fetch-github.md` or a future `fetch-gitlab.md`), produces a **findings artifact** consumed by a posting workflow.
 
-This workflow works primarily from the context artifact. The one exception is reading full file contents at HEAD to verify findings, which requires forge-specific commands (see Step 2).
+This workflow works primarily from the context artifact. The one exception is reading full file contents at HEAD to verify findings, which requires forge-specific commands (see Step 3).
 
 ## Mindset
 
 You are a senior team member reviewing a contribution. Your goal is to help the author ship confidently, not demonstrate expertise. Every comment should either prevent a real problem or teach something useful — if it does neither, don't leave it.
 
-## Step 1: Choose review perspectives
+## Step 0: Humanizer prerequisite
 
-Read `../references/review-perspectives.md` for examples of review perspectives and the signals that suggest them. Pick the perspectives that fit this PR — the reference is a starting point, not a mandatory checklist. Invent new perspectives when the PR calls for it.
+Load `../references/humanizer.md` and run the Humanizer prerequisite before drafting. Hard-stop until `humanizer_found` is true. This applies to every draft path, including analysis-only.
+
+## Step 1: Ask which specialist skills to invoke
+
+Read `../references/review-perspectives.md`. After fetch/context is available and **before deep analysis**, always ask the user which installed skills (if any) to invoke for this review. "None" is valid. Do not invent a hardcoded specialist roster — use whatever the user names, then follow those skills for domain knowledge.
+
+Also choose review perspectives from the reference (Correctness, Security, etc.) as a thin router. The reference is a starting point, not a mandatory checklist. Invent new perspectives when the PR calls for it.
 
 For small PRs, reviewing directly from a single perspective is often enough. For larger or more complex PRs, multiple perspectives help catch different classes of issues.
 
 ## Step 2: Analyze the diff
 
-Review the diff through each chosen perspective. When dispatching subagent reviewers, each receives:
+Review the diff through each chosen perspective (and any user-named specialist skills). When dispatching subagent reviewers, each receives:
 
 - The diff from the context artifact
 - Linked requirements (`linked_issues`)
@@ -55,25 +61,33 @@ Present verified findings and dropped findings (with reasoning) to the user befo
 
 The posted review should read like a person wrote it, not a report generator. The structured presentation in Step 3 helps the user decide what to include; the actual GitHub comments use a different voice.
 
+Prefer **inline comments** for findings. Put substance on the line; do not duplicate inline content in the top-level comment.
+
 ### Top-level comment
 
-Keep it short and direct — frame what the inline comments are about so the author knows the scope at a glance. Include a requirements coverage note if linked issues were checked. Skip performative praise; it reads as filler.
+Reserved for **important issues to resolve before merge** — not a summary or roll-up of the inlines. Do not restate what is already inline. A brief thanks is fine when needed. No performative praise.
 
-If `existing_reviews` shows you've already left a top-level comment on this PR, a new one is often unnecessary — consider posting only the inline findings. A follow-up summary is still warranted if the scope of feedback changed significantly or the prior review was on a different revision.
+If `existing_reviews` shows you've already left a top-level comment on this PR, a new one is often unnecessary — consider posting only the inline findings. A follow-up top-level is still warranted if there are new merge-blocking issues or the prior review was on a different revision.
 
 ### Inline comments
 
 Post one inline comment per finding worth raising — no artificial cap. Never leave a comment just to show you noticed something. Not every finding needs the same weight — substantial issues get a full comment, nits can be grouped into a single comment as one-liners.
 
-Write each comment as natural prose — a short paragraph explaining the issue and why it matters. Avoid bullet lists, bold headers, and over-structured formatting. Keep just enough information for the author to understand the problem and act on it. Code suggestions and code blocks are fine since they're functional, not formatting.
+Write each comment as natural prose — a short paragraph explaining the issue and why it matters. Avoid bullet lists, bold headers, and over-structured formatting.
 
-Assume deliberate choices. Ask why before suggesting alternatives. Explain reasoning only when the fix isn't obvious. Call out specific things done well when genuine — name the pattern or decision, not generic praise.
+**Guide, don't dictate.** Assume deliberate choices. When the design intent is unclear, ask why before proposing alternatives. Explain reasoning only when the fix isn't obvious.
 
-**If nothing significant survives verification**, that's a valid outcome. Produce a short approving review. Don't manufacture issues.
+**GitHub `suggestion` blocks:** use them **only** when the fix is small and obvious — one clear replacement hunk the author can apply as-is. Otherwise leave a question or guidance without a suggestion block.
+
+**If nothing significant survives verification**, that's a valid outcome. Produce a short approving review. Don't manufacture issues. Simple thanks is enough; no performative praise.
+
+### Humanize before show-user
+
+After drafting top-level + inlines, follow `../references/humanizer.md` → When to invoke. Run humanizer on the full draft, then present the humanized draft. Never show pre-humanizer prose as the review draft.
 
 ## Step 5: Choose event type
 
-Present the draft to the user and ask which event type to use:
+Present the **humanized** draft to the user and ask which event type to use:
 
 | Event | When |
 |-------|------|

--- a/skills/rhdh-pr-review/workflows/review-code.md
+++ b/skills/rhdh-pr-review/workflows/review-code.md
@@ -77,7 +77,7 @@ Post one inline comment per finding worth raising — no artificial cap. Never l
 
 Write each comment as natural prose — a short paragraph explaining the issue and why it matters. Avoid bullet lists, bold headers, and over-structured formatting.
 
-**Guide, don't dictate.** Assume deliberate choices. When the design intent is unclear, ask why before proposing alternatives. Explain reasoning only when the fix isn't obvious. Finding `type: "suggestion"` means "propose a direction," not "paste a patch" — still guide unless a GitHub `suggestion` block applies below.
+**Guide, don't dictate.** Assume deliberate choices. When the design intent is unclear, ask why before proposing alternatives. Explain reasoning only when the fix isn't obvious. Finding `type: "fix"` means "propose a direction," not "paste a patch" — still guide unless a GitHub `suggestion` block applies below.
 
 **GitHub `suggestion` blocks:** use them **only** when the fix is small and obvious — one clear replacement hunk the author can apply as-is. Otherwise leave a question or guidance without a `suggestion` block.
 

--- a/skills/rhdh-pr-review/workflows/review-code.md
+++ b/skills/rhdh-pr-review/workflows/review-code.md
@@ -55,11 +55,11 @@ Reviewers will produce false positives. Verify each finding against actual code 
 - Tested?
 - Anything from the issue's scope missing? (Author may be intentionally splitting work — note, don't block.)
 
-Present verified findings and dropped findings (with reasoning) to the user before drafting. Use a structured format here — categorized by type (suggestion, question, observation), with `file:line` references and short descriptions. This is for the user to scan and approve, not the final comment text.
+Present a **finding inventory** to the user before drafting: `file:line`, category (`question` / `observation` / `fix`), and a one-line label only. This is a triage list for what to include — **not** review prose and **not** the GitHub draft. Do not write full comment bodies here.
 
 ## Step 4: Draft the review
 
-The posted review should read like a person wrote it, not a report generator. The structured presentation in Step 3 helps the user decide what to include; the actual GitHub comments use a different voice.
+The posted review should read like a person wrote it, not a report generator. Step 3 only decides which findings to keep; this step writes the actual comments.
 
 Prefer **inline comments** for findings. Put substance on the line; do not duplicate inline content in the top-level comment.
 
@@ -69,31 +69,33 @@ Reserved for **important issues to resolve before merge** — not a summary or r
 
 If `existing_reviews` shows you've already left a top-level comment on this PR, a new one is often unnecessary — consider posting only the inline findings. A follow-up top-level is still warranted if there are new merge-blocking issues or the prior review was on a different revision.
 
+**If nothing significant survives verification:** draft a short approving top-level (thanks is enough). Don't manufacture issues.
+
 ### Inline comments
 
 Post one inline comment per finding worth raising — no artificial cap. Never leave a comment just to show you noticed something. Not every finding needs the same weight — substantial issues get a full comment, nits can be grouped into a single comment as one-liners.
 
 Write each comment as natural prose — a short paragraph explaining the issue and why it matters. Avoid bullet lists, bold headers, and over-structured formatting.
 
-**Guide, don't dictate.** Assume deliberate choices. When the design intent is unclear, ask why before proposing alternatives. Explain reasoning only when the fix isn't obvious.
+**Guide, don't dictate.** Assume deliberate choices. When the design intent is unclear, ask why before proposing alternatives. Explain reasoning only when the fix isn't obvious. Finding `type: "suggestion"` means "propose a direction," not "paste a patch" — still guide unless a GitHub `suggestion` block applies below.
 
-**GitHub `suggestion` blocks:** use them **only** when the fix is small and obvious — one clear replacement hunk the author can apply as-is. Otherwise leave a question or guidance without a suggestion block.
-
-**If nothing significant survives verification**, that's a valid outcome. Produce a short approving review. Don't manufacture issues. Simple thanks is enough; no performative praise.
+**GitHub `suggestion` blocks:** use them **only** when the fix is small and obvious — one clear replacement hunk the author can apply as-is. Otherwise leave a question or guidance without a `suggestion` block.
 
 ### Humanize before show-user
 
-After drafting top-level + inlines, follow `../references/humanizer.md` → When to invoke. Run humanizer on the full draft, then present the humanized draft. Never show pre-humanizer prose as the review draft.
+After drafting top-level + inlines, follow `../references/humanizer.md` → When to invoke. Run humanizer on the full draft, then present the humanized draft. Never show pre-humanizer prose as the review draft. Applies to posting and analysis-only routes.
 
 ## Step 5: Choose event type
 
-Present the **humanized** draft to the user and ask which event type to use:
+Present the **humanized** draft to the user. For posting routes, ask which event type to use:
 
 | Event | When |
 |-------|------|
 | `COMMENT` | Default. Feedback without a verdict. |
 | `APPROVE` | No issues, or only minor nits. |
 | `REQUEST_CHANGES` | Critical issues that must be fixed. Use sparingly. |
+
+For analysis-only (route 2), present the humanized draft and stop — no event type, no post.
 
 ## Findings artifact
 
@@ -111,8 +113,10 @@ findings artifact
     ├── path: "src/file.ts"
     ├── line: 42
     ├── start_line: null (or number for multi-line)
-    ├── type: "suggestion" | "question" | "observation"
-    └── body: "comment text, optionally with ```suggestion block"
+    ├── type: "question" | "observation" | "fix"
+    └── body: "comment text, optionally with ```suggestion block when allowed"
 ```
 
-**Do not post the review.** If the router selected a posting workflow, hand the findings artifact to it. If the router selected analysis-only (route 2), present the findings to the user and stop here.
+`type` is the finding kind for triage. A GitHub `suggestion` fence inside `body` is separate and only allowed for small obvious hunks (see Step 4).
+
+**Do not post the review.** If the router selected a posting workflow, hand the findings artifact to it. If analysis-only, stop after presenting the humanized draft (Step 5).

--- a/tests/unit/test_rhdh_pr_review_humanizer_setup.py
+++ b/tests/unit/test_rhdh_pr_review_humanizer_setup.py
@@ -197,3 +197,9 @@ def test_humanizer_only_human_output_includes_install_hints(setup_mod, monkeypat
     assert setup_mod.MINIMAL_HUMANIZER_INSTALL in out
     assert setup_mod.RECOMMENDED_HUMANIZER_INSTALL in out
     assert "does not install" in out
+
+
+def test_main_requires_humanizer_only_flag(setup_mod):
+    with pytest.raises(SystemExit) as exc:
+        setup_mod.main(["--json"])
+    assert exc.value.code == 2

--- a/tests/unit/test_rhdh_pr_review_humanizer_setup.py
+++ b/tests/unit/test_rhdh_pr_review_humanizer_setup.py
@@ -1,0 +1,199 @@
+"""Tests for humanizer skill detection in rhdh-pr-review setup.py."""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+SETUP = Path(__file__).parents[2] / "skills/rhdh-pr-review/scripts/setup.py"
+
+
+def load_setup():
+    spec = importlib.util.spec_from_file_location("rhdh_pr_review_setup", SETUP)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def setup_mod():
+    return load_setup()
+
+
+def _write_humanizer(base: Path) -> Path:
+    skill = base / "humanizer" / "SKILL.md"
+    skill.parent.mkdir(parents=True)
+    skill.write_text("# humanizer\n", encoding="utf-8")
+    return skill
+
+
+def test_humanizer_search_paths_order(setup_mod, tmp_path):
+    home = tmp_path / "home"
+    cwd = tmp_path / "cwd"
+    home.mkdir()
+    cwd.mkdir()
+    paths = setup_mod.humanizer_search_paths(home=home, cwd=cwd)
+    assert paths == [
+        home / ".claude" / "skills" / "humanizer" / "SKILL.md",
+        home / ".agents" / "skills" / "humanizer" / "SKILL.md",
+        home / ".cursor" / "skills" / "humanizer" / "SKILL.md",
+        cwd / ".claude" / "skills" / "humanizer" / "SKILL.md",
+        cwd / ".agents" / "skills" / "humanizer" / "SKILL.md",
+        cwd / ".cursor" / "skills" / "humanizer" / "SKILL.md",
+    ]
+
+
+def test_find_humanizer_missing(setup_mod, tmp_path):
+    home = tmp_path / "home"
+    cwd = tmp_path / "cwd"
+    home.mkdir()
+    cwd.mkdir()
+    assert setup_mod.find_humanizer(home=home, cwd=cwd) is None
+
+
+def test_find_humanizer_in_claude_skills(setup_mod, tmp_path):
+    home = tmp_path / "home"
+    cwd = tmp_path / "cwd"
+    home.mkdir()
+    cwd.mkdir()
+    expected = _write_humanizer(home / ".claude" / "skills")
+    found = setup_mod.find_humanizer(home=home, cwd=cwd)
+    assert found == expected.resolve()
+
+
+def test_find_humanizer_prefers_first_match(setup_mod, tmp_path):
+    home = tmp_path / "home"
+    cwd = tmp_path / "cwd"
+    home.mkdir()
+    cwd.mkdir()
+    first = _write_humanizer(home / ".claude" / "skills")
+    _write_humanizer(home / ".agents" / "skills")
+    found = setup_mod.find_humanizer(home=home, cwd=cwd)
+    assert found == first.resolve()
+
+
+def test_find_humanizer_project_local(setup_mod, tmp_path):
+    home = tmp_path / "home"
+    cwd = tmp_path / "cwd"
+    home.mkdir()
+    cwd.mkdir()
+    expected = _write_humanizer(cwd / ".agents" / "skills")
+    found = setup_mod.find_humanizer(home=home, cwd=cwd)
+    assert found == expected.resolve()
+
+
+def test_find_humanizer_cursor_skills(setup_mod, tmp_path):
+    home = tmp_path / "home"
+    cwd = tmp_path / "cwd"
+    home.mkdir()
+    cwd.mkdir()
+    expected = _write_humanizer(home / ".cursor" / "skills")
+    found = setup_mod.find_humanizer(home=home, cwd=cwd)
+    assert found == expected.resolve()
+
+
+def test_find_humanizer_project_local_cursor_skills(setup_mod, tmp_path):
+    home = tmp_path / "home"
+    cwd = tmp_path / "cwd"
+    home.mkdir()
+    cwd.mkdir()
+    expected = _write_humanizer(cwd / ".cursor" / "skills")
+    found = setup_mod.find_humanizer(home=home, cwd=cwd)
+    assert found == expected.resolve()
+
+
+def test_check_humanizer_pass_fields(setup_mod, tmp_path):
+    home = tmp_path / "home"
+    cwd = tmp_path / "cwd"
+    home.mkdir()
+    cwd.mkdir()
+    skill = _write_humanizer(home / ".cursor" / "skills")
+    results = setup_mod.check_humanizer(home=home, cwd=cwd)
+    assert results["humanizer_found"] is True
+    assert results["humanizer_path"] == str(skill.resolve())
+    assert results["overall"] == "pass"
+    assert "humanizer" in results["minimal_install"]
+    assert "blader/humanizer" in results["recommended_install"]
+
+
+def test_check_humanizer_fail_fields(setup_mod, tmp_path):
+    home = tmp_path / "home"
+    cwd = tmp_path / "cwd"
+    home.mkdir()
+    cwd.mkdir()
+    results = setup_mod.check_humanizer(home=home, cwd=cwd)
+    assert results["humanizer_found"] is False
+    assert results["humanizer_path"] is None
+    assert results["overall"] == "fail"
+    assert results["minimal_install"] == setup_mod.MINIMAL_HUMANIZER_INSTALL
+    assert results["recommended_install"] == setup_mod.RECOMMENDED_HUMANIZER_INSTALL
+
+
+def test_humanizer_only_main_exit_nonzero_when_missing(setup_mod, monkeypatch, capsys):
+    monkeypatch.setattr(
+        setup_mod,
+        "check_humanizer",
+        lambda home=None, cwd=None: {
+            "humanizer_found": False,
+            "humanizer_path": None,
+            "minimal_install": setup_mod.MINIMAL_HUMANIZER_INSTALL,
+            "recommended_install": setup_mod.RECOMMENDED_HUMANIZER_INSTALL,
+            "overall": "fail",
+        },
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        setup_mod.main(["--humanizer-only", "--json"])
+    assert exc.value.code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["humanizer_found"] is False
+    assert payload["overall"] == "fail"
+    assert payload["minimal_install"] == setup_mod.MINIMAL_HUMANIZER_INSTALL
+    assert payload["recommended_install"] == setup_mod.RECOMMENDED_HUMANIZER_INSTALL
+
+
+def test_humanizer_only_main_exit_zero_when_found(setup_mod, tmp_path, monkeypatch, capsys):
+    skill_path = str((tmp_path / "humanizer" / "SKILL.md").resolve())
+    monkeypatch.setattr(
+        setup_mod,
+        "check_humanizer",
+        lambda home=None, cwd=None: {
+            "humanizer_found": True,
+            "humanizer_path": skill_path,
+            "minimal_install": setup_mod.MINIMAL_HUMANIZER_INSTALL,
+            "recommended_install": setup_mod.RECOMMENDED_HUMANIZER_INSTALL,
+            "overall": "pass",
+        },
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        setup_mod.main(["--humanizer-only", "--json"])
+    assert exc.value.code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["humanizer_found"] is True
+    assert payload["humanizer_path"] == skill_path
+    assert payload["overall"] == "pass"
+
+
+def test_humanizer_only_human_output_includes_install_hints(setup_mod, monkeypatch, capsys):
+    monkeypatch.setattr(
+        setup_mod,
+        "check_humanizer",
+        lambda home=None, cwd=None: {
+            "humanizer_found": False,
+            "humanizer_path": None,
+            "minimal_install": setup_mod.MINIMAL_HUMANIZER_INSTALL,
+            "recommended_install": setup_mod.RECOMMENDED_HUMANIZER_INSTALL,
+            "overall": "fail",
+        },
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        setup_mod.main(["--humanizer-only"])
+    assert exc.value.code == 1
+    out = capsys.readouterr().out
+    assert "humanizer skill not found" in out
+    assert setup_mod.MINIMAL_HUMANIZER_INSTALL in out
+    assert setup_mod.RECOMMENDED_HUMANIZER_INSTALL in out
+    assert "does not install" in out


### PR DESCRIPTION
## Summary
- Tighten `rhdh-pr-review` draft craft: top-level for merge blockers only, prefer inlines, guide-don't-dictate, GitHub `suggestion` blocks only for small obvious hunks, no performative praise.
- Always ask early which specialist skills (if any) to invoke; perspectives stay a thin router with no hardcoded skill list.
- Hard-require the installed `humanizer` skill for every `review-code` draft (including analysis-only), via grilling-style `scripts/setup.py --humanizer-only` + `references/humanizer.md`.

## Test plan
- [ ] `uv run pytest tests/unit/test_rhdh_pr_review_humanizer_setup.py`
- [ ] `uv run pytest`
- [ ] `python skills/rhdh-pr-review/scripts/setup.py --humanizer-only --json` with/without humanizer installed
- [ ] Dry-run review-code on a small PR: confirm skills ask, inventory vs draft, humanize-before-show-user, analysis-only stops without event type


Made with [Cursor](https://cursor.com)