### PR TITLE
chore: rename project identity to rhdh-skills

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,8 +107,8 @@ jobs:
       - name: Build and smoke-test the standalone rhdh CLI
         run: |
           uv build
-          python -m venv /tmp/rhdh-skill-wheel
-          /tmp/rhdh-skill-wheel/bin/pip install dist/*.whl
-          /tmp/rhdh-skill-wheel/bin/rhdh --help
-          /tmp/rhdh-skill-wheel/bin/rhdh-local --help
-          /tmp/rhdh-skill-wheel/bin/rhdh local --help
+          python -m venv /tmp/rhdh-skills-wheel
+          /tmp/rhdh-skills-wheel/bin/pip install dist/*.whl
+          /tmp/rhdh-skills-wheel/bin/rhdh --help
+          /tmp/rhdh-skills-wheel/bin/rhdh-local --help
+          /tmp/rhdh-skills-wheel/bin/rhdh local --help

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ that preserve the skill interface.
 Changes to skill layout must retain established runtime locations unless an ADR
 explicitly changes them:
 
-- `~/.config/rhdh-skill/config.json`
+- `~/.config/rhdh-skills/config.json`
 - `.rhdh/worklog.jsonl`
 - `.rhdh/TODO.md`
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Install the pack and the three external skills it depends on. Each command opens
 the skills wizard, which asks where to put them:
 
 ```bash
-npx skills add redhat-developer/rhdh-skill --all
+npx skills add redhat-developer/rhdh-skills --all
 npx skills add mattpocock/skills --skill grilling
 npx skills add mattpocock/skills --skill handoff
 npx skills add blader/humanizer

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ See [ADR-0005](docs/adr/0005-one-skill-per-trigger-phrase.md),
 ## CLI and state
 
 - `rhdh` and `rhdh-local` are bundled wrappers, run from their skill directory.
-- Repository configuration lives at `~/.config/rhdh-skill/config.json`.
+- Repository configuration lives at `~/.config/rhdh-skills/config.json`.
 - Worklog and todo state lives under `.rhdh/`.
 - Cross-session handoff is not a pack feature; run `/handoff` when you need it.
 

--- a/docs/adr/0005-one-skill-per-trigger-phrase.md
+++ b/docs/adr/0005-one-skill-per-trigger-phrase.md
@@ -57,7 +57,7 @@ or reads its private files. Human-invoked skills are entry points for people and
 are never invoked by a model-invoked skill.
 
 Setup preserves the existing `rhdh` and `rhdh-local` CLI behaviour,
-`~/.config/rhdh-skill/config.json`, and worklog and todo locations.
+`~/.config/rhdh-skills/config.json`, and worklog and todo locations.
 `/setup-rhdh-skills` is the exclusive human setup router; a domain skill may detect
 a missing capability and name the setup command, but never installs, authenticates,
 or probes host skill directories itself.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "rhdh-skill"
+name = "rhdh-skills"
 version = "0.0.0"
 description = "Composable agent skills for Red Hat Developer Hub development and operations"
 readme = "README.md"

--- a/skills/ci/rhdh-base-images/workflows/update-base-images.md
+++ b/skills/ci/rhdh-base-images/workflows/update-base-images.md
@@ -46,7 +46,7 @@ Verify the target branch exists in each repo before running.
 **Execute** [scripts/base-images-and-rpms.sh](../scripts/base-images-and-rpms.sh); do not reimplement the workflow inline.
 
 ```bash
-SKILL=/path/to/installed/rhdh-base-images   # under 1-rhdh-skill checkout
+SKILL=/path/to/installed/rhdh-base-images   # under 1-rhdh-skills checkout
 chmod +x "${SKILL}/scripts/base-images-and-rpms.sh"
 
 # All three repos under a parent directory

--- a/skills/ci/rhdh-prow-jobs/scripts/analyze_coverage.py
+++ b/skills/ci/rhdh-prow-jobs/scripts/analyze_coverage.py
@@ -46,7 +46,7 @@ def _fetch_api(product_name):
     """Fetch lifecycle data directly from the Red Hat API (fallback)."""
     url = f"{LIFECYCLE_API_URL}?name={urllib.parse.quote_plus(product_name)}"
     req = urllib.request.Request(
-        url, headers={"Accept": "application/json", "User-Agent": "rhdh-skill"}
+        url, headers={"Accept": "application/json", "User-Agent": "rhdh-skills"}
     )
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:

--- a/skills/ci/rhdh-prow-jobs/scripts/rhdh_prow/openshift_release.py
+++ b/skills/ci/rhdh-prow-jobs/scripts/rhdh_prow/openshift_release.py
@@ -105,7 +105,7 @@ def fetch_yaml(filepath: str, root: Path | None, is_remote: bool) -> dict | None
     if is_remote:
         raw_url = f"https://raw.githubusercontent.com/{GITHUB_REPO}/HEAD/{filepath}"
         try:
-            req = urllib.request.Request(raw_url, headers={"User-Agent": "rhdh-skill"})
+            req = urllib.request.Request(raw_url, headers={"User-Agent": "rhdh-skills"})
             with urllib.request.urlopen(req, timeout=30) as resp:
                 return _yaml.load(resp.read().decode("utf-8"))
         except (urllib.error.URLError, OSError) as exc:

--- a/skills/ci/rhdh-prow-trigger/scripts/gangway_adapter.py
+++ b/skills/ci/rhdh-prow-trigger/scripts/gangway_adapter.py
@@ -53,7 +53,7 @@ class GangwayAdapter:
             headers={
                 "Authorization": f"Bearer {self._token()}",
                 "Content-Type": "application/json",
-                "User-Agent": "rhdh-skill",
+                "User-Agent": "rhdh-skills",
             },
             method=method,
         )

--- a/skills/ci/rhdh-prow-trigger/scripts/trigger_nightly_job.py
+++ b/skills/ci/rhdh-prow-trigger/scripts/trigger_nightly_job.py
@@ -87,7 +87,7 @@ def fetch_configured_jobs(repo: str) -> list[str]:
     entries. We extract job names ending in ``-nightly`` via regex.
     """
     url = f"https://prow.ci.openshift.org/configured-jobs/{repo}"
-    req = urllib.request.Request(url, headers={"User-Agent": "rhdh-skill"})
+    req = urllib.request.Request(url, headers={"User-Agent": "rhdh-skills"})
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:
             html = resp.read().decode("utf-8")
@@ -221,7 +221,7 @@ def _fetch_quay_tags(image_repo: str, like_filter: str) -> list[dict]:
         f"https://quay.io/api/v1/repository/{encoded_repo}/tag/"
         f"?limit=100&onlyActiveTags=true&filter_tag_name=like:{encoded_filter}"
     )
-    req = urllib.request.Request(url, headers={"User-Agent": "rhdh-skill"})
+    req = urllib.request.Request(url, headers={"User-Agent": "rhdh-skills"})
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:
             data = json.loads(resp.read().decode("utf-8"))

--- a/skills/meta/setup-rhdh-skills/assets/catalog.json
+++ b/skills/meta/setup-rhdh-skills/assets/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "pack": {
     "name": "RHDH complete",
-    "source": "redhat-developer/rhdh-skill",
+    "source": "redhat-developer/rhdh-skills",
     "url": null,
     "requiredExternalSkills": [
       {

--- a/skills/meta/setup-rhdh-skills/references/private-data.md
+++ b/skills/meta/setup-rhdh-skills/references/private-data.md
@@ -5,7 +5,7 @@ The internal repository contains Jira Rich Filter exports used for release coord
 1. Clone it into a user-selected workspace:
 
    ```bash
-   git clone git@gitlab.cee.redhat.com:rhidp/rhdh-skill-private-data.git
+   git clone git@gitlab.cee.redhat.com:rhidp/rhdh-skills-private-data.git
    ```
 
 2. Register the resolved checkout through the `rhdh` CLI, which keeps the same key names and

--- a/skills/meta/setup-rhdh-skills/references/repositories.md
+++ b/skills/meta/setup-rhdh-skills/references/repositories.md
@@ -1,7 +1,7 @@
 # Configure RHDH repositories
 
 Use `rhdh doctor --json` to inspect repository discovery. The preserved configuration precedence is
-environment override, project `.rhdh/config.json`, user `~/.config/rhdh-skill/config.json`, then
+environment override, project `.rhdh/config.json`, user `~/.config/rhdh-skills/config.json`, then
 bounded workspace discovery.
 
 For each missing repository:

--- a/skills/meta/setup-rhdh-skills/scripts/setup.py
+++ b/skills/meta/setup-rhdh-skills/scripts/setup.py
@@ -87,7 +87,8 @@ def setup_status(
             if (project_root / ".rhdh" / "config.json").is_file()
             else "missing",
             "userConfiguration": "present"
-            if (home / ".config" / "rhdh-skill" / "config.json").is_file()
+            if (home / ".config" / "rhdh-skills" / "config.json").is_file()
+            or (home / ".config" / "rhdh-skill" / "config.json").is_file()
             else "missing",
         },
     }

--- a/skills/meta/setup-rhdh-skills/scripts/setup.py
+++ b/skills/meta/setup-rhdh-skills/scripts/setup.py
@@ -88,7 +88,6 @@ def setup_status(
             else "missing",
             "userConfiguration": "present"
             if (home / ".config" / "rhdh-skills" / "config.json").is_file()
-            or (home / ".config" / "rhdh-skill" / "config.json").is_file()
             else "missing",
         },
     }

--- a/skills/plugins/rhdh-local/scripts/NOTICE
+++ b/skills/plugins/rhdh-local/scripts/NOTICE
@@ -8,7 +8,7 @@ Original work:
   Repository: https://github.com/benwilcock/rhdh-lab
   License: Apache License 2.0
 
-These scripts have been adapted and extended for use in the rhdh-skill project.
+These scripts have been adapted and extended for use in the rhdh-skills project.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use these files except in compliance with the License.

--- a/skills/plugins/rhdh-local/scripts/fetch-plugin-metadata.py
+++ b/skills/plugins/rhdh-local/scripts/fetch-plugin-metadata.py
@@ -293,7 +293,7 @@ def _parse_list(lines: list[str], idx: int, base_indent: int) -> tuple[list[Any]
 
 def _fetch(url: str) -> bytes:
     """Fetch *url* and return the response body bytes."""
-    req = urllib.request.Request(url, headers={"User-Agent": "rhdh-skill/0.1"})
+    req = urllib.request.Request(url, headers={"User-Agent": "rhdh-skills/0.1"})
     with urllib.request.urlopen(req, timeout=30) as resp:
         return resp.read()
 

--- a/skills/reference/rhdh-context/references/rhdh-repos.md
+++ b/skills/reference/rhdh-context/references/rhdh-repos.md
@@ -208,9 +208,9 @@ Reference of all RHDH-related repositories, what each one is used for, and how t
   - **Used by overlay workflows:** `rhdh-plugin-export-overlays` can use the factory container for local plugin builds.
 - **Key paths:** `Containerfile` (image definition)
 
-### rhdh-skill-private-data
+### rhdh-skills-private-data
 
-- **Upstream:** <https://gitlab.cee.redhat.com/rhidp/rhdh-skill-private-data>
+- **Upstream:** <https://gitlab.cee.redhat.com/rhidp/rhdh-skills-private-data>
 - **Description:** Jira Rich Filter exports and operational data used by RHDH skills. Contains exported Rich Filter JSON from the "RHIDP Operational" Jira Rich Filter managed by Matt Reid and Jasper Chui.
 - **Key concepts:**
   - **Rich Filter exports:** JSON exports from Jira Rich Filters that define project-scoped queries, component exclusion lists, team Cloud ID mappings, and queue definitions. Used by the `rhdh-release-status` skill to source JQL queries at runtime instead of hardcoding them.

--- a/skills/reference/rhdh-context/references/rhdh-repos.md
+++ b/skills/reference/rhdh-context/references/rhdh-repos.md
@@ -289,9 +289,9 @@ Reference of all RHDH-related repositories, what each one is used for, and how t
   - **Tags:** `latest` (production), `dev` (non-PR builds), `X.Y.Z` (immutable release), `<sha>` (debugging).
 - **Key paths:** `blueprints/` (infrastructure blueprints), `docs/` (GCP infrastructure and sandbox networking), plus the repository's Fullsend agent skill
 
-### rhdh-skill
+### rhdh-skills
 
-- **Upstream:** <https://github.com/redhat-developer/rhdh-skill>
+- **Upstream:** <https://github.com/redhat-developer/rhdh-skills>
 - **Description:** Composable agent-skill collection for RHDH development and operations. Published via the [Agent Skills](https://agentskills.io) open standard.
 - **Tech stack:** Python (stdlib-only CLIs), Bash, Claude Code skills
 - **Key concepts:**
@@ -302,7 +302,7 @@ Reference of all RHDH-related repositories, what each one is used for, and how t
 ### rhdh-users-skill-pack
 
 - **Upstream:** <https://github.com/redhat-developer/rhdh-users-skill-pack>
-- **Description:** Agent Skills for adopting and using RHDH effectively. Aimed at RHDH end-users (vs `rhdh-skill` which targets the development team). Published via the [Agent Skills](https://agentskills.io) open standard.
+- **Description:** Agent Skills for adopting and using RHDH effectively. Aimed at RHDH end-users (vs `rhdh-skills` which targets the development team). Published via the [Agent Skills](https://agentskills.io) open standard.
 - **Tech stack:** Python (stdlib-only CLIs), Bash, Claude Code skills
 - **Key concepts:**
   - **`rhdh-templates`:** Interactive authoring and validation for RHDH Software Templates — templatize existing repos, create from scratch, fix common gotchas, validate locally or against a running instance.
@@ -356,7 +356,7 @@ rhdh (enterprise distribution, github.com)
     |   +-- rhdh-fullsend (agent sandbox images & /fullsend skill)
     |
     +-- Agent skills:
-        +-- rhdh-skill (dev team skills — overlay, lifecycle, prow, etc.)
+        +-- rhdh-skills (dev team skills — overlay, lifecycle, prow, etc.)
         +-- rhdh-users-skill-pack (user skills — templates, upgrade helper)
 ```
 

--- a/skills/reference/rhdh-context/rhdh/__init__.py
+++ b/skills/reference/rhdh-context/rhdh/__init__.py
@@ -10,7 +10,7 @@ This package provides stable local interfaces for:
 from importlib.metadata import PackageNotFoundError, version
 
 try:
-    __version__ = version("rhdh-skill")
+    __version__ = version("rhdh-skills")
 except PackageNotFoundError:
     __version__ = "0.0.0"
 

--- a/skills/reference/rhdh-context/rhdh/cli.py
+++ b/skills/reference/rhdh-context/rhdh/cli.py
@@ -515,7 +515,7 @@ def cmd_doctor(fmt: OutputFormatter, _args: argparse.Namespace) -> int:
     checks.append({"name": "data_dir", "status": "info", "message": str(data_dir)})
     fmt.log_info(f"Data directory: {data_dir}")
     fmt.log_info("  (worklog.jsonl, TODO.md)")
-    fmt.log_info("  Override with RHDH_SKILL_DATA_DIR env var")
+    fmt.log_info("  Override with RHDH_SKILLS_DATA_DIR env var")
 
     # Summary
     fmt.header("Summary")

--- a/skills/reference/rhdh-context/rhdh/config.py
+++ b/skills/reference/rhdh-context/rhdh/config.py
@@ -23,13 +23,9 @@ from typing import Any, Optional
 PROJECT_CONFIG_DIR_NAME = ".rhdh"
 USER_CONFIG_DIR = Path.home() / ".config" / "rhdh-skills"
 USER_CONFIG_FILE = USER_CONFIG_DIR / "config.json"
-# Pre-rename path; load_user_config still reads it when the new file is absent.
-LEGACY_USER_CONFIG_DIR = Path.home() / ".config" / "rhdh-skill"
-LEGACY_USER_CONFIG_FILE = LEGACY_USER_CONFIG_DIR / "config.json"
 
 # Environment variable for data directory override
 DATA_DIR_ENV_VAR = "RHDH_SKILLS_DATA_DIR"
-LEGACY_DATA_DIR_ENV_VAR = "RHDH_SKILL_DATA_DIR"
 
 # Submodule repository definitions
 # Format: name -> {has_fork, required, config_key, description}
@@ -162,10 +158,9 @@ def get_data_dir() -> Path:
     Always centralizes data in one location to avoid scattering
     across different repos/worktrees.
 
-    Uses RHDH_SKILLS_DATA_DIR (or legacy RHDH_SKILL_DATA_DIR) if set,
-    otherwise ~/.config/rhdh-skills/.
+    Uses RHDH_SKILLS_DATA_DIR if set, otherwise ~/.config/rhdh-skills/.
     """
-    env_value = os.environ.get(DATA_DIR_ENV_VAR) or os.environ.get(LEGACY_DATA_DIR_ENV_VAR)
+    env_value = os.environ.get(DATA_DIR_ENV_VAR)
     if env_value:
         return Path(env_value)
     return USER_CONFIG_DIR
@@ -177,7 +172,7 @@ def get_project_config_path() -> Path:
 
 
 def get_user_config_path() -> Path:
-    """Get the canonical user config.json path (writes always use this)."""
+    """Get user config.json path."""
     return USER_CONFIG_FILE
 
 
@@ -312,15 +307,10 @@ def deep_merge(base: dict, override: dict) -> dict:
 def load_user_config() -> dict:
     """Load user config from ~/.config/rhdh-skills/config.json.
 
-    Falls back to the pre-rename ~/.config/rhdh-skill/config.json when the
-    canonical file is absent.
-
     Returns:
         Config dict, or empty dict if file doesn't exist.
     """
     config_path = get_user_config_path()
-    if not config_path.exists():
-        config_path = LEGACY_USER_CONFIG_FILE
     if not config_path.exists():
         return {}
     try:

--- a/skills/reference/rhdh-context/rhdh/config.py
+++ b/skills/reference/rhdh-context/rhdh/config.py
@@ -5,7 +5,7 @@ Layered configuration with project-local and user-global support.
 Config locations (highest to lowest priority):
 1. Environment variables (RHDH_OVERLAY_REPO, etc.)
 2. Project config (.rhdh/config.json in git root)
-3. User config (~/.config/rhdh/config.json)
+3. User config (~/.config/rhdh-skills/config.json)
 4. Auto-detection (../repo/ relative to skill install)
 
 Supports dot-notation keys (e.g., repos.overlay, user.name).
@@ -21,11 +21,15 @@ from typing import Any, Optional
 
 # Config directory names
 PROJECT_CONFIG_DIR_NAME = ".rhdh"
-USER_CONFIG_DIR = Path.home() / ".config" / "rhdh-skill"
+USER_CONFIG_DIR = Path.home() / ".config" / "rhdh-skills"
 USER_CONFIG_FILE = USER_CONFIG_DIR / "config.json"
+# Pre-rename path; load_user_config still reads it when the new file is absent.
+LEGACY_USER_CONFIG_DIR = Path.home() / ".config" / "rhdh-skill"
+LEGACY_USER_CONFIG_FILE = LEGACY_USER_CONFIG_DIR / "config.json"
 
 # Environment variable for data directory override
-DATA_DIR_ENV_VAR = "RHDH_SKILL_DATA_DIR"
+DATA_DIR_ENV_VAR = "RHDH_SKILLS_DATA_DIR"
+LEGACY_DATA_DIR_ENV_VAR = "RHDH_SKILL_DATA_DIR"
 
 # Submodule repository definitions
 # Format: name -> {has_fork, required, config_key, description}
@@ -109,13 +113,13 @@ SUBMODULE_REPOS: dict[str, dict] = {
         "description": "Upstream Backstage framework",
         "upstream_org": "backstage",
     },
-    "rhdh-skill-private-data": {
+    "rhdh-skills-private-data": {
         "has_fork": False,
         "required": False,
         "config_key": "private-data",
         "description": "Jira Rich Filter exports and operational data for RHDH skills",
         "upstream_host": "gitlab.cee.redhat.com",
-        "upstream_path": "rhidp/rhdh-skill-private-data",
+        "upstream_path": "rhidp/rhdh-skills-private-data",
     },
 }
 
@@ -158,9 +162,10 @@ def get_data_dir() -> Path:
     Always centralizes data in one location to avoid scattering
     across different repos/worktrees.
 
-    Uses RHDH_DATA_DIR env var if set, otherwise ~/.config/rhdh/.
+    Uses RHDH_SKILLS_DATA_DIR (or legacy RHDH_SKILL_DATA_DIR) if set,
+    otherwise ~/.config/rhdh-skills/.
     """
-    env_value = os.environ.get(DATA_DIR_ENV_VAR)
+    env_value = os.environ.get(DATA_DIR_ENV_VAR) or os.environ.get(LEGACY_DATA_DIR_ENV_VAR)
     if env_value:
         return Path(env_value)
     return USER_CONFIG_DIR
@@ -172,7 +177,7 @@ def get_project_config_path() -> Path:
 
 
 def get_user_config_path() -> Path:
-    """Get user config.json path."""
+    """Get the canonical user config.json path (writes always use this)."""
     return USER_CONFIG_FILE
 
 
@@ -305,12 +310,17 @@ def deep_merge(base: dict, override: dict) -> dict:
 
 
 def load_user_config() -> dict:
-    """Load user config from ~/.config/rhdh/config.json.
+    """Load user config from ~/.config/rhdh-skills/config.json.
+
+    Falls back to the pre-rename ~/.config/rhdh-skill/config.json when the
+    canonical file is absent.
 
     Returns:
         Config dict, or empty dict if file doesn't exist.
     """
     config_path = get_user_config_path()
+    if not config_path.exists():
+        config_path = LEGACY_USER_CONFIG_FILE
     if not config_path.exists():
         return {}
     try:

--- a/skills/release/rhdh-platform-lifecycle/scripts/check_eks_lifecycle.py
+++ b/skills/release/rhdh-platform-lifecycle/scripts/check_eks_lifecycle.py
@@ -33,7 +33,7 @@ CONFIG_DIR = "ci-operator/config/redhat-developer/rhdh"
 
 def fetch_text(url):
     """Fetch text content from a URL."""
-    req = urllib.request.Request(url, headers={"User-Agent": "rhdh-skill"})
+    req = urllib.request.Request(url, headers={"User-Agent": "rhdh-skills"})
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:
             return resp.read().decode("utf-8")

--- a/skills/release/rhdh-platform-lifecycle/scripts/rhdh_lifecycle/openshift_release.py
+++ b/skills/release/rhdh-platform-lifecycle/scripts/rhdh_lifecycle/openshift_release.py
@@ -105,7 +105,7 @@ def fetch_yaml(filepath: str, root: Path | None, is_remote: bool) -> dict | None
     if is_remote:
         raw_url = f"https://raw.githubusercontent.com/{GITHUB_REPO}/HEAD/{filepath}"
         try:
-            req = urllib.request.Request(raw_url, headers={"User-Agent": "rhdh-skill"})
+            req = urllib.request.Request(raw_url, headers={"User-Agent": "rhdh-skills"})
             with urllib.request.urlopen(req, timeout=30) as resp:
                 return _yaml.load(resp.read().decode("utf-8"))
         except (urllib.error.URLError, OSError) as exc:
@@ -129,7 +129,7 @@ def fetch_yaml_text(filepath: str, root: Path | None, is_remote: bool) -> str | 
     if is_remote:
         raw_url = f"https://raw.githubusercontent.com/{GITHUB_REPO}/HEAD/{filepath}"
         try:
-            req = urllib.request.Request(raw_url, headers={"User-Agent": "rhdh-skill"})
+            req = urllib.request.Request(raw_url, headers={"User-Agent": "rhdh-skills"})
             with urllib.request.urlopen(req, timeout=30) as resp:
                 return resp.read().decode("utf-8")
         except (urllib.error.URLError, OSError) as exc:

--- a/skills/release/rhdh-platform-lifecycle/scripts/rhdh_lifecycle/redhat.py
+++ b/skills/release/rhdh-platform-lifecycle/scripts/rhdh_lifecycle/redhat.py
@@ -58,7 +58,7 @@ def fetch_api(product_name):
     """
     url = f"{LIFECYCLE_API_URL}?name={urllib.parse.quote_plus(product_name)}"
     req = urllib.request.Request(
-        url, headers={"Accept": "application/json", "User-Agent": "rhdh-skill"}
+        url, headers={"Accept": "application/json", "User-Agent": "rhdh-skills"}
     )
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:

--- a/skills/release/rhdh-platform-lifecycle/scripts/rhdh_lifecycle/versions.py
+++ b/skills/release/rhdh-platform-lifecycle/scripts/rhdh_lifecycle/versions.py
@@ -18,7 +18,7 @@ def fetch_json(url):
 
     Returns the parsed JSON, or None on failure.
     """
-    req = urllib.request.Request(url, headers={"User-Agent": "rhdh-skill"})
+    req = urllib.request.Request(url, headers={"User-Agent": "rhdh-skills"})
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:
             return json.loads(resp.read().decode("utf-8"))

--- a/skills/release/rhdh-release-announce/scripts/rich_filter.py
+++ b/skills/release/rhdh-release-announce/scripts/rich_filter.py
@@ -51,10 +51,7 @@ def _configured_repo() -> Path | None:
     if env_path and Path(env_path).is_dir():
         return Path(env_path).resolve()
 
-    config_paths = [
-        Path.home() / ".config" / "rhdh-skills" / "config.json",
-        Path.home() / ".config" / "rhdh-skill" / "config.json",
-    ]
+    config_paths = [Path.home() / ".config" / "rhdh-skills" / "config.json"]
     try:
         result = subprocess.run(
             ["git", "rev-parse", "--show-toplevel"],

--- a/skills/release/rhdh-release-announce/scripts/rich_filter.py
+++ b/skills/release/rhdh-release-announce/scripts/rich_filter.py
@@ -51,7 +51,10 @@ def _configured_repo() -> Path | None:
     if env_path and Path(env_path).is_dir():
         return Path(env_path).resolve()
 
-    config_paths = [Path.home() / ".config" / "rhdh-skill" / "config.json"]
+    config_paths = [
+        Path.home() / ".config" / "rhdh-skills" / "config.json",
+        Path.home() / ".config" / "rhdh-skill" / "config.json",
+    ]
     try:
         result = subprocess.run(
             ["git", "rev-parse", "--show-toplevel"],

--- a/skills/release/rhdh-release-schedule/scripts/rich_filter.py
+++ b/skills/release/rhdh-release-schedule/scripts/rich_filter.py
@@ -51,10 +51,7 @@ def _configured_repo() -> Path | None:
     if env_path and Path(env_path).is_dir():
         return Path(env_path).resolve()
 
-    config_paths = [
-        Path.home() / ".config" / "rhdh-skills" / "config.json",
-        Path.home() / ".config" / "rhdh-skill" / "config.json",
-    ]
+    config_paths = [Path.home() / ".config" / "rhdh-skills" / "config.json"]
     try:
         result = subprocess.run(
             ["git", "rev-parse", "--show-toplevel"],

--- a/skills/release/rhdh-release-schedule/scripts/rich_filter.py
+++ b/skills/release/rhdh-release-schedule/scripts/rich_filter.py
@@ -51,7 +51,10 @@ def _configured_repo() -> Path | None:
     if env_path and Path(env_path).is_dir():
         return Path(env_path).resolve()
 
-    config_paths = [Path.home() / ".config" / "rhdh-skill" / "config.json"]
+    config_paths = [
+        Path.home() / ".config" / "rhdh-skills" / "config.json",
+        Path.home() / ".config" / "rhdh-skill" / "config.json",
+    ]
     try:
         result = subprocess.run(
             ["git", "rev-parse", "--show-toplevel"],

--- a/skills/release/rhdh-release-status/references/config.md
+++ b/skills/release/rhdh-release-status/references/config.md
@@ -20,7 +20,7 @@ Static configuration values for the RHDH Release Manager skill.
 
 The Rich Filter JSON is sourced from the "RHIDP Operational" Rich Filter in Jira, maintained by Matt Reid and Jasper Chui. It is required for freeze, demo/Test Day, post-freeze, release-note lifecycle, Scrum Team, and exported ad hoc queries.
 
-The repo is discovered via `rhdh.config.get_repo("private-data")`. Register it with `rhdh config set private-data /path/to/rhdh-skill-private-data`.
+The repo is discovered via `rhdh.config.get_repo("private-data")`. Register it with `rhdh config set private-data /path/to/rhdh-skills-private-data`.
 
 **Override:** Set `RHDH_RICH_FILTER_PATH=/path/to/file.json` to use a specific file.
 

--- a/skills/release/rhdh-release-status/scripts/rich_filter.py
+++ b/skills/release/rhdh-release-status/scripts/rich_filter.py
@@ -51,10 +51,7 @@ def _configured_repo() -> Path | None:
     if env_path and Path(env_path).is_dir():
         return Path(env_path).resolve()
 
-    config_paths = [
-        Path.home() / ".config" / "rhdh-skills" / "config.json",
-        Path.home() / ".config" / "rhdh-skill" / "config.json",
-    ]
+    config_paths = [Path.home() / ".config" / "rhdh-skills" / "config.json"]
     try:
         result = subprocess.run(
             ["git", "rev-parse", "--show-toplevel"],

--- a/skills/release/rhdh-release-status/scripts/rich_filter.py
+++ b/skills/release/rhdh-release-status/scripts/rich_filter.py
@@ -51,7 +51,10 @@ def _configured_repo() -> Path | None:
     if env_path and Path(env_path).is_dir():
         return Path(env_path).resolve()
 
-    config_paths = [Path.home() / ".config" / "rhdh-skill" / "config.json"]
+    config_paths = [
+        Path.home() / ".config" / "rhdh-skills" / "config.json",
+        Path.home() / ".config" / "rhdh-skill" / "config.json",
+    ]
     try:
         result = subprocess.run(
             ["git", "rev-parse", "--show-toplevel"],

--- a/skills/release/rhdh-release-teams/scripts/rich_filter.py
+++ b/skills/release/rhdh-release-teams/scripts/rich_filter.py
@@ -51,10 +51,7 @@ def _configured_repo() -> Path | None:
     if env_path and Path(env_path).is_dir():
         return Path(env_path).resolve()
 
-    config_paths = [
-        Path.home() / ".config" / "rhdh-skills" / "config.json",
-        Path.home() / ".config" / "rhdh-skill" / "config.json",
-    ]
+    config_paths = [Path.home() / ".config" / "rhdh-skills" / "config.json"]
     try:
         result = subprocess.run(
             ["git", "rev-parse", "--show-toplevel"],

--- a/skills/release/rhdh-release-teams/scripts/rich_filter.py
+++ b/skills/release/rhdh-release-teams/scripts/rich_filter.py
@@ -51,7 +51,10 @@ def _configured_repo() -> Path | None:
     if env_path and Path(env_path).is_dir():
         return Path(env_path).resolve()
 
-    config_paths = [Path.home() / ".config" / "rhdh-skill" / "config.json"]
+    config_paths = [
+        Path.home() / ".config" / "rhdh-skills" / "config.json",
+        Path.home() / ".config" / "rhdh-skill" / "config.json",
+    ]
     try:
         result = subprocess.run(
             ["git", "rev-parse", "--show-toplevel"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,14 +61,14 @@ def isolated_env(tmp_path, monkeypatch):
     """Create an isolated environment with temp directories.
 
     Sets up:
-    - Temporary data directory via RHDH_SKILL_DATA_DIR env var
-    - Temporary config directory (~/.config/rhdh-skill/)
+    - Temporary data directory via RHDH_SKILLS_DATA_DIR env var
+    - Temporary config directory (~/.config/rhdh-skills/)
     - Temporary project config directory (.rhdh/)
     - Isolated working directory
     - Mock HOME environment
     """
-    # Create temp user config/data dir (matches config.py: .config/rhdh-skill)
-    config_dir = tmp_path / ".config" / "rhdh-skill"
+    # Create temp user config/data dir (matches config.py: .config/rhdh-skills)
+    config_dir = tmp_path / ".config" / "rhdh-skills"
     config_dir.mkdir(parents=True)
 
     # Create temp project config dir
@@ -124,8 +124,8 @@ def isolated_env(tmp_path, monkeypatch):
     # Set HOME to temp dir so config goes there
     monkeypatch.setenv("HOME", str(tmp_path))
 
-    # Set RHDH_SKILL_DATA_DIR to isolate worklog/todo from user's real data
-    monkeypatch.setenv("RHDH_SKILL_DATA_DIR", str(config_dir))
+    # Set RHDH_SKILLS_DATA_DIR to isolate worklog/todo from user's real data
+    monkeypatch.setenv("RHDH_SKILLS_DATA_DIR", str(config_dir))
 
     # Clear any existing env overrides
     monkeypatch.delenv("RHDH_OVERLAY_REPO", raising=False)
@@ -179,7 +179,7 @@ def run_cli_python(*args, env=None, isolated_env=None):
     if isolated_env:
         new_home = Path(isolated_env["root"])
         # Patch user config paths
-        config_module.USER_CONFIG_DIR = new_home / ".config" / "rhdh-skill"
+        config_module.USER_CONFIG_DIR = new_home / ".config" / "rhdh-skills"
         config_module.USER_CONFIG_FILE = config_module.USER_CONFIG_DIR / "config.json"
 
     # Mock find_git_root to return isolated dir (prevents writes to real project)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-"""Shared pytest fixtures for rhdh-skill tests."""
+"""Shared pytest fixtures for rhdh-skills tests."""
 
 import json
 import os

--- a/tests/unit/test_scan_credentials.py
+++ b/tests/unit/test_scan_credentials.py
@@ -36,7 +36,7 @@ def scan_payload(tmp_path: Path, payload: object) -> tuple[int, dict]:
 def plan(**overrides: object) -> dict:
     """A minimal stated write, in the shape the gate presents to the user."""
     operation = {
-        "target": "redhat-developer/rhdh-skill#1",
+        "target": "redhat-developer/rhdh-skills#1",
         "command": "gh pr comment 1 --body 'ok'",
         "preview": {"commandOrRequest": {"body": "ok"}},
     }

--- a/tests/unit/test_setup_rhdh_skills.py
+++ b/tests/unit/test_setup_rhdh_skills.py
@@ -142,7 +142,7 @@ def test_install_plan_fallback_includes_the_repo_and_both_external_sources():
     assert result.returncode == 0, result.stderr or result.stdout
     operations = json.loads(result.stdout)["operations"]
     assert [operation["command"][3] for operation in operations] == [
-        "redhat-developer/rhdh-skill",
+        "redhat-developer/rhdh-skills",
         "blader/humanizer",
         "mattpocock/skills",
     ]

--- a/tests/unit/test_todo.py
+++ b/tests/unit/test_todo.py
@@ -8,11 +8,11 @@ import pytest
 
 @pytest.fixture
 def temp_config_dir(monkeypatch):
-    """Create a temporary data directory using RHDH_SKILL_DATA_DIR env var."""
+    """Create a temporary data directory using RHDH_SKILLS_DATA_DIR env var."""
     with tempfile.TemporaryDirectory() as tmpdir:
         config_dir = Path(tmpdir) / "data"
         config_dir.mkdir()
-        monkeypatch.setenv("RHDH_SKILL_DATA_DIR", str(config_dir))
+        monkeypatch.setenv("RHDH_SKILLS_DATA_DIR", str(config_dir))
         yield config_dir
 
 

--- a/tests/unit/test_worklog.py
+++ b/tests/unit/test_worklog.py
@@ -9,11 +9,11 @@ import pytest
 
 @pytest.fixture
 def temp_config_dir(monkeypatch):
-    """Create a temporary data directory using RHDH_SKILL_DATA_DIR env var."""
+    """Create a temporary data directory using RHDH_SKILLS_DATA_DIR env var."""
     with tempfile.TemporaryDirectory() as tmpdir:
         config_dir = Path(tmpdir) / "data"
         config_dir.mkdir()
-        monkeypatch.setenv("RHDH_SKILL_DATA_DIR", str(config_dir))
+        monkeypatch.setenv("RHDH_SKILLS_DATA_DIR", str(config_dir))
         yield config_dir
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 1
+revision = 3
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.10'",
@@ -10,9 +10,9 @@ resolution-markers = [
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
 ]
 
 [[package]]
@@ -20,11 +20,11 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371 }
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740 },
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
 ]
 
 [[package]]
@@ -34,9 +34,9 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.10'",
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793 }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050 },
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
 ]
 
 [[package]]
@@ -46,36 +46,36 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.10'",
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503 }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484 },
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416 }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366 },
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
 ]
 
 [[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412 }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538 },
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991 }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151 },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
@@ -86,17 +86,17 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.10'" },
-    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "packaging", marker = "python_full_version < '3.10'" },
-    { name = "pluggy", marker = "python_full_version < '3.10'" },
-    { name = "pygments", marker = "python_full_version < '3.10'" },
-    { name = "tomli", marker = "python_full_version < '3.10'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup" },
+    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618 }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750 },
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
 ]
 
 [[package]]
@@ -107,21 +107,21 @@ resolution-markers = [
     "python_full_version >= '3.10'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
-    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "packaging", marker = "python_full_version >= '3.10'" },
-    { name = "pluggy", marker = "python_full_version >= '3.10'" },
-    { name = "pygments", marker = "python_full_version >= '3.10'" },
-    { name = "tomli", marker = "python_full_version == '3.10.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901 }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801 },
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
 ]
 
 [[package]]
-name = "rhdh-skill"
+name = "rhdh-skills"
 version = "0.0.0"
 source = { virtual = "." }
 
@@ -143,86 +143,86 @@ provides-extras = ["dev"]
 name = "ruff"
 version = "0.15.10"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/d9/aa3f7d59a10ef6b14fe3431706f854dbf03c5976be614a9796d36326810c/ruff-0.15.10.tar.gz", hash = "sha256:d1f86e67ebfdef88e00faefa1552b5e510e1d35f3be7d423dc7e84e63788c94e", size = 4631728 }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/d9/aa3f7d59a10ef6b14fe3431706f854dbf03c5976be614a9796d36326810c/ruff-0.15.10.tar.gz", hash = "sha256:d1f86e67ebfdef88e00faefa1552b5e510e1d35f3be7d423dc7e84e63788c94e", size = 4631728, upload-time = "2026-04-09T14:06:09.884Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/00/a1c2fdc9939b2c03691edbda290afcd297f1f389196172826b03d6b6a595/ruff-0.15.10-py3-none-linux_armv6l.whl", hash = "sha256:0744e31482f8f7d0d10a11fcbf897af272fefdfcb10f5af907b18c2813ff4d5f", size = 10563362 },
-    { url = "https://files.pythonhosted.org/packages/5c/15/006990029aea0bebe9d33c73c3e28c80c391ebdba408d1b08496f00d422d/ruff-0.15.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b1e7c16ea0ff5a53b7c2df52d947e685973049be1cdfe2b59a9c43601897b22e", size = 10951122 },
-    { url = "https://files.pythonhosted.org/packages/f2/c0/4ac978fe874d0618c7da647862afe697b281c2806f13ce904ad652fa87e4/ruff-0.15.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:93cc06a19e5155b4441dd72808fdf84290d84ad8a39ca3b0f994363ade4cebb1", size = 10314005 },
-    { url = "https://files.pythonhosted.org/packages/da/73/c209138a5c98c0d321266372fc4e33ad43d506d7e5dd817dd89b60a8548f/ruff-0.15.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83e1dd04312997c99ea6965df66a14fb4f03ba978564574ffc68b0d61fd3989e", size = 10643450 },
-    { url = "https://files.pythonhosted.org/packages/ec/76/0deec355d8ec10709653635b1f90856735302cb8e149acfdf6f82a5feb70/ruff-0.15.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8154d43684e4333360fedd11aaa40b1b08a4e37d8ffa9d95fee6fa5b37b6fab1", size = 10379597 },
-    { url = "https://files.pythonhosted.org/packages/dc/be/86bba8fc8798c081e28a4b3bb6d143ccad3fd5f6f024f02002b8f08a9fa3/ruff-0.15.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ab88715f3a6deb6bde6c227f3a123410bec7b855c3ae331b4c006189e895cef", size = 11146645 },
-    { url = "https://files.pythonhosted.org/packages/a8/89/140025e65911b281c57be1d385ba1d932c2366ca88ae6663685aed8d4881/ruff-0.15.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a768ff5969b4f44c349d48edf4ab4f91eddb27fd9d77799598e130fb628aa158", size = 12030289 },
-    { url = "https://files.pythonhosted.org/packages/88/de/ddacca9545a5e01332567db01d44bd8cf725f2db3b3d61a80550b48308ea/ruff-0.15.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ee3ef42dab7078bda5ff6a1bcba8539e9857deb447132ad5566a038674540d0", size = 11496266 },
-    { url = "https://files.pythonhosted.org/packages/bc/bb/7ddb00a83760ff4a83c4e2fc231fd63937cc7317c10c82f583302e0f6586/ruff-0.15.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51cb8cc943e891ba99989dd92d61e29b1d231e14811db9be6440ecf25d5c1609", size = 11256418 },
-    { url = "https://files.pythonhosted.org/packages/dc/8d/55de0d35aacf6cd50b6ee91ee0f291672080021896543776f4170fc5c454/ruff-0.15.10-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:e59c9bdc056a320fb9ea1700a8d591718b8faf78af065484e801258d3a76bc3f", size = 11288416 },
-    { url = "https://files.pythonhosted.org/packages/68/cf/9438b1a27426ec46a80e0a718093c7f958ef72f43eb3111862949ead3cc1/ruff-0.15.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:136c00ca2f47b0018b073f28cb5c1506642a830ea941a60354b0e8bc8076b151", size = 10621053 },
-    { url = "https://files.pythonhosted.org/packages/4c/50/e29be6e2c135e9cd4cb15fbade49d6a2717e009dff3766dd080fcb82e251/ruff-0.15.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8b80a2f3c9c8a950d6237f2ca12b206bccff626139be9fa005f14feb881a1ae8", size = 10378302 },
-    { url = "https://files.pythonhosted.org/packages/18/2f/e0b36a6f99c51bb89f3a30239bc7bf97e87a37ae80aa2d6542d6e5150364/ruff-0.15.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:e3e53c588164dc025b671c9df2462429d60357ea91af7e92e9d56c565a9f1b07", size = 10850074 },
-    { url = "https://files.pythonhosted.org/packages/11/08/874da392558ce087a0f9b709dc6ec0d60cbc694c1c772dab8d5f31efe8cb/ruff-0.15.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b0c52744cf9f143a393e284125d2576140b68264a93c6716464e129a3e9adb48", size = 11358051 },
-    { url = "https://files.pythonhosted.org/packages/e4/46/602938f030adfa043e67112b73821024dc79f3ab4df5474c25fa4c1d2d14/ruff-0.15.10-py3-none-win32.whl", hash = "sha256:d4272e87e801e9a27a2e8df7b21011c909d9ddd82f4f3281d269b6ba19789ca5", size = 10588964 },
-    { url = "https://files.pythonhosted.org/packages/25/b6/261225b875d7a13b33a6d02508c39c28450b2041bb01d0f7f1a83d569512/ruff-0.15.10-py3-none-win_amd64.whl", hash = "sha256:28cb32d53203242d403d819fd6983152489b12e4a3ae44993543d6fe62ab42ed", size = 11745044 },
-    { url = "https://files.pythonhosted.org/packages/58/ed/dea90a65b7d9e69888890fb14c90d7f51bf0c1e82ad800aeb0160e4bacfd/ruff-0.15.10-py3-none-win_arm64.whl", hash = "sha256:601d1610a9e1f1c2165a4f561eeaa2e2ea1e97f3287c5aa258d3dab8b57c6188", size = 11035607 },
+    { url = "https://files.pythonhosted.org/packages/eb/00/a1c2fdc9939b2c03691edbda290afcd297f1f389196172826b03d6b6a595/ruff-0.15.10-py3-none-linux_armv6l.whl", hash = "sha256:0744e31482f8f7d0d10a11fcbf897af272fefdfcb10f5af907b18c2813ff4d5f", size = 10563362, upload-time = "2026-04-09T14:06:21.189Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/15/006990029aea0bebe9d33c73c3e28c80c391ebdba408d1b08496f00d422d/ruff-0.15.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b1e7c16ea0ff5a53b7c2df52d947e685973049be1cdfe2b59a9c43601897b22e", size = 10951122, upload-time = "2026-04-09T14:06:02.236Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c0/4ac978fe874d0618c7da647862afe697b281c2806f13ce904ad652fa87e4/ruff-0.15.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:93cc06a19e5155b4441dd72808fdf84290d84ad8a39ca3b0f994363ade4cebb1", size = 10314005, upload-time = "2026-04-09T14:06:00.026Z" },
+    { url = "https://files.pythonhosted.org/packages/da/73/c209138a5c98c0d321266372fc4e33ad43d506d7e5dd817dd89b60a8548f/ruff-0.15.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83e1dd04312997c99ea6965df66a14fb4f03ba978564574ffc68b0d61fd3989e", size = 10643450, upload-time = "2026-04-09T14:05:42.137Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/76/0deec355d8ec10709653635b1f90856735302cb8e149acfdf6f82a5feb70/ruff-0.15.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8154d43684e4333360fedd11aaa40b1b08a4e37d8ffa9d95fee6fa5b37b6fab1", size = 10379597, upload-time = "2026-04-09T14:05:49.984Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/be/86bba8fc8798c081e28a4b3bb6d143ccad3fd5f6f024f02002b8f08a9fa3/ruff-0.15.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ab88715f3a6deb6bde6c227f3a123410bec7b855c3ae331b4c006189e895cef", size = 11146645, upload-time = "2026-04-09T14:06:12.246Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/89/140025e65911b281c57be1d385ba1d932c2366ca88ae6663685aed8d4881/ruff-0.15.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a768ff5969b4f44c349d48edf4ab4f91eddb27fd9d77799598e130fb628aa158", size = 12030289, upload-time = "2026-04-09T14:06:04.776Z" },
+    { url = "https://files.pythonhosted.org/packages/88/de/ddacca9545a5e01332567db01d44bd8cf725f2db3b3d61a80550b48308ea/ruff-0.15.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ee3ef42dab7078bda5ff6a1bcba8539e9857deb447132ad5566a038674540d0", size = 11496266, upload-time = "2026-04-09T14:05:55.485Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/bb/7ddb00a83760ff4a83c4e2fc231fd63937cc7317c10c82f583302e0f6586/ruff-0.15.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51cb8cc943e891ba99989dd92d61e29b1d231e14811db9be6440ecf25d5c1609", size = 11256418, upload-time = "2026-04-09T14:05:57.69Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8d/55de0d35aacf6cd50b6ee91ee0f291672080021896543776f4170fc5c454/ruff-0.15.10-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:e59c9bdc056a320fb9ea1700a8d591718b8faf78af065484e801258d3a76bc3f", size = 11288416, upload-time = "2026-04-09T14:05:44.695Z" },
+    { url = "https://files.pythonhosted.org/packages/68/cf/9438b1a27426ec46a80e0a718093c7f958ef72f43eb3111862949ead3cc1/ruff-0.15.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:136c00ca2f47b0018b073f28cb5c1506642a830ea941a60354b0e8bc8076b151", size = 10621053, upload-time = "2026-04-09T14:05:52.782Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/50/e29be6e2c135e9cd4cb15fbade49d6a2717e009dff3766dd080fcb82e251/ruff-0.15.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8b80a2f3c9c8a950d6237f2ca12b206bccff626139be9fa005f14feb881a1ae8", size = 10378302, upload-time = "2026-04-09T14:06:14.361Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2f/e0b36a6f99c51bb89f3a30239bc7bf97e87a37ae80aa2d6542d6e5150364/ruff-0.15.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:e3e53c588164dc025b671c9df2462429d60357ea91af7e92e9d56c565a9f1b07", size = 10850074, upload-time = "2026-04-09T14:06:16.581Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/874da392558ce087a0f9b709dc6ec0d60cbc694c1c772dab8d5f31efe8cb/ruff-0.15.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b0c52744cf9f143a393e284125d2576140b68264a93c6716464e129a3e9adb48", size = 11358051, upload-time = "2026-04-09T14:06:18.948Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/46/602938f030adfa043e67112b73821024dc79f3ab4df5474c25fa4c1d2d14/ruff-0.15.10-py3-none-win32.whl", hash = "sha256:d4272e87e801e9a27a2e8df7b21011c909d9ddd82f4f3281d269b6ba19789ca5", size = 10588964, upload-time = "2026-04-09T14:06:07.14Z" },
+    { url = "https://files.pythonhosted.org/packages/25/b6/261225b875d7a13b33a6d02508c39c28450b2041bb01d0f7f1a83d569512/ruff-0.15.10-py3-none-win_amd64.whl", hash = "sha256:28cb32d53203242d403d819fd6983152489b12e4a3ae44993543d6fe62ab42ed", size = 11745044, upload-time = "2026-04-09T14:05:39.473Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ed/dea90a65b7d9e69888890fb14c90d7f51bf0c1e82ad800aeb0160e4bacfd/ruff-0.15.10-py3-none-win_arm64.whl", hash = "sha256:601d1610a9e1f1c2165a4f561eeaa2e2ea1e97f3287c5aa258d3dab8b57c6188", size = 11035607, upload-time = "2026-04-09T14:05:47.593Z" },
 ]
 
 [[package]]
 name = "tomli"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/30/31573e9457673ab10aa432461bee537ce6cef177667deca369efb79df071/tomli-2.4.0.tar.gz", hash = "sha256:aa89c3f6c277dd275d8e243ad24f3b5e701491a860d5121f2cdd399fbb31fc9c", size = 17477 }
+sdist = { url = "https://files.pythonhosted.org/packages/82/30/31573e9457673ab10aa432461bee537ce6cef177667deca369efb79df071/tomli-2.4.0.tar.gz", hash = "sha256:aa89c3f6c277dd275d8e243ad24f3b5e701491a860d5121f2cdd399fbb31fc9c", size = 17477, upload-time = "2026-01-11T11:22:38.165Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/d9/3dc2289e1f3b32eb19b9785b6a006b28ee99acb37d1d47f78d4c10e28bf8/tomli-2.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b5ef256a3fd497d4973c11bf142e9ed78b150d36f5773f1ca6088c230ffc5867", size = 153663 },
-    { url = "https://files.pythonhosted.org/packages/51/32/ef9f6845e6b9ca392cd3f64f9ec185cc6f09f0a2df3db08cbe8809d1d435/tomli-2.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5572e41282d5268eb09a697c89a7bee84fae66511f87533a6f88bd2f7b652da9", size = 148469 },
-    { url = "https://files.pythonhosted.org/packages/d6/c2/506e44cce89a8b1b1e047d64bd495c22c9f71f21e05f380f1a950dd9c217/tomli-2.4.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:551e321c6ba03b55676970b47cb1b73f14a0a4dce6a3e1a9458fd6d921d72e95", size = 236039 },
-    { url = "https://files.pythonhosted.org/packages/b3/40/e1b65986dbc861b7e986e8ec394598187fa8aee85b1650b01dd925ca0be8/tomli-2.4.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e3f639a7a8f10069d0e15408c0b96a2a828cfdec6fca05296ebcdcc28ca7c76", size = 243007 },
-    { url = "https://files.pythonhosted.org/packages/9c/6f/6e39ce66b58a5b7ae572a0f4352ff40c71e8573633deda43f6a379d56b3e/tomli-2.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1b168f2731796b045128c45982d3a4874057626da0e2ef1fdd722848b741361d", size = 240875 },
-    { url = "https://files.pythonhosted.org/packages/aa/ad/cb089cb190487caa80204d503c7fd0f4d443f90b95cf4ef5cf5aa0f439b0/tomli-2.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:133e93646ec4300d651839d382d63edff11d8978be23da4cc106f5a18b7d0576", size = 246271 },
-    { url = "https://files.pythonhosted.org/packages/0b/63/69125220e47fd7a3a27fd0de0c6398c89432fec41bc739823bcc66506af6/tomli-2.4.0-cp311-cp311-win32.whl", hash = "sha256:b6c78bdf37764092d369722d9946cb65b8767bfa4110f902a1b2542d8d173c8a", size = 96770 },
-    { url = "https://files.pythonhosted.org/packages/1e/0d/a22bb6c83f83386b0008425a6cd1fa1c14b5f3dd4bad05e98cf3dbbf4a64/tomli-2.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:d3d1654e11d724760cdb37a3d7691f0be9db5fbdaef59c9f532aabf87006dbaa", size = 107626 },
-    { url = "https://files.pythonhosted.org/packages/2f/6d/77be674a3485e75cacbf2ddba2b146911477bd887dda9d8c9dfb2f15e871/tomli-2.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:cae9c19ed12d4e8f3ebf46d1a75090e4c0dc16271c5bce1c833ac168f08fb614", size = 94842 },
-    { url = "https://files.pythonhosted.org/packages/3c/43/7389a1869f2f26dba52404e1ef13b4784b6b37dac93bac53457e3ff24ca3/tomli-2.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:920b1de295e72887bafa3ad9f7a792f811847d57ea6b1215154030cf131f16b1", size = 154894 },
-    { url = "https://files.pythonhosted.org/packages/e9/05/2f9bf110b5294132b2edf13fe6ca6ae456204f3d749f623307cbb7a946f2/tomli-2.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7d6d9a4aee98fac3eab4952ad1d73aee87359452d1c086b5ceb43ed02ddb16b8", size = 149053 },
-    { url = "https://files.pythonhosted.org/packages/e8/41/1eda3ca1abc6f6154a8db4d714a4d35c4ad90adc0bcf700657291593fbf3/tomli-2.4.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:36b9d05b51e65b254ea6c2585b59d2c4cb91c8a3d91d0ed0f17591a29aaea54a", size = 243481 },
-    { url = "https://files.pythonhosted.org/packages/d2/6d/02ff5ab6c8868b41e7d4b987ce2b5f6a51d3335a70aa144edd999e055a01/tomli-2.4.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c8a885b370751837c029ef9bc014f27d80840e48bac415f3412e6593bbc18c1", size = 251720 },
-    { url = "https://files.pythonhosted.org/packages/7b/57/0405c59a909c45d5b6f146107c6d997825aa87568b042042f7a9c0afed34/tomli-2.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8768715ffc41f0008abe25d808c20c3d990f42b6e2e58305d5da280ae7d1fa3b", size = 247014 },
-    { url = "https://files.pythonhosted.org/packages/2c/0e/2e37568edd944b4165735687cbaf2fe3648129e440c26d02223672ee0630/tomli-2.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7b438885858efd5be02a9a133caf5812b8776ee0c969fea02c45e8e3f296ba51", size = 251820 },
-    { url = "https://files.pythonhosted.org/packages/5a/1c/ee3b707fdac82aeeb92d1a113f803cf6d0f37bdca0849cb489553e1f417a/tomli-2.4.0-cp312-cp312-win32.whl", hash = "sha256:0408e3de5ec77cc7f81960c362543cbbd91ef883e3138e81b729fc3eea5b9729", size = 97712 },
-    { url = "https://files.pythonhosted.org/packages/69/13/c07a9177d0b3bab7913299b9278845fc6eaaca14a02667c6be0b0a2270c8/tomli-2.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:685306e2cc7da35be4ee914fd34ab801a6acacb061b6a7abca922aaf9ad368da", size = 108296 },
-    { url = "https://files.pythonhosted.org/packages/18/27/e267a60bbeeee343bcc279bb9e8fbed0cbe224bc7b2a3dc2975f22809a09/tomli-2.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:5aa48d7c2356055feef06a43611fc401a07337d5b006be13a30f6c58f869e3c3", size = 94553 },
-    { url = "https://files.pythonhosted.org/packages/34/91/7f65f9809f2936e1f4ce6268ae1903074563603b2a2bd969ebbda802744f/tomli-2.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:84d081fbc252d1b6a982e1870660e7330fb8f90f676f6e78b052ad4e64714bf0", size = 154915 },
-    { url = "https://files.pythonhosted.org/packages/20/aa/64dd73a5a849c2e8f216b755599c511badde80e91e9bc2271baa7b2cdbb1/tomli-2.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9a08144fa4cba33db5255f9b74f0b89888622109bd2776148f2597447f92a94e", size = 149038 },
-    { url = "https://files.pythonhosted.org/packages/9e/8a/6d38870bd3d52c8d1505ce054469a73f73a0fe62c0eaf5dddf61447e32fa/tomli-2.4.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c73add4bb52a206fd0c0723432db123c0c75c280cbd67174dd9d2db228ebb1b4", size = 242245 },
-    { url = "https://files.pythonhosted.org/packages/59/bb/8002fadefb64ab2669e5b977df3f5e444febea60e717e755b38bb7c41029/tomli-2.4.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fb2945cbe303b1419e2706e711b7113da57b7db31ee378d08712d678a34e51e", size = 250335 },
-    { url = "https://files.pythonhosted.org/packages/a5/3d/4cdb6f791682b2ea916af2de96121b3cb1284d7c203d97d92d6003e91c8d/tomli-2.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bbb1b10aa643d973366dc2cb1ad94f99c1726a02343d43cbc011edbfac579e7c", size = 245962 },
-    { url = "https://files.pythonhosted.org/packages/f2/4a/5f25789f9a460bd858ba9756ff52d0830d825b458e13f754952dd15fb7bb/tomli-2.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4cbcb367d44a1f0c2be408758b43e1ffb5308abe0ea222897d6bfc8e8281ef2f", size = 250396 },
-    { url = "https://files.pythonhosted.org/packages/aa/2f/b73a36fea58dfa08e8b3a268750e6853a6aac2a349241a905ebd86f3047a/tomli-2.4.0-cp313-cp313-win32.whl", hash = "sha256:7d49c66a7d5e56ac959cb6fc583aff0651094ec071ba9ad43df785abc2320d86", size = 97530 },
-    { url = "https://files.pythonhosted.org/packages/3b/af/ca18c134b5d75de7e8dc551c5234eaba2e8e951f6b30139599b53de9c187/tomli-2.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:3cf226acb51d8f1c394c1b310e0e0e61fecdd7adcb78d01e294ac297dd2e7f87", size = 108227 },
-    { url = "https://files.pythonhosted.org/packages/22/c3/b386b832f209fee8073c8138ec50f27b4460db2fdae9ffe022df89a57f9b/tomli-2.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:d20b797a5c1ad80c516e41bc1fb0443ddb5006e9aaa7bda2d71978346aeb9132", size = 94748 },
-    { url = "https://files.pythonhosted.org/packages/f3/c4/84047a97eb1004418bc10bdbcfebda209fca6338002eba2dc27cc6d13563/tomli-2.4.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:26ab906a1eb794cd4e103691daa23d95c6919cc2fa9160000ac02370cc9dd3f6", size = 154725 },
-    { url = "https://files.pythonhosted.org/packages/a8/5d/d39038e646060b9d76274078cddf146ced86dc2b9e8bbf737ad5983609a0/tomli-2.4.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:20cedb4ee43278bc4f2fee6cb50daec836959aadaf948db5172e776dd3d993fc", size = 148901 },
-    { url = "https://files.pythonhosted.org/packages/73/e5/383be1724cb30f4ce44983d249645684a48c435e1cd4f8b5cded8a816d3c/tomli-2.4.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:39b0b5d1b6dd03684b3fb276407ebed7090bbec989fa55838c98560c01113b66", size = 243375 },
-    { url = "https://files.pythonhosted.org/packages/31/f0/bea80c17971c8d16d3cc109dc3585b0f2ce1036b5f4a8a183789023574f2/tomli-2.4.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a26d7ff68dfdb9f87a016ecfd1e1c2bacbe3108f4e0f8bcd2228ef9a766c787d", size = 250639 },
-    { url = "https://files.pythonhosted.org/packages/2c/8f/2853c36abbb7608e3f945d8a74e32ed3a74ee3a1f468f1ffc7d1cb3abba6/tomli-2.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:20ffd184fb1df76a66e34bd1b36b4a4641bd2b82954befa32fe8163e79f1a702", size = 246897 },
-    { url = "https://files.pythonhosted.org/packages/49/f0/6c05e3196ed5337b9fe7ea003e95fd3819a840b7a0f2bf5a408ef1dad8ed/tomli-2.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:75c2f8bbddf170e8effc98f5e9084a8751f8174ea6ccf4fca5398436e0320bc8", size = 254697 },
-    { url = "https://files.pythonhosted.org/packages/f3/f5/2922ef29c9f2951883525def7429967fc4d8208494e5ab524234f06b688b/tomli-2.4.0-cp314-cp314-win32.whl", hash = "sha256:31d556d079d72db7c584c0627ff3a24c5d3fb4f730221d3444f3efb1b2514776", size = 98567 },
-    { url = "https://files.pythonhosted.org/packages/7b/31/22b52e2e06dd2a5fdbc3ee73226d763b184ff21fc24e20316a44ccc4d96b/tomli-2.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:43e685b9b2341681907759cf3a04e14d7104b3580f808cfde1dfdb60ada85475", size = 108556 },
-    { url = "https://files.pythonhosted.org/packages/48/3d/5058dff3255a3d01b705413f64f4306a141a8fd7a251e5a495e3f192a998/tomli-2.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:3d895d56bd3f82ddd6faaff993c275efc2ff38e52322ea264122d72729dca2b2", size = 96014 },
-    { url = "https://files.pythonhosted.org/packages/b8/4e/75dab8586e268424202d3a1997ef6014919c941b50642a1682df43204c22/tomli-2.4.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:5b5807f3999fb66776dbce568cc9a828544244a8eb84b84b9bafc080c99597b9", size = 163339 },
-    { url = "https://files.pythonhosted.org/packages/06/e3/b904d9ab1016829a776d97f163f183a48be6a4deb87304d1e0116a349519/tomli-2.4.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c084ad935abe686bd9c898e62a02a19abfc9760b5a79bc29644463eaf2840cb0", size = 159490 },
-    { url = "https://files.pythonhosted.org/packages/e3/5a/fc3622c8b1ad823e8ea98a35e3c632ee316d48f66f80f9708ceb4f2a0322/tomli-2.4.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f2e3955efea4d1cfbcb87bc321e00dc08d2bcb737fd1d5e398af111d86db5df", size = 269398 },
-    { url = "https://files.pythonhosted.org/packages/fd/33/62bd6152c8bdd4c305ad9faca48f51d3acb2df1f8791b1477d46ff86e7f8/tomli-2.4.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e0fe8a0b8312acf3a88077a0802565cb09ee34107813bba1c7cd591fa6cfc8d", size = 276515 },
-    { url = "https://files.pythonhosted.org/packages/4b/ff/ae53619499f5235ee4211e62a8d7982ba9e439a0fb4f2f351a93d67c1dd2/tomli-2.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:413540dce94673591859c4c6f794dfeaa845e98bf35d72ed59636f869ef9f86f", size = 273806 },
-    { url = "https://files.pythonhosted.org/packages/47/71/cbca7787fa68d4d0a9f7072821980b39fbb1b6faeb5f5cf02f4a5559fa28/tomli-2.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0dc56fef0e2c1c470aeac5b6ca8cc7b640bb93e92d9803ddaf9ea03e198f5b0b", size = 281340 },
-    { url = "https://files.pythonhosted.org/packages/f5/00/d595c120963ad42474cf6ee7771ad0d0e8a49d0f01e29576ee9195d9ecdf/tomli-2.4.0-cp314-cp314t-win32.whl", hash = "sha256:d878f2a6707cc9d53a1be1414bbb419e629c3d6e67f69230217bb663e76b5087", size = 108106 },
-    { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504 },
-    { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561 },
-    { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477 },
+    { url = "https://files.pythonhosted.org/packages/3c/d9/3dc2289e1f3b32eb19b9785b6a006b28ee99acb37d1d47f78d4c10e28bf8/tomli-2.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b5ef256a3fd497d4973c11bf142e9ed78b150d36f5773f1ca6088c230ffc5867", size = 153663, upload-time = "2026-01-11T11:21:45.27Z" },
+    { url = "https://files.pythonhosted.org/packages/51/32/ef9f6845e6b9ca392cd3f64f9ec185cc6f09f0a2df3db08cbe8809d1d435/tomli-2.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5572e41282d5268eb09a697c89a7bee84fae66511f87533a6f88bd2f7b652da9", size = 148469, upload-time = "2026-01-11T11:21:46.873Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/c2/506e44cce89a8b1b1e047d64bd495c22c9f71f21e05f380f1a950dd9c217/tomli-2.4.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:551e321c6ba03b55676970b47cb1b73f14a0a4dce6a3e1a9458fd6d921d72e95", size = 236039, upload-time = "2026-01-11T11:21:48.503Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/40/e1b65986dbc861b7e986e8ec394598187fa8aee85b1650b01dd925ca0be8/tomli-2.4.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e3f639a7a8f10069d0e15408c0b96a2a828cfdec6fca05296ebcdcc28ca7c76", size = 243007, upload-time = "2026-01-11T11:21:49.456Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6f/6e39ce66b58a5b7ae572a0f4352ff40c71e8573633deda43f6a379d56b3e/tomli-2.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1b168f2731796b045128c45982d3a4874057626da0e2ef1fdd722848b741361d", size = 240875, upload-time = "2026-01-11T11:21:50.755Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ad/cb089cb190487caa80204d503c7fd0f4d443f90b95cf4ef5cf5aa0f439b0/tomli-2.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:133e93646ec4300d651839d382d63edff11d8978be23da4cc106f5a18b7d0576", size = 246271, upload-time = "2026-01-11T11:21:51.81Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/63/69125220e47fd7a3a27fd0de0c6398c89432fec41bc739823bcc66506af6/tomli-2.4.0-cp311-cp311-win32.whl", hash = "sha256:b6c78bdf37764092d369722d9946cb65b8767bfa4110f902a1b2542d8d173c8a", size = 96770, upload-time = "2026-01-11T11:21:52.647Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0d/a22bb6c83f83386b0008425a6cd1fa1c14b5f3dd4bad05e98cf3dbbf4a64/tomli-2.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:d3d1654e11d724760cdb37a3d7691f0be9db5fbdaef59c9f532aabf87006dbaa", size = 107626, upload-time = "2026-01-11T11:21:53.459Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/6d/77be674a3485e75cacbf2ddba2b146911477bd887dda9d8c9dfb2f15e871/tomli-2.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:cae9c19ed12d4e8f3ebf46d1a75090e4c0dc16271c5bce1c833ac168f08fb614", size = 94842, upload-time = "2026-01-11T11:21:54.831Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/43/7389a1869f2f26dba52404e1ef13b4784b6b37dac93bac53457e3ff24ca3/tomli-2.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:920b1de295e72887bafa3ad9f7a792f811847d57ea6b1215154030cf131f16b1", size = 154894, upload-time = "2026-01-11T11:21:56.07Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/05/2f9bf110b5294132b2edf13fe6ca6ae456204f3d749f623307cbb7a946f2/tomli-2.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7d6d9a4aee98fac3eab4952ad1d73aee87359452d1c086b5ceb43ed02ddb16b8", size = 149053, upload-time = "2026-01-11T11:21:57.467Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/41/1eda3ca1abc6f6154a8db4d714a4d35c4ad90adc0bcf700657291593fbf3/tomli-2.4.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:36b9d05b51e65b254ea6c2585b59d2c4cb91c8a3d91d0ed0f17591a29aaea54a", size = 243481, upload-time = "2026-01-11T11:21:58.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/6d/02ff5ab6c8868b41e7d4b987ce2b5f6a51d3335a70aa144edd999e055a01/tomli-2.4.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c8a885b370751837c029ef9bc014f27d80840e48bac415f3412e6593bbc18c1", size = 251720, upload-time = "2026-01-11T11:22:00.178Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/57/0405c59a909c45d5b6f146107c6d997825aa87568b042042f7a9c0afed34/tomli-2.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8768715ffc41f0008abe25d808c20c3d990f42b6e2e58305d5da280ae7d1fa3b", size = 247014, upload-time = "2026-01-11T11:22:01.238Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0e/2e37568edd944b4165735687cbaf2fe3648129e440c26d02223672ee0630/tomli-2.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7b438885858efd5be02a9a133caf5812b8776ee0c969fea02c45e8e3f296ba51", size = 251820, upload-time = "2026-01-11T11:22:02.727Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/1c/ee3b707fdac82aeeb92d1a113f803cf6d0f37bdca0849cb489553e1f417a/tomli-2.4.0-cp312-cp312-win32.whl", hash = "sha256:0408e3de5ec77cc7f81960c362543cbbd91ef883e3138e81b729fc3eea5b9729", size = 97712, upload-time = "2026-01-11T11:22:03.777Z" },
+    { url = "https://files.pythonhosted.org/packages/69/13/c07a9177d0b3bab7913299b9278845fc6eaaca14a02667c6be0b0a2270c8/tomli-2.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:685306e2cc7da35be4ee914fd34ab801a6acacb061b6a7abca922aaf9ad368da", size = 108296, upload-time = "2026-01-11T11:22:04.86Z" },
+    { url = "https://files.pythonhosted.org/packages/18/27/e267a60bbeeee343bcc279bb9e8fbed0cbe224bc7b2a3dc2975f22809a09/tomli-2.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:5aa48d7c2356055feef06a43611fc401a07337d5b006be13a30f6c58f869e3c3", size = 94553, upload-time = "2026-01-11T11:22:05.854Z" },
+    { url = "https://files.pythonhosted.org/packages/34/91/7f65f9809f2936e1f4ce6268ae1903074563603b2a2bd969ebbda802744f/tomli-2.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:84d081fbc252d1b6a982e1870660e7330fb8f90f676f6e78b052ad4e64714bf0", size = 154915, upload-time = "2026-01-11T11:22:06.703Z" },
+    { url = "https://files.pythonhosted.org/packages/20/aa/64dd73a5a849c2e8f216b755599c511badde80e91e9bc2271baa7b2cdbb1/tomli-2.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9a08144fa4cba33db5255f9b74f0b89888622109bd2776148f2597447f92a94e", size = 149038, upload-time = "2026-01-11T11:22:07.56Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8a/6d38870bd3d52c8d1505ce054469a73f73a0fe62c0eaf5dddf61447e32fa/tomli-2.4.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c73add4bb52a206fd0c0723432db123c0c75c280cbd67174dd9d2db228ebb1b4", size = 242245, upload-time = "2026-01-11T11:22:08.344Z" },
+    { url = "https://files.pythonhosted.org/packages/59/bb/8002fadefb64ab2669e5b977df3f5e444febea60e717e755b38bb7c41029/tomli-2.4.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fb2945cbe303b1419e2706e711b7113da57b7db31ee378d08712d678a34e51e", size = 250335, upload-time = "2026-01-11T11:22:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/3d/4cdb6f791682b2ea916af2de96121b3cb1284d7c203d97d92d6003e91c8d/tomli-2.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bbb1b10aa643d973366dc2cb1ad94f99c1726a02343d43cbc011edbfac579e7c", size = 245962, upload-time = "2026-01-11T11:22:11.27Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/4a/5f25789f9a460bd858ba9756ff52d0830d825b458e13f754952dd15fb7bb/tomli-2.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4cbcb367d44a1f0c2be408758b43e1ffb5308abe0ea222897d6bfc8e8281ef2f", size = 250396, upload-time = "2026-01-11T11:22:12.325Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/2f/b73a36fea58dfa08e8b3a268750e6853a6aac2a349241a905ebd86f3047a/tomli-2.4.0-cp313-cp313-win32.whl", hash = "sha256:7d49c66a7d5e56ac959cb6fc583aff0651094ec071ba9ad43df785abc2320d86", size = 97530, upload-time = "2026-01-11T11:22:13.865Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/af/ca18c134b5d75de7e8dc551c5234eaba2e8e951f6b30139599b53de9c187/tomli-2.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:3cf226acb51d8f1c394c1b310e0e0e61fecdd7adcb78d01e294ac297dd2e7f87", size = 108227, upload-time = "2026-01-11T11:22:15.224Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c3/b386b832f209fee8073c8138ec50f27b4460db2fdae9ffe022df89a57f9b/tomli-2.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:d20b797a5c1ad80c516e41bc1fb0443ddb5006e9aaa7bda2d71978346aeb9132", size = 94748, upload-time = "2026-01-11T11:22:16.009Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c4/84047a97eb1004418bc10bdbcfebda209fca6338002eba2dc27cc6d13563/tomli-2.4.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:26ab906a1eb794cd4e103691daa23d95c6919cc2fa9160000ac02370cc9dd3f6", size = 154725, upload-time = "2026-01-11T11:22:17.269Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5d/d39038e646060b9d76274078cddf146ced86dc2b9e8bbf737ad5983609a0/tomli-2.4.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:20cedb4ee43278bc4f2fee6cb50daec836959aadaf948db5172e776dd3d993fc", size = 148901, upload-time = "2026-01-11T11:22:18.287Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e5/383be1724cb30f4ce44983d249645684a48c435e1cd4f8b5cded8a816d3c/tomli-2.4.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:39b0b5d1b6dd03684b3fb276407ebed7090bbec989fa55838c98560c01113b66", size = 243375, upload-time = "2026-01-11T11:22:19.154Z" },
+    { url = "https://files.pythonhosted.org/packages/31/f0/bea80c17971c8d16d3cc109dc3585b0f2ce1036b5f4a8a183789023574f2/tomli-2.4.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a26d7ff68dfdb9f87a016ecfd1e1c2bacbe3108f4e0f8bcd2228ef9a766c787d", size = 250639, upload-time = "2026-01-11T11:22:20.168Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/8f/2853c36abbb7608e3f945d8a74e32ed3a74ee3a1f468f1ffc7d1cb3abba6/tomli-2.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:20ffd184fb1df76a66e34bd1b36b4a4641bd2b82954befa32fe8163e79f1a702", size = 246897, upload-time = "2026-01-11T11:22:21.544Z" },
+    { url = "https://files.pythonhosted.org/packages/49/f0/6c05e3196ed5337b9fe7ea003e95fd3819a840b7a0f2bf5a408ef1dad8ed/tomli-2.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:75c2f8bbddf170e8effc98f5e9084a8751f8174ea6ccf4fca5398436e0320bc8", size = 254697, upload-time = "2026-01-11T11:22:23.058Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f5/2922ef29c9f2951883525def7429967fc4d8208494e5ab524234f06b688b/tomli-2.4.0-cp314-cp314-win32.whl", hash = "sha256:31d556d079d72db7c584c0627ff3a24c5d3fb4f730221d3444f3efb1b2514776", size = 98567, upload-time = "2026-01-11T11:22:24.033Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/31/22b52e2e06dd2a5fdbc3ee73226d763b184ff21fc24e20316a44ccc4d96b/tomli-2.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:43e685b9b2341681907759cf3a04e14d7104b3580f808cfde1dfdb60ada85475", size = 108556, upload-time = "2026-01-11T11:22:25.378Z" },
+    { url = "https://files.pythonhosted.org/packages/48/3d/5058dff3255a3d01b705413f64f4306a141a8fd7a251e5a495e3f192a998/tomli-2.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:3d895d56bd3f82ddd6faaff993c275efc2ff38e52322ea264122d72729dca2b2", size = 96014, upload-time = "2026-01-11T11:22:26.138Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/4e/75dab8586e268424202d3a1997ef6014919c941b50642a1682df43204c22/tomli-2.4.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:5b5807f3999fb66776dbce568cc9a828544244a8eb84b84b9bafc080c99597b9", size = 163339, upload-time = "2026-01-11T11:22:27.143Z" },
+    { url = "https://files.pythonhosted.org/packages/06/e3/b904d9ab1016829a776d97f163f183a48be6a4deb87304d1e0116a349519/tomli-2.4.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c084ad935abe686bd9c898e62a02a19abfc9760b5a79bc29644463eaf2840cb0", size = 159490, upload-time = "2026-01-11T11:22:28.399Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/5a/fc3622c8b1ad823e8ea98a35e3c632ee316d48f66f80f9708ceb4f2a0322/tomli-2.4.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f2e3955efea4d1cfbcb87bc321e00dc08d2bcb737fd1d5e398af111d86db5df", size = 269398, upload-time = "2026-01-11T11:22:29.345Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/33/62bd6152c8bdd4c305ad9faca48f51d3acb2df1f8791b1477d46ff86e7f8/tomli-2.4.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e0fe8a0b8312acf3a88077a0802565cb09ee34107813bba1c7cd591fa6cfc8d", size = 276515, upload-time = "2026-01-11T11:22:30.327Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/ff/ae53619499f5235ee4211e62a8d7982ba9e439a0fb4f2f351a93d67c1dd2/tomli-2.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:413540dce94673591859c4c6f794dfeaa845e98bf35d72ed59636f869ef9f86f", size = 273806, upload-time = "2026-01-11T11:22:32.56Z" },
+    { url = "https://files.pythonhosted.org/packages/47/71/cbca7787fa68d4d0a9f7072821980b39fbb1b6faeb5f5cf02f4a5559fa28/tomli-2.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0dc56fef0e2c1c470aeac5b6ca8cc7b640bb93e92d9803ddaf9ea03e198f5b0b", size = 281340, upload-time = "2026-01-11T11:22:33.505Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/00/d595c120963ad42474cf6ee7771ad0d0e8a49d0f01e29576ee9195d9ecdf/tomli-2.4.0-cp314-cp314t-win32.whl", hash = "sha256:d878f2a6707cc9d53a1be1414bbb419e629c3d6e67f69230217bb663e76b5087", size = 108106, upload-time = "2026-01-11T11:22:34.451Z" },
+    { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
 ]
 
 [[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391 }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614 },
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]


### PR DESCRIPTION
Install commands, catalog source, docs, the Python package, user config
dir (`~/.config/rhdh-skills`), data-dir env (`RHDH_SKILLS_DATA_DIR`),
and private-data upstream now use `rhdh-skills` after the repo rename.
This is a clean break: old config paths and env names are no longer read.
