### PR TITLE
feat: group npx skills install by catalog category

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -3,6 +3,7 @@
 Generated projection of `skills/meta/setup-rhdh-skills/assets/catalog.json` for
 the `npx skills add` installer tree. Do not hand-edit `marketplace.json`.
 
-This directory is **not** a Claude Code marketplace product. The skills CLI
-reads plugin names here to group skills in its install prompt. See
+Installable groups are the non-`reference` catalog categories. Required
+reference skills are folded into each group that needs them. This directory is
+**not** a Claude Code marketplace product. See
 [ADR-0009](../docs/adr/0009-skills-cli-plugin-manifest.md).

--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -1,0 +1,8 @@
+# `.claude-plugin/`
+
+Generated projection of `skills/meta/setup-rhdh-skills/assets/catalog.json` for
+the `npx skills add` installer tree. Do not hand-edit `marketplace.json`.
+
+This directory is **not** a Claude Code marketplace product. The skills CLI
+reads plugin names here to group skills in its install prompt. See
+[ADR-0009](../docs/adr/0009-skills-cli-plugin-manifest.md).

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,93 @@
+{
+  "name": "rhdh-skills",
+  "owner": {
+    "name": "Red Hat Developer Hub",
+    "url": "https://github.com/redhat-developer/rhdh-skills"
+  },
+  "description": "Projection of the promoted RHDH skill catalog for npx skills installer grouping. Not a Claude Code marketplace product.",
+  "plugins": [
+    {
+      "name": "jira",
+      "source": "./",
+      "description": "Jira skills from the RHDH pack",
+      "skills": [
+        "./skills/jira/rhdh-jira-create",
+        "./skills/jira/rhdh-jira-link",
+        "./skills/jira/rhdh-jira-refine",
+        "./skills/jira/rhdh-jira-sprint-plan",
+        "./skills/jira/rhdh-jira-sprint-report",
+        "./skills/jira/rhdh-jira-update"
+      ]
+    },
+    {
+      "name": "plugins",
+      "source": "./",
+      "description": "Plugins skills from the RHDH pack",
+      "skills": [
+        "./skills/plugins/rhdh-backstage-upgrade",
+        "./skills/plugins/rhdh-local",
+        "./skills/plugins/rhdh-overlay",
+        "./skills/plugins/rhdh-plugin-authoring",
+        "./skills/plugins/rhdh-plugin-bug-fix",
+        "./skills/plugins/rhdh-plugin-export",
+        "./skills/plugins/rhdh-plugin-midstream-propagate",
+        "./skills/plugins/rhdh-plugin-nfs-migration",
+        "./skills/plugins/rhdh-plugin-wiring",
+        "./skills/plugins/rhdh-pr-create",
+        "./skills/plugins/rhdh-pr-review",
+        "./skills/plugins/rhdh-test-placement"
+      ]
+    },
+    {
+      "name": "CI",
+      "source": "./",
+      "description": "CI skills from the RHDH pack",
+      "skills": [
+        "./skills/ci/rhdh-base-images",
+        "./skills/ci/rhdh-konflux-tasks",
+        "./skills/ci/rhdh-prow-jobs",
+        "./skills/ci/rhdh-prow-release-branch",
+        "./skills/ci/rhdh-prow-trigger",
+        "./skills/ci/rhdh-yarn-bump"
+      ]
+    },
+    {
+      "name": "release",
+      "source": "./",
+      "description": "Release skills from the RHDH pack",
+      "skills": [
+        "./skills/release/rhdh-overlay-cve-export",
+        "./skills/release/rhdh-platform-lifecycle",
+        "./skills/release/rhdh-release-announce",
+        "./skills/release/rhdh-release-schedule",
+        "./skills/release/rhdh-release-status",
+        "./skills/release/rhdh-release-teams",
+        "./skills/release/rhdh-test-plan-review"
+      ]
+    },
+    {
+      "name": "reference",
+      "source": "./",
+      "description": "Reference skills from the RHDH pack",
+      "skills": [
+        "./skills/reference/backstage-api-changes",
+        "./skills/reference/mutation-gate",
+        "./skills/reference/rhdh-context",
+        "./skills/reference/rhdh-forge",
+        "./skills/reference/rhdh-jira-api",
+        "./skills/reference/rhdh-jira-authoring"
+      ]
+    },
+    {
+      "name": "meta",
+      "source": "./",
+      "description": "Meta skills from the RHDH pack",
+      "skills": [
+        "./skills/meta/agent-readiness",
+        "./skills/meta/ask-rhdh",
+        "./skills/meta/setup-rhdh-skills",
+        "./skills/meta/skill-authoring"
+      ]
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,51 +4,19 @@
     "name": "Red Hat Developer Hub",
     "url": "https://github.com/redhat-developer/rhdh-skills"
   },
-  "description": "Projection of the promoted RHDH skill catalog for npx skills installer grouping. Not a Claude Code marketplace product.",
+  "description": "Projection of the promoted RHDH skill catalog for npx skills installer grouping. Not a Claude Code marketplace product. Reference skills are folded into each installable category that requires them.",
   "plugins": [
     {
-      "name": "jira",
+      "name": "meta",
       "source": "./",
-      "description": "Jira skills from the RHDH pack",
+      "description": "Meta skills from the RHDH pack",
       "skills": [
-        "./skills/jira/rhdh-jira-create",
-        "./skills/jira/rhdh-jira-link",
-        "./skills/jira/rhdh-jira-refine",
-        "./skills/jira/rhdh-jira-sprint-plan",
-        "./skills/jira/rhdh-jira-sprint-report",
-        "./skills/jira/rhdh-jira-update"
-      ]
-    },
-    {
-      "name": "plugins",
-      "source": "./",
-      "description": "Plugins skills from the RHDH pack",
-      "skills": [
-        "./skills/plugins/rhdh-backstage-upgrade",
-        "./skills/plugins/rhdh-local",
-        "./skills/plugins/rhdh-overlay",
-        "./skills/plugins/rhdh-plugin-authoring",
-        "./skills/plugins/rhdh-plugin-bug-fix",
-        "./skills/plugins/rhdh-plugin-export",
-        "./skills/plugins/rhdh-plugin-midstream-propagate",
-        "./skills/plugins/rhdh-plugin-nfs-migration",
-        "./skills/plugins/rhdh-plugin-wiring",
-        "./skills/plugins/rhdh-pr-create",
-        "./skills/plugins/rhdh-pr-review",
-        "./skills/plugins/rhdh-test-placement"
-      ]
-    },
-    {
-      "name": "CI",
-      "source": "./",
-      "description": "CI skills from the RHDH pack",
-      "skills": [
-        "./skills/ci/rhdh-base-images",
-        "./skills/ci/rhdh-konflux-tasks",
-        "./skills/ci/rhdh-prow-jobs",
-        "./skills/ci/rhdh-prow-release-branch",
-        "./skills/ci/rhdh-prow-trigger",
-        "./skills/ci/rhdh-yarn-bump"
+        "./skills/meta/agent-readiness",
+        "./skills/reference/rhdh-context",
+        "./skills/meta/ask-rhdh",
+        "./skills/meta/setup-rhdh-skills",
+        "./skills/reference/mutation-gate",
+        "./skills/meta/skill-authoring"
       ]
     },
     {
@@ -66,27 +34,55 @@
       ]
     },
     {
-      "name": "reference",
+      "name": "CI",
       "source": "./",
-      "description": "Reference skills from the RHDH pack",
+      "description": "CI skills from the RHDH pack",
       "skills": [
-        "./skills/reference/backstage-api-changes",
+        "./skills/ci/rhdh-base-images",
         "./skills/reference/mutation-gate",
-        "./skills/reference/rhdh-context",
-        "./skills/reference/rhdh-forge",
-        "./skills/reference/rhdh-jira-api",
-        "./skills/reference/rhdh-jira-authoring"
+        "./skills/ci/rhdh-konflux-tasks",
+        "./skills/ci/rhdh-prow-jobs",
+        "./skills/ci/rhdh-prow-release-branch",
+        "./skills/ci/rhdh-prow-trigger",
+        "./skills/ci/rhdh-yarn-bump"
       ]
     },
     {
-      "name": "meta",
+      "name": "plugins",
       "source": "./",
-      "description": "Meta skills from the RHDH pack",
+      "description": "Plugins skills from the RHDH pack",
       "skills": [
-        "./skills/meta/agent-readiness",
-        "./skills/meta/ask-rhdh",
-        "./skills/meta/setup-rhdh-skills",
-        "./skills/meta/skill-authoring"
+        "./skills/plugins/rhdh-backstage-upgrade",
+        "./skills/reference/backstage-api-changes",
+        "./skills/plugins/rhdh-local",
+        "./skills/plugins/rhdh-overlay",
+        "./skills/reference/mutation-gate",
+        "./skills/plugins/rhdh-plugin-authoring",
+        "./skills/plugins/rhdh-plugin-bug-fix",
+        "./skills/reference/rhdh-forge",
+        "./skills/plugins/rhdh-plugin-export",
+        "./skills/plugins/rhdh-plugin-midstream-propagate",
+        "./skills/plugins/rhdh-plugin-nfs-migration",
+        "./skills/plugins/rhdh-plugin-wiring",
+        "./skills/plugins/rhdh-pr-create",
+        "./skills/plugins/rhdh-pr-review",
+        "./skills/plugins/rhdh-test-placement"
+      ]
+    },
+    {
+      "name": "jira",
+      "source": "./",
+      "description": "Jira skills from the RHDH pack",
+      "skills": [
+        "./skills/jira/rhdh-jira-create",
+        "./skills/reference/rhdh-jira-api",
+        "./skills/reference/rhdh-jira-authoring",
+        "./skills/reference/mutation-gate",
+        "./skills/jira/rhdh-jira-link",
+        "./skills/jira/rhdh-jira-refine",
+        "./skills/jira/rhdh-jira-sprint-plan",
+        "./skills/jira/rhdh-jira-sprint-report",
+        "./skills/jira/rhdh-jira-update"
       ]
     }
   ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     rev: v0.17.2
     hooks:
       - id: markdownlint-cli2
-        args: ["--fix"]
+        args: ['--fix']
         exclude: ^\.planning/
 
   # Secret detection
@@ -40,11 +40,18 @@ repos:
     rev: v0.10.0.1
     hooks:
       - id: shellcheck
-        args: ["--severity=warning"]
+        args: ['--severity=warning']
 
-  # Run tests before commit
+  # Keep the skills CLI grouping manifest aligned with the catalog
   - repo: local
     hooks:
+      - id: generate-plugin-manifest
+        name: generate .claude-plugin marketplace from catalog
+        entry: uv run python scripts/generate_plugin_manifest.py --write
+        language: system
+        files: ^(skills/meta/setup-rhdh-skills/assets/catalog\.json|\.claude-plugin/marketplace\.json)$
+        pass_filenames: false
+        stages: [pre-commit]
       - id: pytest
         name: pytest
         entry: uv run pytest tests/ -q

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,9 +62,13 @@ root. Retired history belongs under `internal/deprecated/`. Neither ships.
    category, invocation, and required skills.
 6. Regenerate the routing table:
    `cd skills/meta/ask-rhdh && python scripts/render_routes.py --write`
-7. Update `README.md` if membership or naming changed.
-8. Add script, adapter, and catalog contract tests as applicable.
-9. Run `uv run pytest`.
+7. Let pre-commit regenerate `.claude-plugin/marketplace.json` from the catalog
+   (or run `uv run python scripts/generate_plugin_manifest.py --write`). That
+   file groups `npx skills add` by category; it is not a Claude Code marketplace
+   product — see [ADR-0009](docs/adr/0009-skills-cli-plugin-manifest.md).
+8. Update `README.md` if membership or naming changed.
+9. Add script, adapter, and catalog contract tests as applicable.
+10. Run `uv run pytest`.
 
 ### Rules the validator and reviewers enforce
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,8 +64,9 @@ root. Retired history belongs under `internal/deprecated/`. Neither ships.
    `cd skills/meta/ask-rhdh && python scripts/render_routes.py --write`
 7. Let pre-commit regenerate `.claude-plugin/marketplace.json` from the catalog
    (or run `uv run python scripts/generate_plugin_manifest.py --write`). That
-   file groups `npx skills add` by category; it is not a Claude Code marketplace
-   product — see [ADR-0009](docs/adr/0009-skills-cli-plugin-manifest.md).
+   file groups `npx skills add` by installable category and folds required
+   `reference` skills into each consumer group; it is not a Claude Code
+   marketplace product — see [ADR-0009](docs/adr/0009-skills-cli-plugin-manifest.md).
 8. Update `README.md` if membership or naming changed.
 9. Add script, adapter, and catalog contract tests as applicable.
 10. Run `uv run pytest`.

--- a/README.md
+++ b/README.md
@@ -11,10 +11,9 @@ Install the pack and the three external skills it depends on. Each command opens
 the skills wizard, which asks where to put them:
 
 ```bash
-npx skills add redhat-developer/rhdh-skills --all
-npx skills add mattpocock/skills --skill grilling
-npx skills add mattpocock/skills --skill handoff
-npx skills add blader/humanizer
+npx skills add redhat-developer/rhdh-skills --global
+npx skills add mattpocock/skills --global
+npx skills add blader/humanizer --global
 ```
 
 Restart your agent client so it discovers them.
@@ -55,7 +54,7 @@ name.
 Skills are grouped into six folders:
 
 | Folder | Covers |
-|---|---|
+| --- | --- |
 | `jira/` | Creating, refining, updating, and reporting on RHIDP, RHDHPLAN, RHDHBUGS, and RHDHSUPP work, plus sprint ceremonies and linking PRs to issues. |
 | `plugins/` | Authoring, wiring, exporting, and fixing Backstage dynamic plugins; the overlays repository; local RHDH; opening and reviewing pull requests; midstream propagation. |
 | `ci/` | Prow job configuration and nightly triggers, Konflux and Tekton task updates, base images, and Yarn bumps. |

--- a/docs/adr/0009-skills-cli-plugin-manifest.md
+++ b/docs/adr/0009-skills-cli-plugin-manifest.md
@@ -1,0 +1,50 @@
+# Skills CLI plugin manifest
+
+**Status:** Accepted.
+
+## Context
+
+`npx skills add` shows a flat searchable list unless the cloned repository
+declares plugins in `.claude-plugin/marketplace.json` (or `plugin.json`). The
+CLI maps each listed skill path to a `pluginName` and switches the install
+prompt to a grouped tree (select a category header to toggle every skill in
+it).
+
+This repository already groups promoted skills into editorial categories in
+`catalog.json` (`jira`, `plugins`, `ci`, `release`, `reference`, `meta`). Those
+folders remain editorial for install layout — skills still flatten into host
+skill directories — but the same membership is the natural grouping for the
+installer UI.
+
+Shipping a Claude Code marketplace plugin was considered and rejected: the pack
+installs through skills.sh / `npx skills` and `/setup-rhdh-skills`, not
+`claude plugins install`.
+
+## Decision
+
+Keep `.claude-plugin/marketplace.json` as a **generated projection** of
+`skills/meta/setup-rhdh-skills/assets/catalog.json`:
+
+- One marketplace plugin per catalog category.
+- Plugin `name` is the category label shown in the installer (`CI` spelled as an
+  acronym so the CLI does not render "Ci").
+- Each plugin lists `./skills/<category>/<name>` paths in catalog order.
+- No root `plugin.json` umbrella — that shape implies a single Claude plugin
+  bundle we do not ship.
+
+Regenerate with `scripts/generate_plugin_manifest.py` (`--write` / `--check`).
+Pre-commit rewrites the file when the catalog (or the manifest) changes; tests
+fail on drift.
+
+Document the directory in `.claude-plugin/README.md` so the files are not
+removed as "leftover marketplace" scaffolding.
+
+## Consequences
+
+- `npx skills add redhat-developer/rhdh-skills` shows six collapsible groups
+  instead of a flat list of ~40 skills.
+- Category membership has one source of truth: the setup catalog. The manifest
+  cannot invent skills the catalog does not list.
+- Editorial category renames require a catalog change; the manifest follows.
+- Contributors must not treat `.claude-plugin/` as a product surface for Claude
+  Code plugin distribution.

--- a/docs/adr/0009-skills-cli-plugin-manifest.md
+++ b/docs/adr/0009-skills-cli-plugin-manifest.md
@@ -10,25 +10,35 @@ CLI maps each listed skill path to a `pluginName` and switches the install
 prompt to a grouped tree (select a category header to toggle every skill in
 it).
 
-This repository already groups promoted skills into editorial categories in
-`catalog.json` (`jira`, `plugins`, `ci`, `release`, `reference`, `meta`). Those
-folders remain editorial for install layout — skills still flatten into host
-skill directories — but the same membership is the natural grouping for the
-installer UI.
+This repository groups promoted skills into editorial categories in
+`catalog.json` (`jira`, `plugins`, `ci`, `release`, `reference`, `meta`).
+Folders remain editorial for readers of the repo — skills still flatten into
+host skill directories at install. The installer UI should follow the same
+membership, with one exception: `reference` is a shared support layer other
+skills invoke by name. Offering it as its own install group invites incomplete
+installs (domain skills without the gate, API, or forge they call).
 
 Shipping a Claude Code marketplace plugin was considered and rejected: the pack
 installs through skills.sh / `npx skills` and `/setup-rhdh-skills`, not
 `claude plugins install`.
+
+The skills CLI does not yet honor a `depends` frontmatter field (proposed
+upstream, not shipped). Until it does, the only way a category group install
+pulls support skills is to list those paths in that category's plugin `skills`
+array.
 
 ## Decision
 
 Keep `.claude-plugin/marketplace.json` as a **generated projection** of
 `skills/meta/setup-rhdh-skills/assets/catalog.json`:
 
-- One marketplace plugin per catalog category.
+- One marketplace plugin per **installable** catalog category (`reference` is
+  omitted).
 - Plugin `name` is the category label shown in the installer (`CI` spelled as an
   acronym so the CLI does not render "Ci").
-- Each plugin lists `./skills/<category>/<name>` paths in catalog order.
+- Each plugin lists that category's `./skills/<category>/<name>` paths, then the
+  transitive `requiresSkills` closure of skills whose catalog category is
+  `reference` (not `optionalSkills`).
 - No root `plugin.json` umbrella — that shape implies a single Claude plugin
   bundle we do not ship.
 
@@ -41,10 +51,20 @@ removed as "leftover marketplace" scaffolding.
 
 ## Consequences
 
-- `npx skills add redhat-developer/rhdh-skills` shows six collapsible groups
-  instead of a flat list of ~40 skills.
+- `npx skills add redhat-developer/rhdh-skills` shows five collapsible groups
+  (Jira, Plugins, CI, Release, Meta). Selecting a group lists that domain's
+  skills plus the reference skills they require.
+- The `reference/` folder and catalog category remain for authors and
+  validators; they are not an installer group.
+- The skills CLI assigns each skill path one `pluginName` (last plugin that
+  lists it wins). The generator therefore emits installable plugins in reverse
+  catalog order so earlier categories (Jira, then Plugins, …) keep shared
+  reference skills in their tree group. A Plugins-only or Meta-only select can
+  still miss a shared skill that an earlier category also requires and therefore
+  owns in the UI. Prefer installing every domain group you need, or the full
+  set, until upstream `depends` can attach support skills to each selected
+  skill regardless of group.
 - Category membership has one source of truth: the setup catalog. The manifest
   cannot invent skills the catalog does not list.
-- Editorial category renames require a catalog change; the manifest follows.
 - Contributors must not treat `.claude-plugin/` as a product surface for Claude
   Code plugin distribution.

--- a/scripts/generate_plugin_manifest.py
+++ b/scripts/generate_plugin_manifest.py
@@ -2,8 +2,10 @@
 """Generate `.claude-plugin/marketplace.json` from the skill catalog.
 
 The marketplace file is a projection for `npx skills add` grouping, not a Claude
-Code marketplace product and not a second inventory. Membership and category
-order come from `catalog.json`; hand-editing the generated file will drift.
+Code marketplace product and not a second inventory. Membership comes from
+`catalog.json`. The `reference` category is editorial only: those skills are
+folded into every installable category that `requiresSkills` them (transitively),
+so selecting that category installs its support layer too.
 
     python scripts/generate_plugin_manifest.py            # print the JSON
     python scripts/generate_plugin_manifest.py --write    # rewrite marketplace.json
@@ -23,6 +25,10 @@ from typing import Any
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CATALOG_PATH = REPO_ROOT / "skills" / "meta" / "setup-rhdh-skills" / "assets" / "catalog.json"
 MANIFEST_PATH = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+
+# Editorial category that must not appear as an installer group. Its skills ship
+# as dependencies of the installable categories that require them.
+HIDDEN_INSTALL_CATEGORIES = frozenset({"reference"})
 
 # skills CLI title-cases each kebab segment; spell acronyms so the tree reads
 # "CI" rather than "Ci".
@@ -47,8 +53,54 @@ def plugin_description(category: str) -> str:
     return f"{label} skills from the RHDH pack"
 
 
+def _skill_path(entry: dict[str, Any]) -> str:
+    return f"./skills/{entry['category']}/{entry['name']}"
+
+
+def _reference_closure(
+    skill_name: str,
+    by_name: dict[str, dict[str, Any]],
+    visiting: set[str] | None = None,
+) -> list[str]:
+    """Return reference-skill paths required by ``skill_name``, dependents first.
+
+    Walks ``requiresSkills`` only (not ``optionalSkills``). Non-reference
+    dependencies are followed when they themselves require reference skills.
+    """
+    if visiting is None:
+        visiting = set()
+    if skill_name in visiting:
+        raise ValueError(f"requiresSkills cycle involving {skill_name}")
+    visiting.add(skill_name)
+
+    entry = by_name.get(skill_name)
+    if entry is None:
+        raise ValueError(f"requiresSkills names unknown skill {skill_name!r}")
+
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for dependency in entry.get("requiresSkills") or []:
+        if not isinstance(dependency, str):
+            raise ValueError(f"{skill_name}: requiresSkills entries must be strings")
+        dep_entry = by_name.get(dependency)
+        if dep_entry is None:
+            raise ValueError(f"{skill_name}: requiresSkills names unknown skill {dependency!r}")
+        for path in _reference_closure(dependency, by_name, visiting):
+            if path not in seen:
+                seen.add(path)
+                ordered.append(path)
+        if dep_entry.get("category") in HIDDEN_INSTALL_CATEGORIES:
+            path = _skill_path(dep_entry)
+            if path not in seen:
+                seen.add(path)
+                ordered.append(path)
+
+    visiting.remove(skill_name)
+    return ordered
+
+
 def build_manifest(catalog: dict[str, Any]) -> dict[str, Any]:
-    """One marketplace plugin per catalog category, skills in catalog order."""
+    """One marketplace plugin per installable category, with reference deps folded in."""
     categories = catalog.get("categories")
     skills = catalog.get("skills")
     pack = catalog.get("pack") or {}
@@ -57,7 +109,8 @@ def build_manifest(catalog: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(skills, list):
         raise ValueError("catalog.json has no skills list")
 
-    by_category: dict[str, list[str]] = {category: [] for category in categories}
+    by_name: dict[str, dict[str, Any]] = {}
+    by_category: dict[str, list[dict[str, Any]]] = {category: [] for category in categories}
     for entry in skills:
         name = entry.get("name")
         category = entry.get("category")
@@ -65,13 +118,33 @@ def build_manifest(catalog: dict[str, Any]) -> dict[str, Any]:
             raise ValueError(f"catalog skill entry missing name/category: {entry!r}")
         if category not in by_category:
             raise ValueError(f"{name}: category {category!r} is not in catalog categories")
-        by_category[category].append(f"./skills/{category}/{name}")
+        if name in by_name:
+            raise ValueError(f"duplicate catalog skill name {name!r}")
+        by_name[name] = entry
+        by_category[category].append(entry)
+
+    installable = [category for category in categories if category not in HIDDEN_INSTALL_CATEGORIES]
+    if not installable:
+        raise ValueError("catalog.json has no installable categories")
 
     plugins = []
-    for category in categories:
-        paths = by_category[category]
-        if not paths:
+    for category in installable:
+        entries = by_category[category]
+        if not entries:
             raise ValueError(f"category {category!r} has no skills in the catalog")
+
+        paths: list[str] = []
+        seen: set[str] = set()
+        for entry in entries:
+            own = _skill_path(entry)
+            if own not in seen:
+                seen.add(own)
+                paths.append(own)
+            for path in _reference_closure(entry["name"], by_name):
+                if path not in seen:
+                    seen.add(path)
+                    paths.append(path)
+
         plugins.append(
             {
                 "name": plugin_name(category),
@@ -80,6 +153,10 @@ def build_manifest(catalog: dict[str, Any]) -> dict[str, Any]:
                 "skills": paths,
             }
         )
+
+    # skills CLI: last plugin that lists a path wins pluginName. Put earlier
+    # installable categories last so shared reference skills stay in those groups.
+    plugins.reverse()
 
     source = pack.get("source") or "redhat-developer/rhdh-skills"
     return {
@@ -90,7 +167,9 @@ def build_manifest(catalog: dict[str, Any]) -> dict[str, Any]:
         },
         "description": (
             "Projection of the promoted RHDH skill catalog for npx skills "
-            "installer grouping. Not a Claude Code marketplace product."
+            "installer grouping. Not a Claude Code marketplace product. "
+            "Reference skills are folded into each installable category that "
+            "requires them."
         ),
         "plugins": plugins,
     }

--- a/scripts/generate_plugin_manifest.py
+++ b/scripts/generate_plugin_manifest.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Generate `.claude-plugin/marketplace.json` from the skill catalog.
+
+The marketplace file is a projection for `npx skills add` grouping, not a Claude
+Code marketplace product and not a second inventory. Membership and category
+order come from `catalog.json`; hand-editing the generated file will drift.
+
+    python scripts/generate_plugin_manifest.py            # print the JSON
+    python scripts/generate_plugin_manifest.py --write    # rewrite marketplace.json
+    python scripts/generate_plugin_manifest.py --check    # exit 1 if stale
+
+Exit codes: 0 in sync or written, 1 stale under --check, 2 inputs unreadable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CATALOG_PATH = REPO_ROOT / "skills" / "meta" / "setup-rhdh-skills" / "assets" / "catalog.json"
+MANIFEST_PATH = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+
+# skills CLI title-cases each kebab segment; spell acronyms so the tree reads
+# "CI" rather than "Ci".
+PLUGIN_NAME_BY_CATEGORY = {
+    "ci": "CI",
+}
+
+
+def _fail(message: str) -> None:
+    json.dump({"ok": False, "error": message}, sys.stdout, indent=2)
+    print()
+    sys.exit(2)
+
+
+def plugin_name(category: str) -> str:
+    return PLUGIN_NAME_BY_CATEGORY.get(category, category)
+
+
+def plugin_description(category: str) -> str:
+    name = plugin_name(category)
+    label = name if category in PLUGIN_NAME_BY_CATEGORY else name[:1].upper() + name[1:]
+    return f"{label} skills from the RHDH pack"
+
+
+def build_manifest(catalog: dict[str, Any]) -> dict[str, Any]:
+    """One marketplace plugin per catalog category, skills in catalog order."""
+    categories = catalog.get("categories")
+    skills = catalog.get("skills")
+    pack = catalog.get("pack") or {}
+    if not isinstance(categories, list) or not categories:
+        raise ValueError("catalog.json has no categories list")
+    if not isinstance(skills, list):
+        raise ValueError("catalog.json has no skills list")
+
+    by_category: dict[str, list[str]] = {category: [] for category in categories}
+    for entry in skills:
+        name = entry.get("name")
+        category = entry.get("category")
+        if not isinstance(name, str) or not isinstance(category, str):
+            raise ValueError(f"catalog skill entry missing name/category: {entry!r}")
+        if category not in by_category:
+            raise ValueError(f"{name}: category {category!r} is not in catalog categories")
+        by_category[category].append(f"./skills/{category}/{name}")
+
+    plugins = []
+    for category in categories:
+        paths = by_category[category]
+        if not paths:
+            raise ValueError(f"category {category!r} has no skills in the catalog")
+        plugins.append(
+            {
+                "name": plugin_name(category),
+                "source": "./",
+                "description": plugin_description(category),
+                "skills": paths,
+            }
+        )
+
+    source = pack.get("source") or "redhat-developer/rhdh-skills"
+    return {
+        "name": "rhdh-skills",
+        "owner": {
+            "name": "Red Hat Developer Hub",
+            "url": f"https://github.com/{source}",
+        },
+        "description": (
+            "Projection of the promoted RHDH skill catalog for npx skills "
+            "installer grouping. Not a Claude Code marketplace product."
+        ),
+        "plugins": plugins,
+    }
+
+
+def render_manifest() -> str:
+    catalog = json.loads(CATALOG_PATH.read_text(encoding="utf-8"))
+    return json.dumps(build_manifest(catalog), indent=2) + "\n"
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        prog="generate_plugin_manifest",
+        description="Generate .claude-plugin/marketplace.json from the skill catalog.",
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--write", action="store_true", help="rewrite marketplace.json")
+    mode.add_argument("--check", action="store_true", help="exit 1 if marketplace.json is stale")
+    parser.add_argument("--json", action="store_true", help="structured output")
+    args = parser.parse_args(argv)
+
+    try:
+        rendered = render_manifest()
+    except (OSError, ValueError, KeyError, json.JSONDecodeError) as error:
+        _fail(str(error))
+        return
+
+    if not (args.write or args.check):
+        if args.json:
+            json.dump({"ok": True, "manifest": json.loads(rendered)}, sys.stdout, indent=2)
+            print()
+        else:
+            sys.stdout.write(rendered)
+        return
+
+    current = MANIFEST_PATH.read_text(encoding="utf-8") if MANIFEST_PATH.is_file() else ""
+    in_sync = current == rendered
+
+    if args.check:
+        if args.json or not in_sync:
+            json.dump(
+                {
+                    "ok": in_sync,
+                    "path": str(MANIFEST_PATH),
+                    "expected": rendered,
+                    "found": current,
+                },
+                sys.stdout,
+                indent=2,
+            )
+            print()
+        sys.exit(0 if in_sync else 1)
+
+    if not in_sync:
+        MANIFEST_PATH.parent.mkdir(parents=True, exist_ok=True)
+        MANIFEST_PATH.write_text(rendered, encoding="utf-8")
+    if args.json:
+        json.dump(
+            {"ok": True, "path": str(MANIFEST_PATH), "rewritten": not in_sync},
+            sys.stdout,
+            indent=2,
+        )
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_plugin_manifest.py
+++ b/tests/unit/test_plugin_manifest.py
@@ -43,17 +43,60 @@ def test_the_generator_can_read_its_inputs():
     )
 
 
-def test_every_catalog_skill_is_listed_under_its_category_plugin():
-    """One marketplace plugin per category; every catalog skill path appears once."""
+def test_reference_is_not_an_installer_group():
+    """Reference stays editorial; the installer must not offer a Reference group."""
     generator = load_generator()
     catalog = generator.json.loads(generator.CATALOG_PATH.read_text(encoding="utf-8"))
     manifest = generator.build_manifest(catalog)
 
-    plugins = {plugin["name"]: plugin for plugin in manifest["plugins"]}
-    assert list(plugins) == [generator.plugin_name(category) for category in catalog["categories"]]
-
-    expected_paths = {
-        f"./skills/{entry['category']}/{entry['name']}" for entry in catalog["skills"]
+    assert "reference" in catalog["categories"]
+    assert generator.plugin_name("reference") not in {
+        plugin["name"] for plugin in manifest["plugins"]
     }
-    listed_paths = {path for plugin in manifest["plugins"] for path in plugin["skills"]}
-    assert listed_paths == expected_paths
+    installable = [
+        category
+        for category in catalog["categories"]
+        if category not in generator.HIDDEN_INSTALL_CATEGORIES
+    ]
+    # Manifest plugins are reversed so earlier categories win shared pluginNames.
+    assert [plugin["name"] for plugin in manifest["plugins"]] == [
+        generator.plugin_name(category) for category in reversed(installable)
+    ]
+
+
+def test_each_installable_category_includes_its_reference_requires():
+    """Selecting a category group must list that category's required reference skills."""
+    generator = load_generator()
+    catalog = generator.json.loads(generator.CATALOG_PATH.read_text(encoding="utf-8"))
+    by_name = {entry["name"]: entry for entry in catalog["skills"]}
+    manifest = generator.build_manifest(catalog)
+    plugins = {plugin["name"]: plugin for plugin in manifest["plugins"]}
+
+    for entry in catalog["skills"]:
+        category = entry["category"]
+        if category in generator.HIDDEN_INSTALL_CATEGORIES:
+            continue
+        plugin = plugins[generator.plugin_name(category)]
+        assert generator._skill_path(entry) in plugin["skills"]
+        for path in generator._reference_closure(entry["name"], by_name):
+            assert path in plugin["skills"], (
+                f"{entry['name']} requires {path}, but the {category} plugin omits it"
+            )
+
+
+def test_every_required_reference_skill_is_reachable_from_some_plugin():
+    """No required reference skill is left only in the hidden editorial category."""
+    generator = load_generator()
+    catalog = generator.json.loads(generator.CATALOG_PATH.read_text(encoding="utf-8"))
+    by_name = {entry["name"]: entry for entry in catalog["skills"]}
+    manifest = generator.build_manifest(catalog)
+    listed = {path for plugin in manifest["plugins"] for path in plugin["skills"]}
+
+    required_reference = set()
+    for entry in catalog["skills"]:
+        if entry["category"] in generator.HIDDEN_INSTALL_CATEGORIES:
+            continue
+        required_reference.update(generator._reference_closure(entry["name"], by_name))
+
+    assert required_reference
+    assert required_reference <= listed

--- a/tests/unit/test_plugin_manifest.py
+++ b/tests/unit/test_plugin_manifest.py
@@ -1,0 +1,59 @@
+"""The skills CLI marketplace manifest is a projection of the catalog, not a second inventory."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+GENERATOR = PROJECT_ROOT / "scripts" / "generate_plugin_manifest.py"
+
+
+def load_generator():
+    """Import the generator by path; it is a repo script, not an installed module."""
+    spec = importlib.util.spec_from_file_location("generate_plugin_manifest", GENERATOR)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def check_exit_code() -> int:
+    """Run `--check` in-process and return the code it exits with."""
+    generator = load_generator()
+    with pytest.raises(SystemExit) as exit_info:
+        generator.main(["--check"])
+    return exit_info.value.code
+
+
+def test_the_plugin_manifest_matches_the_catalog():
+    """A stale marketplace.json fails the suite."""
+    assert check_exit_code() == 0, (
+        "`.claude-plugin/marketplace.json` has drifted from the catalog. "
+        "Regenerate it:\n"
+        "  uv run python scripts/generate_plugin_manifest.py --write"
+    )
+
+
+def test_the_generator_can_read_its_inputs():
+    """Exit 2 means the generator broke; do not conflate that with a passing check."""
+    assert check_exit_code() != 2, (
+        "generate_plugin_manifest.py could not read its inputs. Check that "
+        f"{GENERATOR} still resolves CATALOG_PATH."
+    )
+
+
+def test_every_catalog_skill_is_listed_under_its_category_plugin():
+    """One marketplace plugin per category; every catalog skill path appears once."""
+    generator = load_generator()
+    catalog = generator.json.loads(generator.CATALOG_PATH.read_text(encoding="utf-8"))
+    manifest = generator.build_manifest(catalog)
+
+    plugins = {plugin["name"]: plugin for plugin in manifest["plugins"]}
+    assert list(plugins) == [generator.plugin_name(category) for category in catalog["categories"]]
+
+    expected_paths = {
+        f"./skills/{entry['category']}/{entry['name']}" for entry in catalog["skills"]
+    }
+    listed_paths = {path for plugin in manifest["plugins"] for path in plugin["skills"]}
+    assert listed_paths == expected_paths


### PR DESCRIPTION
`npx skills add redhat-developer/rhdh-skills` now shows six collapsible category groups (Jira, Plugins, CI, Release, Reference, Meta) instead of a flat list of ~40 skills.

This comes from a generated `.claude-plugin/marketplace.json` projected from `catalog.json`. Pre-commit and a `--check` test keep it from drifting. The directory is intentionally **not** a Claude Code marketplace product — ADR-0009 records why it still exists.

README install commands now use `--global` and let the wizard pick skills from mattpocock/skills rather than pinning grilling/handoff on the command line.
