### PR TITLE
fix(rhdh-base-images): keep newer go.mod pins and drop RPM source noise

### DIFF
--- a/skills/ci/rhdh-base-images/SKILL.md
+++ b/skills/ci/rhdh-base-images/SKILL.md
@@ -50,8 +50,14 @@ tree is clean before writing.
   GitLab scripts branch in `references/repos.md`.
 - Keep base-image UBI minors aligned with RPM repository URLs.
 - On RHDH, update Node headers when the builder image changes Node.
-- On rhdh-operator `main`, align `go.mod` with the Go toolset image.
+- On rhdh-operator `main`, raise `go.mod` to the Go toolset image when the
+  image is newer. Never lower `go` or `toolchain` to match an older image;
+  a newer pin (for example from Renovate) is valid.
 - Exclude RHDH `e2e-tests/` and `.ci/` from image scans.
+- Ignore `rpm-lockfile-prototype` lines matching `No sources found for` or
+  "no matching sources". Those source RPMs are often unpublished; the binary
+  lockfile is still valid. Do not report them as unread, failed, or remaining
+  risks.
 
 Another skill invokes `/rhdh-base-images` by name and uses what it reports; it
 never reaches for these script paths.
@@ -61,7 +67,8 @@ never reaches for these script paths.
 An analysis is complete when every repository in scope is named with its current
 and latest tag, UBI skew and toolchain drift are stated or stated as none, and
 every registry, lockfile, or branch the scan could not read is named as unread
-instead of reported as current.
+instead of reported as current. Filtered `No sources found for` /
+"no matching sources" lines are not unread and are omitted from the report.
 
 An update is complete when the target branch was verified to exist against a
 clean working tree before any edit, every approved operation has been reported by

--- a/skills/ci/rhdh-base-images/scripts/base-images-and-rpms.sh
+++ b/skills/ci/rhdh-base-images/scripts/base-images-and-rpms.sh
@@ -272,12 +272,19 @@ open_automation_pr_in_browser() {
     popd >/dev/null
 }
 
+# rpm-lockfile-prototype logs this when a binary RPM has no matching source RPM
+# in repo metadata (common for kernel-headers, efi-srpm-macros). The binary
+# lockfile is still valid; never surface those lines to the agent.
+filter_rpm_lockfile_source_warnings() {
+    grep -viE -- 'no sources found for |no matching sources' || true
+}
+
 update_rpm_lockfile() {
     local repo_dir="$1"
     local kind="$2"
     local rpm_tool="$3"
     local branch="$4"
-    local containerfile
+    local containerfile rpm_err rpm_rc
     containerfile=$(rpm_containerfile_for "${repo_dir}" "${kind}")
 
     [[ -f "${repo_dir}/${containerfile}" ]] || die "${repo_dir}: missing ${containerfile}"
@@ -291,8 +298,14 @@ update_rpm_lockfile() {
     fi
 
     pushd "${repo_dir}" >/dev/null
-    "${rpm_tool}" -f "${containerfile}" rpms.in.yaml \
-        || warn "rpm-lockfile-prototype failed for ${repo_dir}; keeping existing rpms.lock.yaml"
+    rpm_err=$(mktemp)
+    rpm_rc=0
+    "${rpm_tool}" -f "${containerfile}" rpms.in.yaml 2>"${rpm_err}" || rpm_rc=$?
+    filter_rpm_lockfile_source_warnings <"${rpm_err}" >&2
+    rm -f "${rpm_err}"
+    if [[ ${rpm_rc} -ne 0 ]]; then
+        warn "rpm-lockfile-prototype failed for ${repo_dir}; keeping existing rpms.lock.yaml"
+    fi
     commit_push_rpm_lockfile "${branch}"
     popd >/dev/null
 }
@@ -515,6 +528,14 @@ go_mod_language_version() {
     echo "${major}.${minor}.0"
 }
 
+# Return 0 if version $1 is greater than or equal to version $2.
+# Accepts optional "go" prefix. Empty operands are not greater-or-equal.
+go_version_gte() {
+    local left="${1#go}" right="${2#go}"
+    [[ -n "${left}" && -n "${right}" ]] || return 1
+    [[ "$(printf '%s\n%s\n' "${left}" "${right}" | sort -V | tail -n1)" == "${left}" ]]
+}
+
 update_operator_go_mod() {
     local repo_dir="$1"
     local branch="$2"
@@ -554,18 +575,36 @@ update_operator_go_mod() {
 
     go_lang=$(go_mod_language_version "${go_full}")
     current_toolchain=$(grep -E '^toolchain ' go.mod 2>/dev/null | awk '{print $2}' || true)
-    if [[ "${current_toolchain}" == "go${go_full}" ]] \
-        && grep -qE "^go ${go_lang}$" go.mod 2>/dev/null; then
-        log "Go toolchain: already aligned with go${go_full}"
+    local current_go current_plain bump_go=0 bump_toolchain=0
+    current_go=$(grep -E '^go ' go.mod 2>/dev/null | awk '{print $2}' || true)
+    current_plain="${current_toolchain#go}"
+
+    # Never lower go.mod to match an older toolset image. A newer toolchain
+    # (for example from Renovate) is valid in Konflux local-toolchain mode.
+    if [[ -z "${current_go}" ]] || ! go_version_gte "${current_go}" "${go_lang}"; then
+        bump_go=1
+    fi
+    if [[ -z "${current_plain}" ]] || ! go_version_gte "${current_plain}" "${go_full}"; then
+        bump_toolchain=1
+    fi
+
+    if [[ ${bump_go} -eq 0 && ${bump_toolchain} -eq 0 ]]; then
+        if [[ "${current_plain}" == "${go_full}" ]]; then
+            log "Go toolchain: already aligned with go${go_full}"
+        else
+            log "Go toolchain: keeping ${current_toolchain} (newer than image go${go_full}; will not downgrade)"
+        fi
         popd >/dev/null
         return 0
     fi
 
-    log "Go toolchain: updating go.mod to go ${go_lang} / toolchain go${go_full}"
-    sed -i \
-        -e "s/^go .*/go ${go_lang}/" \
-        -e "s/^toolchain .*/toolchain go${go_full}/" \
-        go.mod
+    log "Go toolchain: updating go.mod to go ${go_lang} / toolchain go${go_full} (forward only)"
+    if [[ ${bump_go} -eq 1 ]]; then
+        sed -i -e "s/^go .*/go ${go_lang}/" go.mod
+    fi
+    if [[ ${bump_toolchain} -eq 1 ]]; then
+        sed -i -e "s/^toolchain .*/toolchain go${go_full}/" go.mod
+    fi
 
     commit_push_paths "${branch}" "chore: align go.mod with ubi9/go-toolset go${go_full} [skip-build]" go.mod
     popd >/dev/null

--- a/skills/ci/rhdh-base-images/workflows/update-base-images.md
+++ b/skills/ci/rhdh-base-images/workflows/update-base-images.md
@@ -150,6 +150,8 @@ git push origin <chore/automated-update-base-images-*>   # same PR as base image
 
 When no base-images PR exists (e.g. `--skip-base`), the script uses `chore/automated-update-rpm-lockfile/<branch>` and opens a PR.
 
+`rpm-lockfile-prototype` often logs `No sources found for <pkg>` when the matching source RPM is unpublished (commonly `kernel-headers` and `efi-srpm-macros`). The bundled script drops those lines. Never list them as remaining risks; Konflux still consumes the binary lockfile.
+
 ### Node headers (rhdh only)
 
 When the `ubi9/nodejs-*` builder image in `build/containerfiles/Containerfile` ships a different Node version than `.nvmrc` / `.nvm/releases/`, the script:
@@ -163,12 +165,14 @@ See [rhdh `.nvm/releases/README.adoc`](https://github.com/redhat-developer/rhdh/
 
 ### Go toolchain (rhdh-operator, main only)
 
-On **main** only (not `release-*`), after base image bumps, reads `go version` from the `ubi9/go-toolset` image in `.rhdh/docker/Dockerfile` and updates `go.mod`:
+On **main** only (not `release-*`), after base image bumps, reads `go version` from the `ubi9/go-toolset` image in `.rhdh/docker/Dockerfile` and updates `go.mod` **only when that version is newer** than the current `go` / `toolchain` lines:
 
 ```text
 go 1.26.0
 toolchain go1.26.4
 ```
+
+Do not downgrade. If `go.mod` already pins a newer toolchain (for example `go1.26.6` from Renovate while the image ships `go1.26.5`), leave it. Konflux builds with the local toolchain; matching the image is not required.
 
 ## Anti-patterns
 
@@ -176,6 +180,8 @@ toolchain go1.26.4
 - Running on a branch that does not exist in one of the three repos.
 - Omitting `registry.redhat.io` login before base image updates.
 - Committing `rpms.lock.yaml` without checking the base image minor (e.g. UBI `9.8`) still matches `rpms.in.yaml` repo URLs.
+- Treating `rpm-lockfile-prototype` `No sources found for` / "no matching sources" warnings as a failure or remaining risk. The source RPM is often unpublished; the lockfile is still valid.
+- Lowering `go.mod` `toolchain` (or `go`) to match an older `ubi9/go-toolset` image. Keep the newer pin.
 
 ## Additional resources
 

--- a/tests/unit/test_base_images_and_rpms.py
+++ b/tests/unit/test_base_images_and_rpms.py
@@ -239,6 +239,27 @@ class TestAnalyzeBaseImagesScript:
         assert "SKIPPED (no well-formed tag" in result.stdout
 
 
+NO_SOURCES_FOUND_FOR = "No sources found for"
+
+
+def _extract_bash_function(script: Path, name: str) -> str:
+    """Return the named top-level `name() { ... }` body from a Bash script."""
+    text = script.read_text(encoding="utf-8")
+    marker = f"{name}() {{"
+    start = text.find(marker)
+    if start < 0:
+        raise AssertionError(f"{name}() not found in {script}")
+    depth = 0
+    for index, char in enumerate(text[start:], start):
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : index + 1]
+    raise AssertionError(f"{name}() is unclosed in {script}")
+
+
 class TestBaseImagesAndRpmsScript:
     """Smoke tests for the orchestrator --analyze flag."""
 
@@ -251,3 +272,70 @@ class TestBaseImagesAndRpmsScript:
         )
         assert result.returncode == 0
         assert "--analyze" in result.stdout
+
+    def test_skill_instructs_ignoring_rpm_source_warnings(self) -> None:
+        skill = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+        assert NO_SOURCES_FOUND_FOR in skill
+        assert "no matching sources" in skill
+        assert "Do not report them as unread, failed, or remaining" in skill
+
+    def test_script_pipes_rpm_stderr_through_source_warning_filter(self) -> None:
+        script = MAIN_SCRIPT.read_text(encoding="utf-8")
+        assert "filter_rpm_lockfile_source_warnings <\"${rpm_err}\"" in script
+
+    def test_filter_rpm_lockfile_source_warnings_drops_noise(self) -> None:
+        function = _extract_bash_function(MAIN_SCRIPT, "filter_rpm_lockfile_source_warnings")
+        noise = (
+            f"WARNING:rpm_lockfile:{NO_SOURCES_FOUND_FOR} "
+            "kernel-headers-5.14.0-687.41.1.el9_8.x86_64\n"
+            f"WARNING:rpm_lockfile:{NO_SOURCES_FOUND_FOR} efi-srpm-macros-6-4.el9.noarch\n"
+            "note: no matching sources for kernel-headers\n"
+            "error: dnf transaction failed\n"
+        )
+        result = subprocess.run(
+            ["bash", "-c", f"{function}\nfilter_rpm_lockfile_source_warnings"],
+            input=noise,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout == "error: dnf transaction failed\n"
+
+    def test_skill_forbids_go_toolchain_downgrade(self) -> None:
+        skill = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+        assert "Never lower `go` or `toolchain`" in skill
+        script = MAIN_SCRIPT.read_text(encoding="utf-8")
+        assert "will not downgrade" in script
+
+
+class TestGoVersionGte:
+    """Forward-only Go toolchain compares used before editing operator go.mod."""
+
+    @staticmethod
+    def _gte(left: str, right: str) -> int:
+        function = _extract_bash_function(MAIN_SCRIPT, "go_version_gte")
+        quoted_left = "''" if left == "" else left
+        quoted_right = "''" if right == "" else right
+        result = subprocess.run(
+            ["bash", "-c", f"{function}\ngo_version_gte {quoted_left} {quoted_right}"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return result.returncode
+
+    def test_newer_patch_is_gte(self) -> None:
+        assert self._gte("1.26.6", "1.26.5") == 0
+
+    def test_older_patch_is_not_gte(self) -> None:
+        assert self._gte("1.26.5", "1.26.6") == 1
+
+    def test_equal_is_gte(self) -> None:
+        assert self._gte("1.26.5", "1.26.5") == 0
+
+    def test_strips_go_prefix(self) -> None:
+        assert self._gte("go1.26.6", "1.26.5") == 0
+
+    def test_empty_is_not_gte(self) -> None:
+        assert self._gte("", "1.26.5") == 1

--- a/tests/unit/test_base_images_and_rpms.py
+++ b/tests/unit/test_base_images_and_rpms.py
@@ -281,7 +281,7 @@ class TestBaseImagesAndRpmsScript:
 
     def test_script_pipes_rpm_stderr_through_source_warning_filter(self) -> None:
         script = MAIN_SCRIPT.read_text(encoding="utf-8")
-        assert "filter_rpm_lockfile_source_warnings <\"${rpm_err}\"" in script
+        assert 'filter_rpm_lockfile_source_warnings <"${rpm_err}"' in script
 
     def test_filter_rpm_lockfile_source_warnings_drops_noise(self) -> None:
         function = _extract_bash_function(MAIN_SCRIPT, "filter_rpm_lockfile_source_warnings")


### PR DESCRIPTION
## Summary
- `/rhdh-base-images` no longer lowers rhdh-operator `go.mod` `toolchain`/`go` to match an older `ubi9/go-toolset` image (see rhdh-operator #3402).
- `rpm-lockfile-prototype` `No sources found for` / "no matching sources" lines are filtered and not treated as remaining risks.

## Test plan
- [x] `uv run pytest tests/unit/test_base_images_and_rpms.py`
- [ ] Review the forward-only `go_version_gte` cases and RPM stderr filter tests.

Generated-by: cursor

Ref: https://redhat.atlassian.net/browse/RHIDP-16501
