### PR TITLE
docs(rhdh-konflux-tasks): prefer -oci-ta task variants in PLRs

### DIFF
--- a/skills/ci/rhdh-konflux-tasks/SKILL.md
+++ b/skills/ci/rhdh-konflux-tasks/SKILL.md
@@ -52,9 +52,23 @@ PLR.
 
 When the Konflux catalog ships both a workspace-based task and an
 `<name>-oci-ta` variant, **prefer the `-oci-ta` bundle** in templates,
-shared pipelines, and PLRs. OCI-TA tasks pass artifacts between steps with
-`SOURCE_ARTIFACT` / `CACHI2_ARTIFACT` results and `ociStorage` params instead
-of binding the `source` workspace.
+shared pipelines, and PLRs — **except operator-bundle** (see below).
+OCI-TA tasks pass artifacts between steps with `SOURCE_ARTIFACT` /
+`CACHI2_ARTIFACT` results and `ociStorage` params instead of binding the
+`source` workspace.
+
+**Scope:** apply OCI-TA preference to hub, operator, must-gather, rag-content,
+bootc, and (on variant B) hub/operator shared build-pipelines. **Do not**
+migrate `rhdh-operator-bundle.yaml` or `rhdh-operator-bundle-*` PLRs to
+`-oci-ta` tasks unless the user explicitly requests operator-bundle changes.
+`generatePipelineRuns.sh` still regenerates operator-bundle PLRs from that
+template; leave the template on legacy bundles when doing a stream-wide
+OCI-TA pass.
+
+**In scope (variant A examples):** `rhdh-pipeline.yaml`, `rhdh-bootc-pipeline.yaml`,
+`rhdh-rag-content-*` inline PLRs.
+
+**Out of scope:** `rhdh-operator-bundle.yaml`, `rhdh-operator-bundle-*` PLRs.
 
 Common midstream mappings (taskRef `name` → bundle image):
 
@@ -81,9 +95,10 @@ name may stay `prefetch-dependencies`):
 - Downstream tasks consume `$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)`
   and `CACHI2_ARTIFACT` instead of the `source` workspace.
 
-On variant B, migrate `prefetch-dependencies-hub` /
-`prefetch-dependencies-operator` **and** `prefetch-dependencies-bundle` when
-OCI-TA exists — do not leave bundle on non-OCI `task-prefetch-dependencies`.
+On variant B, migrate `prefetch-dependencies-hub` and
+`prefetch-dependencies-operator` when OCI-TA exists. **Do not** migrate
+operator-bundle prefetch (`prefetch-dependencies-bundle` /
+`rhdh-operator-bundle.yaml`) as part of a stream-wide OCI-TA pass.
 
 ## Writing rules
 

--- a/skills/ci/rhdh-konflux-tasks/SKILL.md
+++ b/skills/ci/rhdh-konflux-tasks/SKILL.md
@@ -52,25 +52,15 @@ PLR.
 
 When the Konflux catalog ships both a workspace-based task and an
 `<name>-oci-ta` variant, **prefer the `-oci-ta` bundle** in templates,
-shared pipelines, and PLRs — **except operator-bundle** (see below).
-OCI-TA tasks pass artifacts between steps with `SOURCE_ARTIFACT` /
-`CACHI2_ARTIFACT` results and `ociStorage` params instead of binding the
-`source` workspace.
+shared pipelines, and PLRs. OCI-TA tasks pass artifacts via
+`SOURCE_ARTIFACT` / `CACHI2_ARTIFACT` and `ociStorage` params instead of
+the `source` workspace.
 
-**Scope:** apply OCI-TA preference to hub, operator, must-gather, rag-content,
-bootc, and (on variant B) hub/operator shared build-pipelines. **Do not**
-migrate `rhdh-operator-bundle.yaml` or `rhdh-operator-bundle-*` PLRs to
-`-oci-ta` tasks unless the user explicitly requests operator-bundle changes.
-`generatePipelineRuns.sh` still regenerates operator-bundle PLRs from that
-template; leave the template on legacy bundles when doing a stream-wide
-OCI-TA pass.
-
-**In scope (variant A examples):** `rhdh-pipeline.yaml`, `rhdh-bootc-pipeline.yaml`,
-`rhdh-rag-content-*` inline PLRs.
-
-**Out of scope:** `rhdh-operator-bundle.yaml`, `rhdh-operator-bundle-*` PLRs.
-
-Common midstream mappings (taskRef `name` → bundle image):
+**Operator-bundle exception:** do not migrate `rhdh-operator-bundle.yaml` or
+`rhdh-operator-bundle-*` PLRs to `-oci-ta` tasks on a stream-wide pass unless
+the user explicitly requests operator-bundle changes. Hub, operator,
+must-gather, rag-content, and bootc are in scope. Per-variant file lists:
+[konflux-rhdh-midstream.md](references/konflux-rhdh-midstream.md#oci-ta-file-scope).
 
 | Legacy task | Preferred OCI-TA task |
 |-------------|----------------------|
@@ -84,21 +74,14 @@ Common midstream mappings (taskRef `name` → bundle image):
 | `push-dockerfile` | `push-dockerfile-oci-ta` |
 
 **`prefetch-dependencies` → `prefetch-dependencies-oci-ta`** (pipeline task
-name may stay `prefetch-dependencies`):
+name may stay `prefetch-dependencies`): add `SOURCE_ARTIFACT`,
+`ociStorage`, `ociArtifactExpiresAfter`, `enable-package-registry-proxy`;
+drop `dev-package-managers` and the `source` workspace; keep
+`git-basic-auth` and `netrc`; wire downstream tasks to prefetch
+`SOURCE_ARTIFACT` / `CACHI2_ARTIFACT` results.
 
-- Add params: `SOURCE_ARTIFACT` from `clone-repository`, `ociStorage`
-  (`$(params.output-image).prefetch`), `ociArtifactExpiresAfter`
-  (`$(params.image-expires-after)`), `enable-package-registry-proxy`
-  (`$(params.enable-package-registry-proxy)`).
-- Remove `dev-package-managers` and the `source` workspace binding; keep
-  `git-basic-auth` and `netrc` workspaces.
-- Downstream tasks consume `$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)`
-  and `CACHI2_ARTIFACT` instead of the `source` workspace.
-
-On variant B, migrate `prefetch-dependencies-hub` and
-`prefetch-dependencies-operator` when OCI-TA exists. **Do not** migrate
-operator-bundle prefetch (`prefetch-dependencies-bundle` /
-`rhdh-operator-bundle.yaml`) as part of a stream-wide OCI-TA pass.
+OCI-TA swaps are **not** handled by `updateDigests.sh` — apply params and
+workspaces from the task's live `MIGRATION.md`, then regenerate PLRs.
 
 ## Writing rules
 
@@ -109,9 +92,7 @@ writes. Follow `/mutation-gate`.
   explicitly asks. `generatePipelineRuns.sh` neither commits nor pushes.
 - When replacing a legacy task with `-oci-ta`, edit templates and shared
   pipelines first, then regenerate PLRs (or patch inline `pipelineSpec` PLRs by
-  hand).
-- Edit templates and shared pipelines first, then regenerate. Editing only the
-  PipelineRuns leaves the real source of truth stale.
+  hand). Editing only PLRs leaves the source of truth stale.
 - Apply only the user actions a live `MIGRATION.md` documents. Skip "no action
   required" sections, and do not invent drift checks or `verify_*` guards that
   will fail on the next Konflux bump.

--- a/skills/ci/rhdh-konflux-tasks/SKILL.md
+++ b/skills/ci/rhdh-konflux-tasks/SKILL.md
@@ -48,6 +48,43 @@ and the pipelines need to catch up", it is this skill. Never run a full
 regeneration to deliver a single workspace bump; it rewrites every component's
 PLR.
 
+## Prefer `-oci-ta` task variants
+
+When the Konflux catalog ships both a workspace-based task and an
+`<name>-oci-ta` variant, **prefer the `-oci-ta` bundle** in templates,
+shared pipelines, and PLRs. OCI-TA tasks pass artifacts between steps with
+`SOURCE_ARTIFACT` / `CACHI2_ARTIFACT` results and `ociStorage` params instead
+of binding the `source` workspace.
+
+Common midstream mappings (taskRef `name` → bundle image):
+
+| Legacy task | Preferred OCI-TA task |
+|-------------|----------------------|
+| `git-clone` | `git-clone-oci-ta` |
+| `prefetch-dependencies` | `prefetch-dependencies-oci-ta` |
+| `buildah` | `buildah-oci-ta` |
+| `source-build` | `source-build-oci-ta` |
+| `sast-snyk-check` | `sast-snyk-check-oci-ta` |
+| `sast-shell-check` | `sast-shell-check-oci-ta` |
+| `sast-unicode-check` | `sast-unicode-check-oci-ta` |
+| `push-dockerfile` | `push-dockerfile-oci-ta` |
+
+**`prefetch-dependencies` → `prefetch-dependencies-oci-ta`** (pipeline task
+name may stay `prefetch-dependencies`):
+
+- Add params: `SOURCE_ARTIFACT` from `clone-repository`, `ociStorage`
+  (`$(params.output-image).prefetch`), `ociArtifactExpiresAfter`
+  (`$(params.image-expires-after)`), `enable-package-registry-proxy`
+  (`$(params.enable-package-registry-proxy)`).
+- Remove `dev-package-managers` and the `source` workspace binding; keep
+  `git-basic-auth` and `netrc` workspaces.
+- Downstream tasks consume `$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)`
+  and `CACHI2_ARTIFACT` instead of the `source` workspace.
+
+On variant B, migrate `prefetch-dependencies-hub` /
+`prefetch-dependencies-operator` **and** `prefetch-dependencies-bundle` when
+OCI-TA exists — do not leave bundle on non-OCI `task-prefetch-dependencies`.
+
 ## Writing rules
 
 Editing `.tekton` YAML, committing, pushing, and opening a pull request are
@@ -55,6 +92,9 @@ writes. Follow `/mutation-gate`.
 
 - Always pass `--no-push` / `--nopush`. Do not push or open a PR unless the user
   explicitly asks. `generatePipelineRuns.sh` neither commits nor pushes.
+- When replacing a legacy task with `-oci-ta`, edit templates and shared
+  pipelines first, then regenerate PLRs (or patch inline `pipelineSpec` PLRs by
+  hand).
 - Edit templates and shared pipelines first, then regenerate. Editing only the
   PipelineRuns leaves the real source of truth stale.
 - Apply only the user actions a live `MIGRATION.md` documents. Skip "no action

--- a/skills/ci/rhdh-konflux-tasks/references/konflux-rhdh-midstream.md
+++ b/skills/ci/rhdh-konflux-tasks/references/konflux-rhdh-midstream.md
@@ -19,6 +19,8 @@ If unsure, run: `ls .tekton-templates/rhdh-pipeline.yaml .tekton-templates/rhdh-
 
 Used on current stable branches. Hub, operator, and must-gather share `rhdh-pipeline.yaml`; operator-bundle uses a separate template.
 
+**OCI-TA preference:** migrate tasks in `rhdh-pipeline.yaml`, `rhdh-bootc-pipeline.yaml`, and inline `rhdh-rag-content-*` PLRs. **Exclude** `rhdh-operator-bundle.yaml` and its generated PLRs unless the user explicitly requests operator-bundle changes.
+
 ### Files to update
 
 | Location | When to edit |
@@ -94,12 +96,11 @@ Apply in **three** places:
 3. **PLR templates** `rhdh-hub.yaml` / `rhdh-operator.yaml`:
    - Add `spec.params` entry so the value reaches the shared pipeline.
 4. **Operator-bundle template** `rhdh-operator-bundle.yaml`:
-   - Same as unified layout (inline `pipelineSpec`).
+   - Same as unified layout (inline `pipelineSpec`) — **only when operator-bundle is explicitly in scope**; skip OCI-TA task swaps on stream-wide passes.
 
-`prefetch-dependencies-bundle` should use `prefetch-dependencies-oci-ta` when the
-catalog offers it (same OCI-TA params and workspaces as hub/operator prefetch).
-Do not leave bundle on non-OCI `task-prefetch-dependencies` when an `-oci-ta`
-bundle exists.
+`prefetch-dependencies-bundle` on operator-bundle may remain on non-OCI
+`task-prefetch-dependencies` during hub/operator OCI-TA work. Do not migrate
+operator-bundle prefetch to `-oci-ta` unless the user asks.
 
 ### Generator notes
 

--- a/skills/ci/rhdh-konflux-tasks/references/konflux-rhdh-midstream.md
+++ b/skills/ci/rhdh-konflux-tasks/references/konflux-rhdh-midstream.md
@@ -96,7 +96,10 @@ Apply in **three** places:
 4. **Operator-bundle template** `rhdh-operator-bundle.yaml`:
    - Same as unified layout (inline `pipelineSpec`).
 
-`prefetch-dependencies-bundle` uses non-OCI `task-prefetch-dependencies` — no `enable-package-registry-proxy` change unless MIGRATION.md says so.
+`prefetch-dependencies-bundle` should use `prefetch-dependencies-oci-ta` when the
+catalog offers it (same OCI-TA params and workspaces as hub/operator prefetch).
+Do not leave bundle on non-OCI `task-prefetch-dependencies` when an `-oci-ta`
+bundle exists.
 
 ### Generator notes
 

--- a/skills/ci/rhdh-konflux-tasks/references/konflux-rhdh-midstream.md
+++ b/skills/ci/rhdh-konflux-tasks/references/konflux-rhdh-midstream.md
@@ -13,13 +13,25 @@ Detect which variant applies **before** editing (see table below). Edit **templa
 
 If unsure, run: `ls .tekton-templates/rhdh-pipeline.yaml .tekton-templates/rhdh-hub.yaml 2>/dev/null`
 
+## OCI-TA file scope
+
+Canonical rule and task mapping table:
+[SKILL.md § Prefer `-oci-ta`](../SKILL.md#prefer--oci-ta-task-variants).
+
+| Variant | In scope for `-oci-ta` swaps | Out of scope |
+|---------|------------------------------|--------------|
+| A (unified) | `rhdh-pipeline.yaml`, `rhdh-bootc-pipeline.yaml`, `rhdh-rag-content-*` PLRs | `rhdh-operator-bundle.yaml`, `rhdh-operator-bundle-*` PLRs |
+| B (1.9) | `build-pipeline-rhdh-hub.yaml`, `build-pipeline-rhdh-operator.yaml`, hub/operator PLR wrappers | `rhdh-operator-bundle.yaml`, `prefetch-dependencies-bundle` |
+
+`generatePipelineRuns.sh` still regenerates operator-bundle PLRs from its
+template; leave that template unchanged during hub/operator OCI-TA work unless
+the user explicitly requests operator-bundle changes.
+
 ---
 
 ## Variant A: Unified pipeline layout
 
 Used on current stable branches. Hub, operator, and must-gather share `rhdh-pipeline.yaml`; operator-bundle uses a separate template.
-
-**OCI-TA preference:** migrate tasks in `rhdh-pipeline.yaml`, `rhdh-bootc-pipeline.yaml`, and inline `rhdh-rag-content-*` PLRs. **Exclude** `rhdh-operator-bundle.yaml` and its generated PLRs unless the user explicitly requests operator-bundle changes.
 
 ### Files to update
 
@@ -95,12 +107,9 @@ Apply in **three** places:
    - Remove `dev-package-managers`; pass `enable-package-registry-proxy: $(params.enable-package-registry-proxy)`.
 3. **PLR templates** `rhdh-hub.yaml` / `rhdh-operator.yaml`:
    - Add `spec.params` entry so the value reaches the shared pipeline.
-4. **Operator-bundle template** `rhdh-operator-bundle.yaml`:
-   - Same as unified layout (inline `pipelineSpec`) — **only when operator-bundle is explicitly in scope**; skip OCI-TA task swaps on stream-wide passes.
 
-`prefetch-dependencies-bundle` on operator-bundle may remain on non-OCI
-`task-prefetch-dependencies` during hub/operator OCI-TA work. Do not migrate
-operator-bundle prefetch to `-oci-ta` unless the user asks.
+Operator-bundle prefetch (`prefetch-dependencies-bundle`) is out of scope —
+see [OCI-TA file scope](#oci-ta-file-scope) above.
 
 ### Generator notes
 

--- a/skills/ci/rhdh-konflux-tasks/workflows/konflux-task-update.md
+++ b/skills/ci/rhdh-konflux-tasks/workflows/konflux-task-update.md
@@ -32,22 +32,14 @@ After a **minor** Konflux task tag bump, update `.tekton` pipelines and generato
 
 If both plugin-catalog and midstream markers exist, apply changes only for the repo/branch you are on.
 
-## Prefer `-oci-ta` tasks
-
-Before bumping digests, scan `.tekton` and `.tekton-templates` for legacy
-(non-OCI-TA) `taskRef` bundles (`task-git-clone:`, `task-prefetch-dependencies:`,
-`task-buildah:`, etc.). When the catalog lists `<name>-oci-ta`, migrate to that
-variant first — see the mapping table in [SKILL.md](../SKILL.md#prefer--oci-ta-task-variants).
-
-**Exception — operator-bundle:** do not replace legacy tasks with `-oci-ta` in
-`rhdh-operator-bundle.yaml` or `rhdh-operator-bundle-*` PLRs unless the user
-explicitly asks. Hub, operator, must-gather, rag-content, and bootc are in
-scope; operator-bundle is not.
-
-OCI-TA migrations are **not** handled by `updateDigests.sh`; apply param and
-workspace changes from the task's live `MIGRATION.md`, then regenerate PLRs.
-
 ## Workflow
+
+### 0. OCI-TA preference (before digest bump)
+
+Scan for legacy (non-OCI-TA) `taskRef` bundles and migrate where the catalog
+offers `<name>-oci-ta` — [SKILL.md § Prefer `-oci-ta`](../SKILL.md#prefer--oci-ta-task-variants).
+Midstream paths in scope vs out of scope:
+[konflux-rhdh-midstream.md § OCI-TA file scope](../references/konflux-rhdh-midstream.md#oci-ta-file-scope).
 
 ### 1. Bump digests
 
@@ -107,7 +99,7 @@ Use live `MIGRATION.md` as source of truth. Common cases:
 
 | Task | Action |
 |------|--------|
-| `prefetch-dependencies` → `prefetch-dependencies-oci-ta` | Switch taskRef to `prefetch-dependencies-oci-ta` bundle; add `SOURCE_ARTIFACT`, `ociStorage`, `ociArtifactExpiresAfter`, `enable-package-registry-proxy`; drop `source` workspace and `dev-package-managers`; wire downstream tasks to `SOURCE_ARTIFACT` / `CACHI2_ARTIFACT` results. |
+| `prefetch-dependencies` → `prefetch-dependencies-oci-ta` | See [SKILL.md § Prefer `-oci-ta`](../SKILL.md#prefer--oci-ta-task-variants). |
 | `prefetch-dependencies-oci-ta` 0.2→0.3 | Remove `dev-package-managers`; add pipeline param `enable-package-registry-proxy` (default `"true"`) and pass to prefetch task. Variant B: also add param on `build-pipeline-rhdh-{hub,operator}.yaml` tasks `prefetch-dependencies-hub` / `prefetch-dependencies-operator`, and on PLR `spec.params` in `rhdh-hub.yaml` / `rhdh-operator.yaml`. |
 | `build-image-index` 0.2→0.3 | Remove `COMMIT_SHA` / `IMAGE_EXPIRES_AFTER` from **build-image-index** task only; keep on buildah (`build-container`) and prefetch |
 | `init` 0.3→0.4 | No pipeline changes |
@@ -125,4 +117,4 @@ Use live `MIGRATION.md` as source of truth. Common cases:
 - Adding `verify_*` guards that fail on the next Konflux bump.
 - Dropping `image-expires-after` from PLRs only because `build-image-index` no longer uses it.
 - Hardcoding `1-` in `updatePLRs.sh` Containerfile comments; use `${RHDH_XY_VERSION}` so `1.10.0` becomes `1-10`, not `1`.
-- Migrating `rhdh-operator-bundle.yaml` or `rhdh-operator-bundle-*` PLRs to `-oci-ta` tasks during a stream-wide OCI-TA pass (operator-bundle is out of scope unless explicitly requested).
+- Migrating operator-bundle to `-oci-ta` on a stream-wide pass — see [SKILL.md § Prefer `-oci-ta`](../SKILL.md#prefer--oci-ta-task-variants).

--- a/skills/ci/rhdh-konflux-tasks/workflows/konflux-task-update.md
+++ b/skills/ci/rhdh-konflux-tasks/workflows/konflux-task-update.md
@@ -39,6 +39,11 @@ Before bumping digests, scan `.tekton` and `.tekton-templates` for legacy
 `task-buildah:`, etc.). When the catalog lists `<name>-oci-ta`, migrate to that
 variant first — see the mapping table in [SKILL.md](../SKILL.md#prefer--oci-ta-task-variants).
 
+**Exception — operator-bundle:** do not replace legacy tasks with `-oci-ta` in
+`rhdh-operator-bundle.yaml` or `rhdh-operator-bundle-*` PLRs unless the user
+explicitly asks. Hub, operator, must-gather, rag-content, and bootc are in
+scope; operator-bundle is not.
+
 OCI-TA migrations are **not** handled by `updateDigests.sh`; apply param and
 workspace changes from the task's live `MIGRATION.md`, then regenerate PLRs.
 
@@ -120,3 +125,4 @@ Use live `MIGRATION.md` as source of truth. Common cases:
 - Adding `verify_*` guards that fail on the next Konflux bump.
 - Dropping `image-expires-after` from PLRs only because `build-image-index` no longer uses it.
 - Hardcoding `1-` in `updatePLRs.sh` Containerfile comments; use `${RHDH_XY_VERSION}` so `1.10.0` becomes `1-10`, not `1`.
+- Migrating `rhdh-operator-bundle.yaml` or `rhdh-operator-bundle-*` PLRs to `-oci-ta` tasks during a stream-wide OCI-TA pass (operator-bundle is out of scope unless explicitly requested).

--- a/skills/ci/rhdh-konflux-tasks/workflows/konflux-task-update.md
+++ b/skills/ci/rhdh-konflux-tasks/workflows/konflux-task-update.md
@@ -32,6 +32,16 @@ After a **minor** Konflux task tag bump, update `.tekton` pipelines and generato
 
 If both plugin-catalog and midstream markers exist, apply changes only for the repo/branch you are on.
 
+## Prefer `-oci-ta` tasks
+
+Before bumping digests, scan `.tekton` and `.tekton-templates` for legacy
+(non-OCI-TA) `taskRef` bundles (`task-git-clone:`, `task-prefetch-dependencies:`,
+`task-buildah:`, etc.). When the catalog lists `<name>-oci-ta`, migrate to that
+variant first — see the mapping table in [SKILL.md](../SKILL.md#prefer--oci-ta-task-variants).
+
+OCI-TA migrations are **not** handled by `updateDigests.sh`; apply param and
+workspace changes from the task's live `MIGRATION.md`, then regenerate PLRs.
+
 ## Workflow
 
 ### 1. Bump digests
@@ -92,6 +102,7 @@ Use live `MIGRATION.md` as source of truth. Common cases:
 
 | Task | Action |
 |------|--------|
+| `prefetch-dependencies` → `prefetch-dependencies-oci-ta` | Switch taskRef to `prefetch-dependencies-oci-ta` bundle; add `SOURCE_ARTIFACT`, `ociStorage`, `ociArtifactExpiresAfter`, `enable-package-registry-proxy`; drop `source` workspace and `dev-package-managers`; wire downstream tasks to `SOURCE_ARTIFACT` / `CACHI2_ARTIFACT` results. |
 | `prefetch-dependencies-oci-ta` 0.2→0.3 | Remove `dev-package-managers`; add pipeline param `enable-package-registry-proxy` (default `"true"`) and pass to prefetch task. Variant B: also add param on `build-pipeline-rhdh-{hub,operator}.yaml` tasks `prefetch-dependencies-hub` / `prefetch-dependencies-operator`, and on PLR `spec.params` in `rhdh-hub.yaml` / `rhdh-operator.yaml`. |
 | `build-image-index` 0.2→0.3 | Remove `COMMIT_SHA` / `IMAGE_EXPIRES_AFTER` from **build-image-index** task only; keep on buildah (`build-container`) and prefetch |
 | `init` 0.3→0.4 | No pipeline changes |


### PR DESCRIPTION
## Summary

- Add an OCI-TA preference section to `rhdh-konflux-tasks` with common legacy → `-oci-ta` task mappings.
- Document `prefetch-dependencies` → `prefetch-dependencies-oci-ta` param/workspace migration.
- Update variant B guidance so operator-bundle prefetch also uses `-oci-ta` when available.

## Test plan

- [ ] Skill route loads updated workflow and midstream reference without broken links

https://redhat.atlassian.net/browse/RHIDP-16541

Generated-by: cursor
