### PR TITLE
docs: sync catalog konflux.additional-tags node-v* with .nvmrc

### DIFF
--- a/skills/ci/rhdh-base-images/SKILL.md
+++ b/skills/ci/rhdh-base-images/SKILL.md
@@ -75,4 +75,7 @@ instead of reported as current. Filtered `No sources found for` /
 An update is complete when the target branch was verified to exist against a
 clean working tree before any edit, every approved operation has been reported by
 target and outcome, and the push and PR state is stated explicitly — including
-"not pushed" when the default local behavior was kept.
+"not pushed" when the default local behavior was kept. When Node headers /
+`.nvmrc` changed, also state that plugin-catalog `builder.Containerfile`
+`konflux.additional-tags` `node-v*` must be updated to the same version
+(handoff to `/rhdh-konflux-tasks` or a catalog MR).

--- a/skills/ci/rhdh-base-images/references/repos.md
+++ b/skills/ci/rhdh-base-images/references/repos.md
@@ -6,7 +6,7 @@
 - Branches: `main`, `release-1.9`, `release-1.10`, …
 - Base images: `build/containerfiles/Containerfile`, `.ci/images/Dockerfile`, and other `Dockerfile`/`Containerfile` paths within `-maxdepth 5`
 - RPM lock: `build/containerfiles/Containerfile` + `rpms.in.yaml` → `rpms.lock.yaml`
-- Node headers: when builder image Node version changes, update `.nvm/releases/node-v*-headers.tar.gz`, `.nvmrc`, and `.nvm/releases/README.adoc` (see `.nvm/releases/README.adoc`)
+- Node headers: when builder image Node version changes, update `.nvm/releases/node-v*-headers.tar.gz`, `.nvmrc`, and `.nvm/releases/README.adoc` (see `.nvm/releases/README.adoc`). After that change, report the handoff: plugin-catalog `builder.Containerfile` `konflux.additional-tags` `node-v*` must match the new `.nvmrc` (owned by `/rhdh-konflux-tasks`).
 - Workflow reference: `.github/workflows/update-rpm-lockfile.yaml`
 
 ## redhat-developer/rhdh-must-gather
@@ -27,7 +27,7 @@
 
 ## Not this skill: rhdh-plugin-catalog
 
-GitLab `rhidp/rhdh-plugin-catalog` `build/containerfiles/builder.Containerfile` is owned by `/rhdh-konflux-tasks`. After this skill reports the GitHub rhdh UBI Node tag (`ubi9/nodejs-*` today; `ubi10/nodejs-*` when that line ships), that skill pins the catalog FROM and copies `.nvm/`.
+GitLab `rhidp/rhdh-plugin-catalog` `build/containerfiles/builder.Containerfile` is owned by `/rhdh-konflux-tasks`. After this skill reports the GitHub rhdh UBI Node tag (`ubi9/nodejs-*` today; `ubi10/nodejs-*` when that line ships), that skill pins the catalog FROM, copies `.nvm/`, and rewrites `konflux.additional-tags` `node-v*` to match `.nvmrc`.
 
 ## Midstream script source
 

--- a/skills/ci/rhdh-base-images/workflows/update-base-images.md
+++ b/skills/ci/rhdh-base-images/workflows/update-base-images.md
@@ -164,6 +164,12 @@ the script:
 3. Updates `.nvmrc` (version without `v` prefix) and `.nvm/releases/README.adoc` (date + version)
 4. Removes stale `node-v*-headers.tar.gz` files and pushes to the same automation PR
 
+When Node headers / `.nvmrc` change on rhdh, the completion report **must** state
+that plugin-catalog `build/containerfiles/builder.Containerfile`
+`konflux.additional-tags` `node-v*` must be updated to the same version (handoff
+to `/rhdh-konflux-tasks` or a catalog MR). Do not edit the catalog from this
+skill.
+
 See [rhdh `.nvm/releases/README.adoc`](https://github.com/redhat-developer/rhdh/blob/main/.nvm/releases/README.adoc). On **release-1.9**, headers come from `docker/Dockerfile` (`ubi9/nodejs-22`), not Node 24.
 
 ### Go toolchain (rhdh-operator, main only)
@@ -186,6 +192,7 @@ Do not downgrade. If `go.mod` already pins a newer toolchain (for example `go1.2
 - Treating `rpm-lockfile-prototype` `No sources found for` / "no matching sources" warnings as a failure or remaining risk. The source RPM is often unpublished; the lockfile is still valid.
 - Lowering `go.mod` `toolchain` (or `go`) to match an older `ubi9/go-toolset` image. Keep the newer pin.
 - Editing GitLab `rhdh-plugin-catalog` `builder.Containerfile` from this skill. That pin is `/rhdh-konflux-tasks` after this skill reports the GitHub rhdh UBI Node tag.
+- Claiming Node headers / `.nvmrc` are done while plugin-catalog still advertises an old `node-v*` in `konflux.additional-tags`. Report the catalog handoff.
 
 ## Additional resources
 

--- a/skills/ci/rhdh-konflux-tasks/SKILL.md
+++ b/skills/ci/rhdh-konflux-tasks/SKILL.md
@@ -77,9 +77,12 @@ not a Tekton pin problem. Plugin-catalog `build/containerfiles/builder.Container
 both **FROM**s a UBI Node image (`ubi9/nodejs-*` today; `ubi10/nodejs-*` when
 that line ships) and COPYs local `.nvm/`. After `/rhdh-base-images` reports the
 latest tag and tarball on GitHub rhdh, pin that same image name + `tag@sha256`
-on the catalog FROM line **and** copy the matching headers. Do not rewrite
-ubi9→ubi10 (or the reverse) unless GitHub rhdh already moved. Headers without a
-FROM bump still build on the old Node. Catalog has no `rpms.lock.yaml`.
+on the catalog FROM line **and** copy the matching headers. Also rewrite the
+`node-v*` token in `LABEL konflux.additional-tags=...` to
+`node-v$(tr -d '\n\r' < .nvmrc)` so Konflux publishes the matching tag; leave
+other tags (`latest`, `1.9`, `1.9-72`, …) untouched. Do not rewrite ubi9→ubi10
+(or the reverse) unless GitHub rhdh already moved. Headers without a FROM bump
+still build on the old Node. Catalog has no `rpms.lock.yaml`.
 
 | Konflux / catalog stream | `/rhdh-base-images` `-b` |
 |--------------------------|--------------------------|
@@ -169,9 +172,11 @@ days, Slack `#konflux-users`). Do not treat a no-successor warning as debug.
 
 `/rhdh-base-images` has run for the mapped GitHub branch (analyze at minimum).
 Name current vs latest `FROM` tags, Node header version, whether headers or
-RPMs changed, and on plugin-catalog the `builder.Containerfile` FROM old→new
-plus whether `.nvm/releases/` matches `node --version` in that image. If that
-skill was skipped, say why (no checkouts named and `/rhdh-context` found none).
+RPMs changed, and on plugin-catalog the `builder.Containerfile` FROM old→new,
+whether `.nvm/releases/` matches `node --version` in that image, and that
+`grep konflux.additional-tags build/containerfiles/builder.Containerfile`
+contains `node-v` matching `.nvmrc`. If that skill was skipped, say why (no
+checkouts named and `/rhdh-context` found none).
 
 State the commit state and, explicitly, that nothing was pushed, unless the user
 asked for a push. Name any migration document that could not be resolved rather

--- a/skills/ci/rhdh-konflux-tasks/references/konflux-plugin-catalog.md
+++ b/skills/ci/rhdh-konflux-tasks/references/konflux-plugin-catalog.md
@@ -13,7 +13,7 @@
 | `.tekton/generatePipelineRunsForPlugins.sh` | Deprecated name of `updatePLRs.sh` on 1.9 / 1.10 streams |
 | `.tekton/updateToStableBranch.py` | Version renames only — not Konflux migrations |
 | `build/scripts/checkTrustedTasks.sh` | ECP trusted-task check (same contract as the skill script) |
-| `build/containerfiles/builder.Containerfile` | Pin UBI Node FROM (`ubi9/nodejs-*` or later `ubi10/nodejs-*`) `tag@sha256` to the latest image `/rhdh-base-images` reported for that image name; COPY `.nvm/` headers must match `node --version` in that image |
+| `build/containerfiles/builder.Containerfile` | Pin UBI Node FROM (`ubi9/nodejs-*` or later `ubi10/nodejs-*`) `tag@sha256` to the latest image `/rhdh-base-images` reported for that image name; COPY `.nvm/` headers must match `node --version` in that image; rewrite `node-v*` in `konflux.additional-tags` to match `.nvmrc` |
 
 Plugin PLRs with `pipelineRef: oci-plugin-build-pipeline` inherit task wiring from the shared pipeline; add PLR `spec.params` when migrations require explicit pipeline parameters.
 
@@ -95,4 +95,9 @@ After the digest bump, invoke `/rhdh-base-images` for the mapped GitHub branch
    `node-v*-headers.tar.gz`, `.nvmrc`, and `.nvm/releases/README.adoc` from the
    rhdh checkout (or download from nodejs.org). Headers must match the catalog
    FROM image (for example v22.23.1 from `ubi9/nodejs-22:9.8-1787706653`).
-4. Omit `[skip-build]` when the builder should rebuild on the new FROM.
+4. Rewrite only the `node-v*` token in `LABEL konflux.additional-tags=...` to
+   `node-v$(tr -d '\n\r' < .nvmrc)`. Leave other tags untouched. Success:
+   `grep konflux.additional-tags build/containerfiles/builder.Containerfile`
+   contains `node-v` matching `.nvmrc`. Anti-pattern: copying headers while
+   leaving a stale `node-v*` label (Konflux keeps publishing the old tag).
+5. Omit `[skip-build]` when the builder should rebuild on the new FROM.

--- a/skills/ci/rhdh-konflux-tasks/workflows/konflux-task-update.md
+++ b/skills/ci/rhdh-konflux-tasks/workflows/konflux-task-update.md
@@ -121,6 +121,15 @@ digest problem.
 2. Name `rhdh`, `rhdh-operator`, and `rhdh-must-gather` checkouts (user, or `/rhdh-context`).
 3. Invoke **`/rhdh-base-images` by name**. Do not run `base-images-and-rpms.sh` from this skill. Analyze first; if headers, `FROM` tags, or RPMs are stale, let that skill own the update and `/mutation-gate`.
 4. On plugin-catalog, pin `build/containerfiles/builder.Containerfile` FROM to the latest UBI Node `tag@sha256` `/rhdh-base-images` reported (same image name as the current FROM: `ubi9/nodejs-*` or later `ubi10/nodejs-*`; Node 22 on 1.9, Node 24 on 1.10/main today). Prefer `major.minor-buildid` (9.8-… or 10.x-…); numeric-only tags often 404. Then copy the matching `node-v*-headers.tar.gz` and `.nvmrc` from the rhdh checkout into catalog `.nvm/` (the Containerfile COPYs it). Update `.nvm/releases/README.adoc` version/date if present. Headers must match `node --version` in the **catalog** FROM image. Catalog has no `rpms.lock.yaml`. Do not `[skip-build]` if the builder should rebuild.
+5. Rewrite only the `node-v*` token in `LABEL konflux.additional-tags=...` inside `build/containerfiles/builder.Containerfile` to match catalog `.nvmrc`. Leave other tags (`latest`, `1.9`, `1.9-72`, …) untouched:
+
+```bash
+nvm_ver=$(tr -d '\n\r' < .nvmrc)
+sed -i -E "s/node-v[0-9]+\.[0-9]+\.[0-9]+/node-v${nvm_ver}/" \
+  build/containerfiles/builder.Containerfile
+grep konflux.additional-tags build/containerfiles/builder.Containerfile
+# must contain node-v${nvm_ver}
+```
 
 ### 6. Human review and push
 
@@ -153,3 +162,4 @@ Use live `MIGRATION.md` as source of truth. Common cases:
 - Migrating operator-bundle to `-oci-ta` on a stream-wide pass — see [SKILL.md § Prefer `-oci-ta`](../SKILL.md#prefer--oci-ta-task-variants).
 - Reconstructing `/rhdh-base-images` script flags in this skill, or skipping that handoff when Konflux logs `could not find releases/node-v*-headers.tar.gz`.
 - Copying plugin-catalog `.nvm/` headers while leaving `builder.Containerfile` FROM on an older UBI Node tag. Konflux still builds the old Node until FROM moves.
+- Copying headers / `.nvmrc` while leaving a stale `node-v*` in `konflux.additional-tags`. Konflux keeps publishing the old tag until that label matches `.nvmrc`.


### PR DESCRIPTION
## Summary
- `/rhdh-konflux-tasks`: after copying `.nvmrc` / headers into plugin-catalog, rewrite only the `node-v*` token in `builder.Containerfile` `konflux.additional-tags` to match `.nvmrc`.
- `/rhdh-base-images`: Completion / Node-header docs require reporting that catalog handoff (do not edit catalog from base-images).

## Test plan
- [ ] Grep both skills for `konflux.additional-tags` and the anti-pattern about stale `node-v*`.
- [ ] Confirm workflow sed step leaves non-node tags untouched.

Ref: https://redhat.atlassian.net/browse/RHIDP-16541

Generated-by: cursor

Made with [Cursor](https://cursor.com)