### PR TITLE
fix: point generated Jira URLs to redhat.atlassian.net

### DIFF
--- a/skills/release/rhdh-release-announce/scripts/release.py
+++ b/skills/release/rhdh-release-announce/scripts/release.py
@@ -836,7 +836,7 @@ def cmd_notes(args: argparse.Namespace, fmt: OutputFormatter) -> None:
         jql, url = jql_mod.render_with_url(template_name, version=version)
         lifecycle[stage] = {"count": _acli_count(jql, fmt), "jira_url": url}
 
-    dashboard_url = "https://issues.redhat.com/secure/Dashboard.jspa?selectPageId=12382090"
+    dashboard_url = "https://redhat.atlassian.net/jira/dashboards/21418"
 
     fmt.header(f"RHDH {version} — Release Notes")
     for stage, data in lifecycle.items():

--- a/skills/release/rhdh-release-announce/scripts/slack-templates.md
+++ b/skills/release/rhdh-release-announce/scripts/slack-templates.md
@@ -19,7 +19,7 @@ Templates for release milestone announcements. Each template uses `{{PLACEHOLDER
 ```slack
 :announcement: *RHDH {{RELEASE_VERSION}} [Feature Freeze](https://docs.google.com/document/d/1IjMH985f3XUhXl_6drfUKopLxTBoY0VMJ2Zpr_62K2g/edit?tab=t.0#bookmark=id.5a1n60q199qh) Update* :announcement:
 
-Feature Freeze is coming up and its target date is *{{FEATURE_FREEZE_DATE}}*. To check on the Feature Freeze status, you can use the [RHDH Release Tracking dashboard](https://issues.redhat.com/secure/Dashboard.jspa?selectPageId=12363303) and set fixversion to the current release.
+Feature Freeze is coming up and its target date is *{{FEATURE_FREEZE_DATE}}*. To check on the Feature Freeze status, you can use the [RHDH Release Tracking dashboard](https://redhat.atlassian.net/jira/dashboards/21028) and set fixversion to the current release.
 
 Here's what's outstanding for Feature Freeze. Please review and share if there are any risks to meet this milestone.
 
@@ -45,13 +45,13 @@ cc @rhdh-release
 ```slack
 :rotating_light: *RHDH {{RELEASE_VERSION}} [Feature Freeze](https://docs.google.com/document/d/1IjMH985f3XUhXl_6drfUKopLxTBoY0VMJ2Zpr_62K2g/edit?tab=t.0#bookmark=id.5a1n60q199qh)* :rotating_light:
 
-Its Feature Freeze! To see the latest status use the [RHDH Release Tracking dashboard](https://issues.redhat.com/secure/Dashboard.jspa?selectPageId=12363303) and set fixversion to the current release.
+Its Feature Freeze! To see the latest status use the [RHDH Release Tracking dashboard](https://redhat.atlassian.net/jira/dashboards/21028) and set fixversion to the current release.
 :one: The release branch is created, and any work intended for the release must be cherry-picked into this branch.
 :two: Release and test pipelines are being set up for the release branch.
 :three: The Test Plan is approved, and any required manual testing is identified.
 :four: [{{EPIC_ISSUE_COUNT}}]({{JIRA_LINK}}) Engineering EPICs that are outstanding.
 :five: [{{CVE_ISSUE_COUNT}}]({{JIRA_LINK}}) CVEs on target to be fixed before code freeze.
-:six: [{{OUTSTANDING_RELEASE_NOTES_ISSUE_COUNT}}]({{JIRA_LINK}}) Release Notes to be updated before Release Notes date. Refer to [Release Notes Dashboard](https://issues.redhat.com/secure/Dashboard.jspa?selectPageId=12382090) for more details.
+:six: [{{OUTSTANDING_RELEASE_NOTES_ISSUE_COUNT}}]({{JIRA_LINK}}) Release Notes to be updated before Release Notes date. Refer to [Release Notes Dashboard](https://redhat.atlassian.net/jira/dashboards/21418) for more details.
 :seven: Reminder to start verifying Features and creating Feature Demos.
 
 Please adhere to these rules so we can keep the release stable and on track. Let me know if you have any questions.
@@ -76,7 +76,7 @@ cc @rhdh-release
 ```slack
 :announcement: *RHDH {{RELEASE_VERSION}} [Code Freeze](https://docs.google.com/document/d/1IjMH985f3XUhXl_6drfUKopLxTBoY0VMJ2Zpr_62K2g/edit?tab=t.0#bookmark=id.ecpldu1g74vj) Update* :announcement:
 
-Code Freeze is coming up and its target date is *{{CODE_FREEZE_DATE}}*. To check on the Code Freeze status, you can use the [RHDH Release Tracking dashboard](https://issues.redhat.com/secure/Dashboard.jspa?selectPageId=12363303) and set fixversion to the current release.
+Code Freeze is coming up and its target date is *{{CODE_FREEZE_DATE}}*. To check on the Code Freeze status, you can use the [RHDH Release Tracking dashboard](https://redhat.atlassian.net/jira/dashboards/21028) and set fixversion to the current release.
 
 :one: Here's what's outstanding for Code Freeze. Please review and share if there are any risks to meet this milestone or retriage to future release if applicable.
 
@@ -105,7 +105,7 @@ cc @rhdh-release
 :one: No cherry-picks into the release {{RELEASE_VERSION}} branch are allowed without explicit approval from both the @rhdh-release-manager
 :two: [{{BLOCKER_BUG_ISSUE_COUNT}}]({{JIRA_LINK}}) Blocker bugs outstanding.
 :three: Regarding CVEs: Only critical severity CVEs will be considered for inclusion before GA, and these will follow the same approval process (Release Manager). All other CVEs will be handled in the next z stream release
-:four: Review and update [Release Notes and Known Issues](https://issues.redhat.com/secure/Dashboard.jspa?selectPageId=12382090#)
+:four: Review and update [Release Notes and Known Issues](https://redhat.atlassian.net/jira/dashboards/21418)
 :five: [Feature Demos](https://docs.google.com/document/d/1IjMH985f3XUhXl_6drfUKopLxTBoY0VMJ2Zpr_62K2g/edit?tab=t.0#bookmark=id.l8izl2mswrfb): [{{FEATURE_DEMO_ISSUE_COUNT}}]({{JIRA_LINK}}) Features are tagged for demos. Add your demos and update the RHDH Release Features Slide in the {{RELEASE_VERSION}} [folder](https://drive.google.com/drive/folders/1QKf2hgOxCo6cmWkJ0b78o1Byx8uxgK_E?q=title:%3C1.9.0%3E)
 :six: [{{TEST_DAY_FEATURE_ISSUE_COUNT}}]({{JIRA_LINK}}) Features are tagged for Testday. Please review they are ready for Testday.
 :seven: [{{OPEN_ISSUE_COUNT}}]({{JIRA_LINK}}) issues set to {{RELEASE_VERSION}} and not closed. Please review and move to the next release as appropriate and can be fixed in main branch ONLY.

--- a/skills/release/rhdh-release-schedule/scripts/release.py
+++ b/skills/release/rhdh-release-schedule/scripts/release.py
@@ -836,7 +836,7 @@ def cmd_notes(args: argparse.Namespace, fmt: OutputFormatter) -> None:
         jql, url = jql_mod.render_with_url(template_name, version=version)
         lifecycle[stage] = {"count": _acli_count(jql, fmt), "jira_url": url}
 
-    dashboard_url = "https://issues.redhat.com/secure/Dashboard.jspa?selectPageId=12382090"
+    dashboard_url = "https://redhat.atlassian.net/jira/dashboards/21418"
 
     fmt.header(f"RHDH {version} — Release Notes")
     for stage, data in lifecycle.items():

--- a/skills/release/rhdh-release-schedule/scripts/slack-templates.md
+++ b/skills/release/rhdh-release-schedule/scripts/slack-templates.md
@@ -19,7 +19,7 @@ Templates for release milestone announcements. Each template uses `{{PLACEHOLDER
 ```slack
 :announcement: *RHDH {{RELEASE_VERSION}} [Feature Freeze](https://docs.google.com/document/d/1IjMH985f3XUhXl_6drfUKopLxTBoY0VMJ2Zpr_62K2g/edit?tab=t.0#bookmark=id.5a1n60q199qh) Update* :announcement:
 
-Feature Freeze is coming up and its target date is *{{FEATURE_FREEZE_DATE}}*. To check on the Feature Freeze status, you can use the [RHDH Release Tracking dashboard](https://issues.redhat.com/secure/Dashboard.jspa?selectPageId=12363303) and set fixversion to the current release.
+Feature Freeze is coming up and its target date is *{{FEATURE_FREEZE_DATE}}*. To check on the Feature Freeze status, you can use the [RHDH Release Tracking dashboard](https://redhat.atlassian.net/jira/dashboards/21028) and set fixversion to the current release.
 
 Here's what's outstanding for Feature Freeze. Please review and share if there are any risks to meet this milestone.
 
@@ -45,13 +45,13 @@ cc @rhdh-release
 ```slack
 :rotating_light: *RHDH {{RELEASE_VERSION}} [Feature Freeze](https://docs.google.com/document/d/1IjMH985f3XUhXl_6drfUKopLxTBoY0VMJ2Zpr_62K2g/edit?tab=t.0#bookmark=id.5a1n60q199qh)* :rotating_light:
 
-Its Feature Freeze! To see the latest status use the [RHDH Release Tracking dashboard](https://issues.redhat.com/secure/Dashboard.jspa?selectPageId=12363303) and set fixversion to the current release.
+Its Feature Freeze! To see the latest status use the [RHDH Release Tracking dashboard](https://redhat.atlassian.net/jira/dashboards/21028) and set fixversion to the current release.
 :one: The release branch is created, and any work intended for the release must be cherry-picked into this branch.
 :two: Release and test pipelines are being set up for the release branch.
 :three: The Test Plan is approved, and any required manual testing is identified.
 :four: [{{EPIC_ISSUE_COUNT}}]({{JIRA_LINK}}) Engineering EPICs that are outstanding.
 :five: [{{CVE_ISSUE_COUNT}}]({{JIRA_LINK}}) CVEs on target to be fixed before code freeze.
-:six: [{{OUTSTANDING_RELEASE_NOTES_ISSUE_COUNT}}]({{JIRA_LINK}}) Release Notes to be updated before Release Notes date. Refer to [Release Notes Dashboard](https://issues.redhat.com/secure/Dashboard.jspa?selectPageId=12382090) for more details.
+:six: [{{OUTSTANDING_RELEASE_NOTES_ISSUE_COUNT}}]({{JIRA_LINK}}) Release Notes to be updated before Release Notes date. Refer to [Release Notes Dashboard](https://redhat.atlassian.net/jira/dashboards/21418) for more details.
 :seven: Reminder to start verifying Features and creating Feature Demos.
 
 Please adhere to these rules so we can keep the release stable and on track. Let me know if you have any questions.
@@ -76,7 +76,7 @@ cc @rhdh-release
 ```slack
 :announcement: *RHDH {{RELEASE_VERSION}} [Code Freeze](https://docs.google.com/document/d/1IjMH985f3XUhXl_6drfUKopLxTBoY0VMJ2Zpr_62K2g/edit?tab=t.0#bookmark=id.ecpldu1g74vj) Update* :announcement:
 
-Code Freeze is coming up and its target date is *{{CODE_FREEZE_DATE}}*. To check on the Code Freeze status, you can use the [RHDH Release Tracking dashboard](https://issues.redhat.com/secure/Dashboard.jspa?selectPageId=12363303) and set fixversion to the current release.
+Code Freeze is coming up and its target date is *{{CODE_FREEZE_DATE}}*. To check on the Code Freeze status, you can use the [RHDH Release Tracking dashboard](https://redhat.atlassian.net/jira/dashboards/21028) and set fixversion to the current release.
 
 :one: Here's what's outstanding for Code Freeze. Please review and share if there are any risks to meet this milestone or retriage to future release if applicable.
 
@@ -105,7 +105,7 @@ cc @rhdh-release
 :one: No cherry-picks into the release {{RELEASE_VERSION}} branch are allowed without explicit approval from both the @rhdh-release-manager
 :two: [{{BLOCKER_BUG_ISSUE_COUNT}}]({{JIRA_LINK}}) Blocker bugs outstanding.
 :three: Regarding CVEs: Only critical severity CVEs will be considered for inclusion before GA, and these will follow the same approval process (Release Manager). All other CVEs will be handled in the next z stream release
-:four: Review and update [Release Notes and Known Issues](https://issues.redhat.com/secure/Dashboard.jspa?selectPageId=12382090#)
+:four: Review and update [Release Notes and Known Issues](https://redhat.atlassian.net/jira/dashboards/21418#)
 :five: [Feature Demos](https://docs.google.com/document/d/1IjMH985f3XUhXl_6drfUKopLxTBoY0VMJ2Zpr_62K2g/edit?tab=t.0#bookmark=id.l8izl2mswrfb): [{{FEATURE_DEMO_ISSUE_COUNT}}]({{JIRA_LINK}}) Features are tagged for demos. Add your demos and update the RHDH Release Features Slide in the {{RELEASE_VERSION}} [folder](https://drive.google.com/drive/folders/1QKf2hgOxCo6cmWkJ0b78o1Byx8uxgK_E?q=title:%3C1.9.0%3E)
 :six: [{{TEST_DAY_FEATURE_ISSUE_COUNT}}]({{JIRA_LINK}}) Features are tagged for Testday. Please review they are ready for Testday.
 :seven: [{{OPEN_ISSUE_COUNT}}]({{JIRA_LINK}}) issues set to {{RELEASE_VERSION}} and not closed. Please review and move to the next release as appropriate and can be fixed in main branch ONLY.

--- a/skills/release/rhdh-release-status/scripts/jql.py
+++ b/skills/release/rhdh-release-status/scripts/jql.py
@@ -15,7 +15,7 @@ import re
 from pathlib import Path
 from urllib.parse import quote
 
-JIRA_SEARCH_BASE = "https://issues.redhat.com/issues/?jql="
+JIRA_SEARCH_BASE = "https://redhat.atlassian.net/issues/?jql="
 
 _DATA_DIR = Path(__file__).resolve().parent
 _JQL_FILE = _DATA_DIR / "jql-release.md"

--- a/skills/release/rhdh-release-status/scripts/release.py
+++ b/skills/release/rhdh-release-status/scripts/release.py
@@ -836,7 +836,7 @@ def cmd_notes(args: argparse.Namespace, fmt: OutputFormatter) -> None:
         jql, url = jql_mod.render_with_url(template_name, version=version)
         lifecycle[stage] = {"count": _acli_count(jql, fmt), "jira_url": url}
 
-    dashboard_url = "https://issues.redhat.com/secure/Dashboard.jspa?selectPageId=12382090"
+    dashboard_url = "https://redhat.atlassian.net/jira/dashboards/21418"
 
     fmt.header(f"RHDH {version} — Release Notes")
     for stage, data in lifecycle.items():

--- a/skills/release/rhdh-release-status/scripts/release.py
+++ b/skills/release/rhdh-release-status/scripts/release.py
@@ -35,7 +35,7 @@ import rich_filter as rf_mod  # noqa: E402
 import slack_templates as slack_mod  # noqa: E402
 from _support import OutputFormatter, find_acli  # noqa: E402
 
-JIRA_BASE = "https://issues.redhat.com"
+JIRA_BASE = "https://redhat.atlassian.net"
 SCHEDULE_SHEET_ID = "1knVzlMW0l0X4c7gkoiuaGql1zuFgEGwHHBsj-ygUTnc"
 TEAM_SHEET_ID = "1vQXfvID72qwqvLb17eyGOvnZXrZG7NBzTGv6RP9wvyM"
 

--- a/skills/release/rhdh-release-status/scripts/slack-templates.md
+++ b/skills/release/rhdh-release-status/scripts/slack-templates.md
@@ -19,7 +19,7 @@ Templates for release milestone announcements. Each template uses `{{PLACEHOLDER
 ```slack
 :announcement: *RHDH {{RELEASE_VERSION}} [Feature Freeze](https://docs.google.com/document/d/1IjMH985f3XUhXl_6drfUKopLxTBoY0VMJ2Zpr_62K2g/edit?tab=t.0#bookmark=id.5a1n60q199qh) Update* :announcement:
 
-Feature Freeze is coming up and its target date is *{{FEATURE_FREEZE_DATE}}*. To check on the Feature Freeze status, you can use the [RHDH Release Tracking dashboard](https://issues.redhat.com/secure/Dashboard.jspa?selectPageId=12363303) and set fixversion to the current release.
+Feature Freeze is coming up and its target date is *{{FEATURE_FREEZE_DATE}}*. To check on the Feature Freeze status, you can use the [RHDH Release Tracking dashboard](https://redhat.atlassian.net/jira/dashboards/21028) and set fixversion to the current release.
 
 Here's what's outstanding for Feature Freeze. Please review and share if there are any risks to meet this milestone.
 
@@ -45,13 +45,13 @@ cc @rhdh-release
 ```slack
 :rotating_light: *RHDH {{RELEASE_VERSION}} [Feature Freeze](https://docs.google.com/document/d/1IjMH985f3XUhXl_6drfUKopLxTBoY0VMJ2Zpr_62K2g/edit?tab=t.0#bookmark=id.5a1n60q199qh)* :rotating_light:
 
-Its Feature Freeze! To see the latest status use the [RHDH Release Tracking dashboard](https://issues.redhat.com/secure/Dashboard.jspa?selectPageId=12363303) and set fixversion to the current release.
+Its Feature Freeze! To see the latest status use the [RHDH Release Tracking dashboard](https://redhat.atlassian.net/jira/dashboards/21028) and set fixversion to the current release.
 :one: The release branch is created, and any work intended for the release must be cherry-picked into this branch.
 :two: Release and test pipelines are being set up for the release branch.
 :three: The Test Plan is approved, and any required manual testing is identified.
 :four: [{{EPIC_ISSUE_COUNT}}]({{JIRA_LINK}}) Engineering EPICs that are outstanding.
 :five: [{{CVE_ISSUE_COUNT}}]({{JIRA_LINK}}) CVEs on target to be fixed before code freeze.
-:six: [{{OUTSTANDING_RELEASE_NOTES_ISSUE_COUNT}}]({{JIRA_LINK}}) Release Notes to be updated before Release Notes date. Refer to [Release Notes Dashboard](https://issues.redhat.com/secure/Dashboard.jspa?selectPageId=12382090) for more details.
+:six: [{{OUTSTANDING_RELEASE_NOTES_ISSUE_COUNT}}]({{JIRA_LINK}}) Release Notes to be updated before Release Notes date. Refer to [Release Notes Dashboard](https://redhat.atlassian.net/jira/dashboards/21418) for more details.
 :seven: Reminder to start verifying Features and creating Feature Demos.
 
 Please adhere to these rules so we can keep the release stable and on track. Let me know if you have any questions.
@@ -76,7 +76,7 @@ cc @rhdh-release
 ```slack
 :announcement: *RHDH {{RELEASE_VERSION}} [Code Freeze](https://docs.google.com/document/d/1IjMH985f3XUhXl_6drfUKopLxTBoY0VMJ2Zpr_62K2g/edit?tab=t.0#bookmark=id.ecpldu1g74vj) Update* :announcement:
 
-Code Freeze is coming up and its target date is *{{CODE_FREEZE_DATE}}*. To check on the Code Freeze status, you can use the [RHDH Release Tracking dashboard](https://issues.redhat.com/secure/Dashboard.jspa?selectPageId=12363303) and set fixversion to the current release.
+Code Freeze is coming up and its target date is *{{CODE_FREEZE_DATE}}*. To check on the Code Freeze status, you can use the [RHDH Release Tracking dashboard](https://redhat.atlassian.net/jira/dashboards/21028) and set fixversion to the current release.
 
 :one: Here's what's outstanding for Code Freeze. Please review and share if there are any risks to meet this milestone or retriage to future release if applicable.
 
@@ -105,7 +105,7 @@ cc @rhdh-release
 :one: No cherry-picks into the release {{RELEASE_VERSION}} branch are allowed without explicit approval from both the @rhdh-release-manager
 :two: [{{BLOCKER_BUG_ISSUE_COUNT}}]({{JIRA_LINK}}) Blocker bugs outstanding.
 :three: Regarding CVEs: Only critical severity CVEs will be considered for inclusion before GA, and these will follow the same approval process (Release Manager). All other CVEs will be handled in the next z stream release
-:four: Review and update [Release Notes and Known Issues](https://issues.redhat.com/secure/Dashboard.jspa?selectPageId=12382090#)
+:four: Review and update [Release Notes and Known Issues](https://redhat.atlassian.net/jira/dashboards/21418)
 :five: [Feature Demos](https://docs.google.com/document/d/1IjMH985f3XUhXl_6drfUKopLxTBoY0VMJ2Zpr_62K2g/edit?tab=t.0#bookmark=id.l8izl2mswrfb): [{{FEATURE_DEMO_ISSUE_COUNT}}]({{JIRA_LINK}}) Features are tagged for demos. Add your demos and update the RHDH Release Features Slide in the {{RELEASE_VERSION}} [folder](https://drive.google.com/drive/folders/1QKf2hgOxCo6cmWkJ0b78o1Byx8uxgK_E?q=title:%3C1.9.0%3E)
 :six: [{{TEST_DAY_FEATURE_ISSUE_COUNT}}]({{JIRA_LINK}}) Features are tagged for Testday. Please review they are ready for Testday.
 :seven: [{{OPEN_ISSUE_COUNT}}]({{JIRA_LINK}}) issues set to {{RELEASE_VERSION}} and not closed. Please review and move to the next release as appropriate and can be fixed in main branch ONLY.

--- a/skills/release/rhdh-release-teams/scripts/release.py
+++ b/skills/release/rhdh-release-teams/scripts/release.py
@@ -836,7 +836,7 @@ def cmd_notes(args: argparse.Namespace, fmt: OutputFormatter) -> None:
         jql, url = jql_mod.render_with_url(template_name, version=version)
         lifecycle[stage] = {"count": _acli_count(jql, fmt), "jira_url": url}
 
-    dashboard_url = "https://issues.redhat.com/secure/Dashboard.jspa?selectPageId=12382090"
+    dashboard_url = "https://redhat.atlassian.net/jira/dashboards/21418"
 
     fmt.header(f"RHDH {version} — Release Notes")
     for stage, data in lifecycle.items():

--- a/skills/release/rhdh-release-teams/scripts/slack-templates.md
+++ b/skills/release/rhdh-release-teams/scripts/slack-templates.md
@@ -19,7 +19,7 @@ Templates for release milestone announcements. Each template uses `{{PLACEHOLDER
 ```slack
 :announcement: *RHDH {{RELEASE_VERSION}} [Feature Freeze](https://docs.google.com/document/d/1IjMH985f3XUhXl_6drfUKopLxTBoY0VMJ2Zpr_62K2g/edit?tab=t.0#bookmark=id.5a1n60q199qh) Update* :announcement:
 
-Feature Freeze is coming up and its target date is *{{FEATURE_FREEZE_DATE}}*. To check on the Feature Freeze status, you can use the [RHDH Release Tracking dashboard](https://issues.redhat.com/secure/Dashboard.jspa?selectPageId=12363303) and set fixversion to the current release.
+Feature Freeze is coming up and its target date is *{{FEATURE_FREEZE_DATE}}*. To check on the Feature Freeze status, you can use the [RHDH Release Tracking dashboard](https://redhat.atlassian.net/jira/dashboards/21028) and set fixversion to the current release.
 
 Here's what's outstanding for Feature Freeze. Please review and share if there are any risks to meet this milestone.
 
@@ -45,13 +45,13 @@ cc @rhdh-release
 ```slack
 :rotating_light: *RHDH {{RELEASE_VERSION}} [Feature Freeze](https://docs.google.com/document/d/1IjMH985f3XUhXl_6drfUKopLxTBoY0VMJ2Zpr_62K2g/edit?tab=t.0#bookmark=id.5a1n60q199qh)* :rotating_light:
 
-Its Feature Freeze! To see the latest status use the [RHDH Release Tracking dashboard](https://issues.redhat.com/secure/Dashboard.jspa?selectPageId=12363303) and set fixversion to the current release.
+Its Feature Freeze! To see the latest status use the [RHDH Release Tracking dashboard](https://redhat.atlassian.net/jira/dashboards/21028) and set fixversion to the current release.
 :one: The release branch is created, and any work intended for the release must be cherry-picked into this branch.
 :two: Release and test pipelines are being set up for the release branch.
 :three: The Test Plan is approved, and any required manual testing is identified.
 :four: [{{EPIC_ISSUE_COUNT}}]({{JIRA_LINK}}) Engineering EPICs that are outstanding.
 :five: [{{CVE_ISSUE_COUNT}}]({{JIRA_LINK}}) CVEs on target to be fixed before code freeze.
-:six: [{{OUTSTANDING_RELEASE_NOTES_ISSUE_COUNT}}]({{JIRA_LINK}}) Release Notes to be updated before Release Notes date. Refer to [Release Notes Dashboard](https://issues.redhat.com/secure/Dashboard.jspa?selectPageId=12382090) for more details.
+:six: [{{OUTSTANDING_RELEASE_NOTES_ISSUE_COUNT}}]({{JIRA_LINK}}) Release Notes to be updated before Release Notes date. Refer to [Release Notes Dashboard](https://redhat.atlassian.net/jira/dashboards/21418) for more details.
 :seven: Reminder to start verifying Features and creating Feature Demos.
 
 Please adhere to these rules so we can keep the release stable and on track. Let me know if you have any questions.
@@ -76,7 +76,7 @@ cc @rhdh-release
 ```slack
 :announcement: *RHDH {{RELEASE_VERSION}} [Code Freeze](https://docs.google.com/document/d/1IjMH985f3XUhXl_6drfUKopLxTBoY0VMJ2Zpr_62K2g/edit?tab=t.0#bookmark=id.ecpldu1g74vj) Update* :announcement:
 
-Code Freeze is coming up and its target date is *{{CODE_FREEZE_DATE}}*. To check on the Code Freeze status, you can use the [RHDH Release Tracking dashboard](https://issues.redhat.com/secure/Dashboard.jspa?selectPageId=12363303) and set fixversion to the current release.
+Code Freeze is coming up and its target date is *{{CODE_FREEZE_DATE}}*. To check on the Code Freeze status, you can use the [RHDH Release Tracking dashboard](https://redhat.atlassian.net/jira/dashboards/21028) and set fixversion to the current release.
 
 :one: Here's what's outstanding for Code Freeze. Please review and share if there are any risks to meet this milestone or retriage to future release if applicable.
 
@@ -105,7 +105,7 @@ cc @rhdh-release
 :one: No cherry-picks into the release {{RELEASE_VERSION}} branch are allowed without explicit approval from both the @rhdh-release-manager
 :two: [{{BLOCKER_BUG_ISSUE_COUNT}}]({{JIRA_LINK}}) Blocker bugs outstanding.
 :three: Regarding CVEs: Only critical severity CVEs will be considered for inclusion before GA, and these will follow the same approval process (Release Manager). All other CVEs will be handled in the next z stream release
-:four: Review and update [Release Notes and Known Issues](https://issues.redhat.com/secure/Dashboard.jspa?selectPageId=12382090#)
+:four: Review and update [Release Notes and Known Issues](https://redhat.atlassian.net/jira/dashboards/21418)
 :five: [Feature Demos](https://docs.google.com/document/d/1IjMH985f3XUhXl_6drfUKopLxTBoY0VMJ2Zpr_62K2g/edit?tab=t.0#bookmark=id.l8izl2mswrfb): [{{FEATURE_DEMO_ISSUE_COUNT}}]({{JIRA_LINK}}) Features are tagged for demos. Add your demos and update the RHDH Release Features Slide in the {{RELEASE_VERSION}} [folder](https://drive.google.com/drive/folders/1QKf2hgOxCo6cmWkJ0b78o1Byx8uxgK_E?q=title:%3C1.9.0%3E)
 :six: [{{TEST_DAY_FEATURE_ISSUE_COUNT}}]({{JIRA_LINK}}) Features are tagged for Testday. Please review they are ready for Testday.
 :seven: [{{OPEN_ISSUE_COUNT}}]({{JIRA_LINK}}) issues set to {{RELEASE_VERSION}} and not closed. Please review and move to the next release as appropriate and can be fixed in main branch ONLY.

--- a/tests/unit/test_release_cli.py
+++ b/tests/unit/test_release_cli.py
@@ -101,7 +101,7 @@ class TestJqlUrl:
     def test_url_encoding(self):
         jql_str = "project = RHIDP AND status != closed"
         url = jql.jira_url(jql_str)
-        assert url.startswith("https://issues.redhat.com/issues/?jql=")
+        assert url.startswith("https://redhat.atlassian.net/issues/?jql=")
         assert "%20" in url or "+" in url
         assert "project" not in url.split("jql=")[1].split("%")[0] or quote(jql_str, safe="") in url
 
@@ -116,7 +116,7 @@ class TestJqlUrl:
     def test_render_with_url(self):
         rendered, url = jql.render_with_url("open_issues", version="1.9.0")
         assert '"1.9.0"' in rendered
-        assert url.startswith("https://issues.redhat.com/issues/?jql=")
+        assert url.startswith("https://redhat.atlassian.net/issues/?jql=")
         assert quote(rendered, safe="") in url
 
 


### PR DESCRIPTION
JIRA_BASE and JIRA_SEARCH_BASE were hardcoded to issues.redhat.com (Jira Data Center). All browse and search links now resolve to the Jira Cloud instance. Fixed Dashboard URLs/IDs