### PR TITLE
feat(smoke-tests): check the catalog index before installing

### DIFF
--- a/skills/release/rhdh-smoke-tests/SKILL.md
+++ b/skills/release/rhdh-smoke-tests/SKILL.md
@@ -26,16 +26,18 @@ This is not full QE, Prow e2e, local compose, or an operator-PR catalog test.
 ## Route
 
 1. Collect tags. Stop if tags are missing — do not invent CI tags.
-2. Establish `oc` (login below). Derive `CLUSTER_ROUTER_BASE` before Helm.
-3. Default is an **RC** run. A **GA** run (published chart / OperatorHub `fast`,
+2. Check the catalog index **before installing** (below). A failure stops the
+   run: installing first tells you nothing, because the fallback hides it.
+3. Establish `oc` (login below). Derive `CLUSTER_ROUTER_BASE` before Helm.
+4. Default is an **RC** run. A **GA** run (published chart / OperatorHub `fast`,
    including `fast` ↔ `fast-1.y`) only when the user asked for GA.
-4. Follow `/mutation-gate` **once** for both full chains (login + Helm +
+5. Follow `/mutation-gate` **once** for both full chains (login + Helm +
    Operator). Then launch two agents in the **same turn** (Helm and Operator).
    Do not wait for Helm to finish before launching Operator. Do not run both
    chains in the parent.
-5. Load `workflows/helm.md` in the Helm agent, `workflows/operator.md` in the
+6. Load `workflows/helm.md` in the Helm agent, `workflows/operator.md` in the
    Operator agent.
-6. After every install or upgrade: Guest (below), then verify (below), then a
+7. After every install or upgrade: Guest (below), then verify (below), then a
    live line (below).
 
 | Load when | File |
@@ -45,6 +47,7 @@ This is not full QE, Prow e2e, local compose, or an operator-PR catalog test.
 | Guest fragment | `assets/app-config-guest.yaml` |
 | Helm Guest overlay | `assets/helm-values-guest.yaml` |
 | Console URL → router / API | `scripts/cluster_from_console.py` |
+| Catalog index preflight | `scripts/check_index_refs.py` |
 
 `SKILL_DIR` is the directory that contains this `SKILL.md`.
 
@@ -175,6 +178,30 @@ Failure: same sentence, then `FAILED` and the reason. Skip:
 - Catalog UI warning `spec.backstage` additionalProperty `author` is not
   `packages-low`.
 
+
+## Catalog index preflight
+
+Run before any install, against the index the release under test will use:
+
+```bash
+python3 "${SKILL_DIR}/scripts/check_index_refs.py" \
+  --index registry.access.redhat.com/rhdh/plugin-catalog-index:<stream-or-tag>
+```
+
+Exit 1 means the index names plugin images that do not resolve from
+registry.access.redhat.com. Stop and report; do not install.
+
+This has to happen here rather than after the install, because
+install-dynamic-plugins falls back from `registry.access.redhat.com/rhdh/` to
+`quay.io/rhdh/` when a manifest is missing. An index naming refs that were never
+promoted to RHEC therefore installs cleanly, the pods go green, and the release
+quietly serves images from the wrong registry — which is how RHDH 1.10.4
+shipped. No post-install check on a single cluster reveals that; the index
+itself is the only place it is visible.
+
+The script reports which refs are reachable only via quay. Those are the ones
+that would have been silently substituted.
+
 ## Completion
 
 After both agents finish, print this table (Status first, fixed-width column).
@@ -198,3 +225,8 @@ If Markdown collapses padding, use HTML `<colgroup><col style="width:11em"><col>
 Name the Guest method under the table (Helm `appConfig` vs Operator ConfigMap),
 not as a seventh row. A step that never ran because an earlier write was refused
 is skipped, not omitted.
+
+State the catalog index preflight above the table, on its own line: the index
+checked and how many of its refs resolve from RHEC. When it failed, that line
+and the unreachable refs are the whole report — nothing was installed, so the
+six rows do not exist yet.

--- a/skills/release/rhdh-smoke-tests/scripts/check_index_refs.py
+++ b/skills/release/rhdh-smoke-tests/scripts/check_index_refs.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Assert every plugin the catalog index names is pullable from RHEC.
+
+Run before installing. install-dynamic-plugins falls back from
+registry.access.redhat.com to quay.io when a manifest is missing, so an index
+naming refs that were never pushed to RHEC still installs cleanly and quietly
+serves whatever quay has. Nothing downstream reveals it, which is how RHDH
+1.10.4 shipped. Checking the index itself is the only place this is visible
+before it reaches a customer.
+
+    check_index_refs.py --index registry.access.redhat.com/rhdh/plugin-catalog-index:1.10
+    check_index_refs.py --index <ref> --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+RHEC = "registry.access.redhat.com/rhdh/"
+FALLBACK = "quay.io/rhdh/"
+OCI_REF = re.compile(r"oci://(\S+?)(?:!|\s|$)")
+
+
+def run(*args: str) -> tuple[int, bytes, str]:
+    p = subprocess.run(args, capture_output=True)
+    return p.returncode, p.stdout, p.stderr.decode(errors="replace")
+
+
+def extract_default_yaml(index: str, workdir: Path) -> str | None:
+    """Pull the index and return dynamic-plugins.default.yaml from its layers."""
+    rc, _, err = run(
+        "skopeo",
+        "copy",
+        "--override-os",
+        "linux",
+        "--override-arch",
+        "amd64",
+        "--quiet",
+        f"docker://{index}",
+        f"dir:{workdir}",
+    )
+    if rc != 0:
+        print(
+            f"error: cannot pull {index}: {err.strip().splitlines()[-1] if err else rc}",
+            file=sys.stderr,
+        )
+        return None
+
+    manifest = json.loads((workdir / "manifest.json").read_text())
+    for layer in manifest["layers"]:
+        blob = workdir / layer["digest"].split(":")[1]
+        try:
+            with tarfile.open(blob) as tar:
+                for member in tar.getnames():
+                    if member.endswith("dynamic-plugins.default.yaml"):
+                        handle = tar.extractfile(member)
+                        if handle:
+                            return handle.read().decode(errors="replace")
+        except tarfile.TarError:
+            continue
+    return None
+
+
+def pullable(ref: str) -> bool:
+    rc, _, _ = run("skopeo", "inspect", "--raw", f"docker://{ref}")
+    return rc == 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--index", required=True, help="Catalog index image reference")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        content = extract_default_yaml(args.index, Path(tmp))
+    if content is None:
+        print("error: no dynamic-plugins.default.yaml in the index", file=sys.stderr)
+        return 1
+
+    refs = sorted({m for m in OCI_REF.findall(content) if m.startswith(RHEC)})
+    unpullable = [r for r in refs if not pullable(r)]
+    quay_only = [r for r in unpullable if pullable(r.replace(RHEC, FALLBACK, 1))]
+
+    result = {
+        "index": args.index,
+        "rhec_refs": len(refs),
+        "unpullable": unpullable,
+        "reachable_only_via_quay": quay_only,
+        "ok": not unpullable,
+    }
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"index               {args.index}")
+        print(f"RHEC refs           {len(refs)}")
+        print(f"not pullable        {len(unpullable)}")
+        for ref in unpullable:
+            tail = ref.split("/")[-1]
+            note = "   (present on quay - the fallback would hide this)" if ref in quay_only else ""
+            print(f"  {tail}{note}")
+        if result["ok"]:
+            print("result              OK - every ref resolves from RHEC")
+        else:
+            print("result              FAIL - do not ship this index")
+
+    return 0 if result["ok"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Replaces #111. Same underlying check, moved to where Nick argued it belongs — before the install, in the smoke test, firing by default instead of on demand.

## Why here and not after

`install-dynamic-plugins.py` falls back from `registry.access.redhat.com/rhdh/` to `quay.io/rhdh/` when a manifest is missing:

```python
RHDH_REGISTRY_PREFIX = 'registry.access.redhat.com/rhdh/'
RHDH_FALLBACK_PREFIX = 'quay.io/rhdh/'
```

So an index naming refs that were never promoted to RHEC installs cleanly, the pods go green, and the release quietly serves images from the wrong registry. That is how 1.10.4 shipped. A post-install check can only tell you after the fact, and only about the one cluster it ran against. The index is the only place this is visible before it reaches a customer.

Not added to `/e2e-deploy-rhdh` — no reason to re-check RHEC on every CI build.

## What it found

Run against both 1.10.4 indexes:

| Index | RHEC refs | Unresolvable |
|---|---|---|
| `1.10.4-1788191751` (shipped) | 51 | **8** |
| `1.10.4-1788447603` (the documented workaround) | 51 | **1** |

The eight are the five orchestrator plugins, the two lightspeed plugins, and `backstage-community-plugin-rbac`.

**The respin still names one.** `backstage-community-plugin-rbac@sha256:ffced4a5...` resolves on quay but returns `manifest unknown` on RHEC, where the `:1.10` tag carries a different digest (`sha256:a6a22958...`). So the workaround in the published release note fixes orchestrator and lightspeed and leaves RBAC on the fallback. Reporting that separately.

Worth noting I had analysed both indexes by hand while verifying RHDHBUGS-3720 and found seven. The script found eight.

## Shape

```
1. Collect tags
2. Check the catalog index    <- new, no cluster needed
3. Establish oc
...
```

Exit 1 stops the run before anything is installed. The report names which refs are reachable only via quay, since those are the ones that would have been silently substituted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)