### PR TITLE
fix: validate Prow triggers and add read-only status checks

### DIFF
--- a/skills/ci/rhdh-prow-trigger/SKILL.md
+++ b/skills/ci/rhdh-prow-trigger/SKILL.md
@@ -29,9 +29,10 @@ natural-language request to a full job name, the override options, and execution
 `~/.config/openshift-ci/kubeconfig` so it never disturbs the user's current
 cluster context. It consumes an existing `oc` session and never performs a login.
 
-When `oc` is missing, the dedicated kubeconfig is absent, or the session has
-expired, stop and tell the user to run `/setup-rhdh-skills openshift-ci`. Setup
-owns login; this skill does not.
+Live submission and `--status` require that session. When `oc` is missing, the
+dedicated kubeconfig is absent, or the session has expired, stop and tell the
+user to run `/setup-rhdh-skills openshift-ci`. Setup owns login; this skill does
+not. Offline previews and public job/tag listings do not require authentication.
 
 The public script hands `scripts/gangway_adapter.py` only a kubeconfig path and
 the request payload. That adapter alone retrieves the transient credential and
@@ -40,14 +41,17 @@ tokens out of arguments, output, and anything reported back.
 
 ## Execution rules
 
-Triggering a job is an external write; `--dry-run` and `--list` are not. Follow
-`/mutation-gate`, with the full job name as the target.
+Triggering a job is an external write; `--dry-run`, `--list`, `--list-tags`, and
+`--status` are not. Follow `/mutation-gate`, with the full job name as the target.
 
-- Preview with `--dry-run` first. It prints the adapter request without
-  executing.
-- The preview carries the full command, the parameters, what the run will cost
-  and touch, and how to abort it. Get explicit approval before running without
-  `--dry-run`.
+- Preview with `--dry-run` first. It validates the supported nightly name and
+  flags offline, then prints the adapter request without accessing credentials,
+  creating configuration, or making network requests. It does not validate job,
+  image, or chart existence. Live submission checks the owning repository's
+  configured job list and stops if membership cannot be verified.
+- The preview carries the full command, parameters, resource impact, unknown
+  cost, abort guidance, failure behavior, and verification steps. Use it in the
+  write gate; get explicit approval before running without `--dry-run`.
 - GKE and OSD-GCP each share one cluster. Never start a second job on the same
   platform while one is running; warn the user before triggering either.
 - Approval to inspect or dry-run is not approval to execute. Ask again.

--- a/skills/ci/rhdh-prow-trigger/scripts/gangway_adapter.py
+++ b/skills/ci/rhdh-prow-trigger/scripts/gangway_adapter.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import subprocess
 import urllib.error
+import urllib.parse
 import urllib.request
 from typing import Any
 
@@ -19,6 +20,10 @@ GANGWAY_URL = "https://gangway-ci.apps.ci.l2s4.p1.openshiftapps.com/v1/execution
 
 class GangwayAdapterError(RuntimeError):
     """A credential-opaque failure from the Gangway adapter."""
+
+    def __init__(self, message: str, *, outcome_unknown: bool = False) -> None:
+        super().__init__(message)
+        self.outcome_unknown = outcome_unknown
 
 
 class GangwayAdapter:
@@ -29,18 +34,26 @@ class GangwayAdapter:
         self.executable = executable
 
     def _token(self) -> str:
-        result = subprocess.run(
-            [self.executable, "--kubeconfig", self.kubeconfig, "whoami", "-t"],
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            check=False,
-            shell=False,
-        )
+        try:
+            result = subprocess.run(
+                [self.executable, "--kubeconfig", self.kubeconfig, "whoami", "-t"],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                check=False,
+                shell=False,
+            )
+        except OSError as error:
+            raise GangwayAdapterError(
+                "Cannot run oc. Run /setup-rhdh-skills openshift-ci, then retry."
+            ) from error
         token = result.stdout.strip()
         if result.returncode != 0 or not token:
-            raise GangwayAdapterError("OpenShift CI authentication is missing or expired")
+            raise GangwayAdapterError(
+                "OpenShift CI authentication is missing or expired. "
+                "Run /setup-rhdh-skills openshift-ci, then retry."
+            )
         return token
 
     def _request(
@@ -59,14 +72,52 @@ class GangwayAdapter:
         )
         try:
             with urllib.request.urlopen(request, timeout=30) as response:
-                return json.loads(response.read().decode("utf-8"))
+                body = json.loads(response.read().decode("utf-8"))
         except urllib.error.HTTPError as error:
-            raise GangwayAdapterError(f"Gangway returned HTTP {error.code}") from error
-        except (urllib.error.URLError, OSError, json.JSONDecodeError) as error:
-            raise GangwayAdapterError(f"Gangway request failed: {error}") from error
+            if error.code == 401:
+                guidance = (
+                    "Authentication was rejected. Run /setup-rhdh-skills openshift-ci, then retry."
+                )
+            elif error.code == 403:
+                guidance = "Permission denied. Ask an OpenShift CI administrator to check access."
+            elif error.code == 400:
+                guidance = "Invalid request. Check the job name, execution ID, and overrides."
+            elif error.code == 404:
+                guidance = (
+                    "Execution not found. Check the execution ID."
+                    if method == "GET"
+                    else "Job or endpoint not found. Check the configured job list and Gangway URL."
+                )
+            elif error.code == 429:
+                guidance = "Rate limit exceeded. Wait before retrying."
+            elif error.code >= 500:
+                guidance = "Gangway service failure. Check OpenShift CI service availability."
+            else:
+                guidance = "Check the request and OpenShift CI service availability."
+            raise GangwayAdapterError(
+                f"Gangway returned HTTP {error.code}. {guidance}",
+                outcome_unknown=method == "POST" and (error.code == 408 or error.code >= 500),
+            ) from error
+        except (urllib.error.URLError, OSError) as error:
+            raise GangwayAdapterError(
+                "Gangway network request failed. Check DNS, network/VPN connectivity, "
+                "and OpenShift CI service availability.",
+                outcome_unknown=method == "POST",
+            ) from error
+        except (json.JSONDecodeError, UnicodeDecodeError) as error:
+            raise GangwayAdapterError(
+                "Gangway returned an invalid JSON response. Check OpenShift CI service availability.",
+                outcome_unknown=method == "POST",
+            ) from error
+        if not isinstance(body, dict):
+            raise GangwayAdapterError(
+                "Gangway returned an unexpected response; expected a JSON object.",
+                outcome_unknown=method == "POST",
+            )
+        return body
 
     def trigger(self, payload: dict[str, Any]) -> dict[str, Any]:
         return self._request(GANGWAY_URL, method="POST", payload=payload)
 
     def status(self, job_id: str) -> dict[str, Any]:
-        return self._request(f"{GANGWAY_URL}/{job_id}")
+        return self._request(f"{GANGWAY_URL}/{urllib.parse.quote(job_id, safe='')}")

--- a/skills/ci/rhdh-prow-trigger/scripts/trigger_nightly_job.py
+++ b/skills/ci/rhdh-prow-trigger/scripts/trigger_nightly_job.py
@@ -46,6 +46,7 @@ import argparse
 import json
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -64,6 +65,22 @@ REPOS = [
 ]
 
 OVERLAY_JOB_PREFIX = "periodic-ci-redhat-developer-rhdh-plugin-export-overlays-"
+NIGHTLY_JOB_PATTERN = re.compile(
+    r"periodic-ci-redhat-developer-rhdh-(?:plugin-export-overlays-)?"
+    r"[a-zA-Z0-9][a-zA-Z0-9_.-]*-nightly"
+)
+TRIGGER_OVERRIDES = (
+    "image_registry",
+    "image_repo",
+    "tag",
+    "catalog_index_image",
+    "chart_version",
+    "playwright_version",
+    "org",
+    "repo",
+    "branch",
+    "send_alerts",
+)
 
 
 # --- Logging ---
@@ -96,8 +113,22 @@ def fetch_configured_jobs(repo: str) -> list[str]:
         return []
 
     # Extract job names from embedded JSON: "name":"periodic-ci-...-nightly"
-    matches = re.findall(r'"name":"(periodic-ci-[^"]*-nightly)"', html)
+    matches = re.findall(r'"name"\s*:\s*"(periodic-ci-[^"]*-nightly)"', html)
     return sorted(set(matches))
+
+
+def ensure_configured_job(job: str) -> None:
+    """Require membership in the owning repository's live job list before a POST."""
+    repo = REPOS[1] if job.startswith(OVERLAY_JOB_PREFIX) else REPOS[0]
+    jobs = fetch_configured_jobs(repo)
+    if not jobs:
+        log_error(f"Cannot verify configured nightly jobs for {repo}; no job was submitted.")
+        log_error("Check the configured-jobs page and network access, then retry --list.")
+        sys.exit(1)
+    if job not in jobs:
+        log_error(f"Job is not configured for {repo}: {job}")
+        log_error("Run --list and select a configured nightly job. No job was submitted.")
+        sys.exit(1)
 
 
 def _short_name(job: str, repo: str) -> str:
@@ -403,11 +434,12 @@ def trigger_job(adapter: GangwayAdapter, payload: dict) -> dict:
         body = adapter.trigger(payload)
     except GangwayAdapterError as error:
         log_error(str(error))
-        log_error(
-            "The job name may be invalid. Verify at:\n"
-            "  https://prow.ci.openshift.org/configured-jobs/redhat-developer/rhdh\n"
-            "  https://prow.ci.openshift.org/configured-jobs/redhat-developer/rhdh-plugin-export-overlays"
-        )
+        if error.outcome_unknown:
+            log_warn(
+                "Submission outcome is unknown; a job may have been created. "
+                "Inspect Prow job history before retrying the trigger: "
+                f"https://prow.ci.openshift.org/?job={payload['job_name']}"
+            )
         sys.exit(1)
 
     log_info("Response:")
@@ -415,23 +447,47 @@ def trigger_job(adapter: GangwayAdapter, payload: dict) -> dict:
     return body
 
 
+def command_line(*arguments: str) -> str:
+    """Render a shell-safe command that also works outside the skill directory."""
+    return shlex.join(["uv", "run", os.path.abspath(__file__), *arguments])
+
+
+def show_job_status(adapter: GangwayAdapter, job_id: str) -> None:
+    """Read one existing execution without ever submitting a job."""
+    log_info(f"Job ID: {job_id}")
+    try:
+        response = adapter.status(job_id)
+    except GangwayAdapterError as error:
+        log_error(str(error))
+        sys.exit(1)
+    print(json.dumps(response, indent=2))
+    if response.get("job_url"):
+        log_info(f"Job URL: {response['job_url']}")
+    else:
+        log_warn("Job URL not yet available; repeat --status with this execution ID.")
+
+
 def poll_job_status(adapter: GangwayAdapter, job_id: str) -> None:
     """Poll the Gangway API for the job URL."""
     print("", file=sys.stderr)
     log_info(f"Job ID: {job_id}")
+    log_info(f"Refresh status: {command_line('--status', job_id)}")
     log_info("Waiting for Prow URL...")
 
     job_url = ""
-    for _ in range(5):
+    for attempt in range(5):
         print(".", end="", flush=True, file=sys.stderr)
         try:
             data = adapter.status(job_id)
             job_url = data.get("job_url", "")
             if job_url:
                 break
-        except GangwayAdapterError:
-            pass
-        time.sleep(2)
+        except GangwayAdapterError as error:
+            print("", file=sys.stderr)
+            log_warn(f"Job was submitted, but status lookup failed: {error}")
+            return
+        if attempt < 4:
+            time.sleep(2)
 
     print("", file=sys.stderr)
     if job_url:
@@ -439,13 +495,12 @@ def poll_job_status(adapter: GangwayAdapter, job_id: str) -> None:
     else:
         log_warn("Job URL not yet available.")
 
-    log_info("Re-run this command to refresh the job status through the authenticated adapter.")
-
 
 # --- CLI ---
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Trigger RHDH nightly ProwJobs via the OpenShift CI Gangway REST API.",
+        allow_abbrev=False,
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""\
 Job name patterns:
@@ -454,31 +509,38 @@ Job name patterns:
 
 Examples:
   %(prog)s --list
+  %(prog)s --status <EXECUTION_ID>
   %(prog)s --job periodic-ci-redhat-developer-rhdh-main-e2e-ocp-helm-nightly
   %(prog)s --job periodic-ci-redhat-developer-rhdh-plugin-export-overlays-main-e2e-ocp-helm-nightly
   %(prog)s --job periodic-ci-redhat-developer-rhdh-main-e2e-ocp-helm-nightly --tag 1.9-123
 """,
     )
 
-    parser.add_argument(
+    action = parser.add_mutually_exclusive_group(required=True)
+    action.add_argument(
         "-l",
         "--list",
         action="store_true",
         dest="list_jobs",
         help="List available nightly jobs from all repos.",
     )
-    parser.add_argument(
+    action.add_argument(
         "-j",
         "--job",
         dest="job",
         help="Full ProwJob name to trigger.",
     )
-    parser.add_argument(
+    action.add_argument(
         "-T",
         "--list-tags",
         action="store_true",
         dest="list_tags",
         help="List available image tags from quay.io. Use --image-repo to specify the repo.",
+    )
+    action.add_argument(
+        "--status",
+        metavar="EXECUTION_ID",
+        help="Read an existing execution's status and URL without triggering a job.",
     )
     parser.add_argument(
         "--tag-filter",
@@ -577,16 +639,27 @@ Examples:
 
 def validate_args(args: argparse.Namespace) -> None:
     """Validate parsed arguments."""
-    if not args.list_jobs and not args.list_tags and not args.job:
-        log_error("Either --list, --list-tags, or --job is required.")
+    if args.dry_run and not args.job:
+        log_error("--dry-run requires --job.")
         sys.exit(1)
+
+    if args.status is not None:
+        if not re.fullmatch(r"[a-zA-Z0-9][a-zA-Z0-9_-]*", args.status):
+            log_error("--status requires an execution ID, not a URL or path.")
+            sys.exit(1)
+        if any(getattr(args, name) for name in TRIGGER_OVERRIDES) or args.tag_filter:
+            log_error("--status cannot be combined with trigger overrides or --tag-filter.")
+            sys.exit(1)
 
     if args.tag_filter and not args.list_tags:
         log_warn("--tag-filter is only used with --list-tags, ignoring.")
 
-    if args.job:
-        if not args.job.startswith("periodic-ci-"):
-            log_error(f"Job name must start with 'periodic-ci-', got: {args.job}")
+    if args.job is not None:
+        if not NIGHTLY_JOB_PATTERN.fullmatch(args.job):
+            log_error(
+                "Expected a periodic-ci-redhat-developer-rhdh-*-nightly or "
+                f"periodic-ci-redhat-developer-rhdh-plugin-export-overlays-*-nightly job, got: {args.job}"
+            )
             sys.exit(1)
 
         if args.image_repo and not args.tag:
@@ -602,9 +675,16 @@ def print_summary(args: argparse.Namespace, payload: dict) -> None:
     print("", file=sys.stderr)
 
 
-def print_dry_run(payload: dict) -> None:
-    """Print a credential-free adapter request preview."""
-    print("[DRY RUN] Authenticated adapter request:")
+def print_dry_run(args: argparse.Namespace, payload: dict) -> None:
+    """Print the proposed command, request, impact, and recovery without I/O."""
+    arguments = ["--job", args.job]
+    for name in TRIGGER_OVERRIDES:
+        value = getattr(args, name)
+        if value:
+            arguments.append(f"--{name.replace('_', '-')}")
+            if not isinstance(value, bool):
+                arguments.append(value)
+    print("[DRY RUN] No job submitted. Proposed authenticated adapter request:")
     print(
         json.dumps(
             {
@@ -612,7 +692,35 @@ def print_dry_run(payload: dict) -> None:
                 "operation": "gangway.execution.create",
                 "target": GANGWAY_URL,
                 "authentication": "native oc kubeconfig (redacted)",
+                "execution_command": command_line(*arguments),
                 "payload": payload,
+                "validation": {
+                    "job_name_and_flags": "passed",
+                    "configured_job": "unchecked offline; required before live submission",
+                    "authentication": "unchecked",
+                    "images_and_chart": "unchecked",
+                },
+                "impact": (
+                    "Creates one ProwJob, consuming CI compute and the configured test cluster "
+                    "or cloud resources. Tests deploy workloads and may change cluster state. "
+                    "Duration and monetary cost are unknown; no resources are reserved by this preview."
+                ),
+                "abort": (
+                    "Before submission, decline to run the execution command. After submission, "
+                    "stopping this client does not cancel the job. Give the execution ID/URL to "
+                    "an OpenShift CI administrator to abort the run and check resource cleanup; "
+                    "this CLI has no cancellation operation."
+                ),
+                "failure_behavior": (
+                    "Stop if job discovery, authentication, or submission fails; no automatic "
+                    "POST retry. A network failure, server error, or invalid response can leave "
+                    "submission outcome unknown. Inspect Prow job history before retrying."
+                ),
+                "verification": (
+                    "Report the API response and execution ID/URL. Read the existing execution with "
+                    f"{command_line('--status', '<EXECUTION_ID>')}. "
+                    "If neither ID nor URL is returned, report that verification is incomplete."
+                ),
             },
             indent=2,
         )
@@ -625,8 +733,8 @@ def main(argv: list[str] | None = None) -> None:
         "XDG_CONFIG_HOME", os.path.join(os.path.expanduser("~"), ".config")
     )
     kubeconfig = os.path.join(config_home, "openshift-ci", "kubeconfig")
-    os.makedirs(os.path.dirname(kubeconfig), exist_ok=True)
 
+    argv = sys.argv[1:] if argv is None else argv
     args = parse_args(argv)
     validate_args(args)
 
@@ -642,20 +750,35 @@ def main(argv: list[str] | None = None) -> None:
         )
         return
 
+    if args.status is not None:
+        ensure_capability(kubeconfig)
+        show_job_status(GangwayAdapter(kubeconfig), args.status)
+        return
+
     payload = build_payload(args)
     print_summary(args, payload)
 
     if args.dry_run:
-        print_dry_run(payload)
+        print_dry_run(args, payload)
         return
 
+    ensure_configured_job(args.job)
     ensure_capability(kubeconfig)
+    log_info(f"Command: {command_line(*argv)}")
     adapter = GangwayAdapter(kubeconfig)
     response = trigger_job(adapter, payload)
 
     job_id = response.get("id", "")
     if job_id:
         poll_job_status(adapter, job_id)
+    elif response.get("job_url"):
+        log_info(f"Job URL: {response['job_url']}")
+        log_warn("Gangway returned no execution ID; --status is unavailable for this response.")
+    else:
+        log_warn(
+            "Gangway returned no execution ID or URL; verification is incomplete. "
+            "Inspect Prow job history before submitting another job."
+        )
 
 
 if __name__ == "__main__":

--- a/skills/ci/rhdh-prow-trigger/workflows/trigger-nightly.md
+++ b/skills/ci/rhdh-prow-trigger/workflows/trigger-nightly.md
@@ -11,9 +11,12 @@ Run every command below from this skill's directory.
 
 ## Flow
 
-1. Fetch available jobs and let the user pick one
-2. Ask about image override and additional options (fork, alerts)
-3. Show the command, confirm, execute, report results
+1. Resolve the requested job; fetch available jobs when selection is needed
+2. Fill in any requested overrides that are missing values
+3. Preview, apply the write gate, execute, and report results
+
+For a supplied full job name and flags, go directly to the preview in Step 3.
+For an existing execution ID, use the status command under "Status and recovery".
 
 ## Step 1: Fetch Jobs and Select
 
@@ -125,9 +128,9 @@ Use `--image-repo <REPO>` to query a different image repository (default: `rhdh/
 
 ## Step 3: Plan, approve, and execute
 
-Show the full command, its parameters, the target job, what the run risks, how to
-abort it, and how you will verify it started. Ask for explicit approval before
-omitting `--dry-run`:
+Run this command with `--dry-run` first. Use the printed execution command and
+request details in the write gate described in `../SKILL.md`. Supplement the
+resource impact and abort guidance with any known platform-specific details.
 
 ```bash
 uv run scripts/trigger_nightly_job.py \
@@ -145,10 +148,38 @@ uv run scripts/trigger_nightly_job.py \
   [--dry-run]
 ```
 
-1. **Execute** — run the command as shown
-2. **Change something** — go back and modify parameters
+After approval, run the preview's `execution_command`. If parameters change,
+generate a new preview before submitting.
 
-After execution, show the API response. If a job URL or ID is returned, display it prominently. On error, help diagnose (common issues: expired token, invalid job name).
+After execution, show the API response and any returned URL or ID. If both are
+missing, report that verification is incomplete.
+
+### Status and recovery
+
+To refresh an existing execution, use the GET-only status command:
+
+```bash
+uv run scripts/trigger_nightly_job.py --status <EXECUTION_ID>
+```
+
+The CLI also prints this command after submission. Repeating a trigger creates
+another ProwJob; use `--status` for follow-up, including when URL polling fails.
+Status cannot be combined with `--job`, `--dry-run`, or trigger overrides.
+
+Preserve the adapter's error diagnosis. Authentication failures name the setup
+route; permission failures require access review. An invalid request, unknown
+execution, rate limit, service failure, or network failure has its own guidance.
+Do not reinterpret every API failure as an invalid job name.
+
+Creation is not idempotent. If a POST times out, receives a server error, or
+returns an unreadable response, the job may already exist. Inspect the named
+job's Prow history before another submission; if an execution ID is known, use
+`--status`. Report status lookup failures separately from submission failures.
+
+Use the preview's abort guidance when stopping a submitted run is requested.
+Stopping the client does not cancel the ProwJob, and this CLI has no cancel
+operation. An OpenShift CI administrator needs the execution ID or URL to abort
+the run and check resource cleanup.
 
 ### RC Verification Example
 
@@ -171,7 +202,8 @@ uv run scripts/trigger_nightly_job.py \
 
 ## Reference
 
-- Script flags: `-j/--job`, `-l/--list`, `-T/--list-tags`, `--tag-filter`, `-I/--image-registry`, `-q/--image-repo`, `-t/--tag`, `--catalog-index-image`, `--chart-version`, `--playwright-version`, `-o/--org`, `-r/--repo`, `-b/--branch`, `-S/--send-alerts`, `-n/--dry-run`, `--json`
+- Script flags: `-j/--job`, `-l/--list`, `-T/--list-tags`, `--status`, `--tag-filter`, `-I/--image-registry`, `-q/--image-repo`, `-t/--tag`, `--catalog-index-image`, `--chart-version`, `--playwright-version`, `-o/--org`, `-r/--repo`, `-b/--branch`, `-S/--send-alerts`, `-n/--dry-run`, `--json`
+- API behavior: <https://docs.ci.openshift.org/how-tos/triggering-prowjobs-via-rest/>
 - Authentication and the adapter boundary: see `../SKILL.md`
 - RHDH jobs list: <https://prow.ci.openshift.org/configured-jobs/redhat-developer/rhdh>
 - Overlay jobs list: <https://prow.ci.openshift.org/configured-jobs/redhat-developer/rhdh-plugin-export-overlays>

--- a/tests/unit/test_trigger_nightly_job.py
+++ b/tests/unit/test_trigger_nightly_job.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
+import shlex
 import sys
+import urllib.error
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -17,6 +20,33 @@ SPEC = importlib.util.spec_from_file_location("trigger_nightly_job", SCRIPT)
 assert SPEC and SPEC.loader
 NIGHTLY = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(NIGHTLY)
+ADAPTER = sys.modules["gangway_adapter"]
+JOB = "periodic-ci-redhat-developer-rhdh-release-1.10-e2e-ocp-helm-nightly"
+OVERLAY_JOB = "periodic-ci-redhat-developer-rhdh-plugin-export-overlays-main-e2e-ocp-helm-nightly"
+
+
+@pytest.fixture(autouse=True)
+def offline(monkeypatch, tmp_path):
+    """Every test must opt in to simulated network and native CLI responses."""
+
+    def unexpected_io(*_args, **_kwargs):
+        pytest.fail("Unexpected network or credential access")
+
+    monkeypatch.setattr(NIGHTLY.urllib.request, "urlopen", unexpected_io)
+    monkeypatch.setattr(NIGHTLY.subprocess, "run", unexpected_io)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+
+
+@pytest.fixture
+def live_cli(monkeypatch):
+    monkeypatch.setattr(NIGHTLY, "ensure_capability", lambda _path: None)
+    monkeypatch.setattr(NIGHTLY, "fetch_configured_jobs", lambda _repo: [JOB, OVERLAY_JOB])
+
+
+@pytest.fixture
+def adapter(monkeypatch):
+    monkeypatch.setattr(ADAPTER.GangwayAdapter, "_token", lambda _self: "test-token")
+    return ADAPTER.GangwayAdapter("ci-kubeconfig")
 
 
 def test_existing_native_cli_session_is_consumed_without_login(monkeypatch):
@@ -55,19 +85,258 @@ def test_missing_session_routes_to_human_setup_without_login(monkeypatch, capsys
     assert all("login" not in argv for argv in calls)
 
 
-def test_dry_run_is_a_credential_free_adapter_preview(capsys):
-    payload = {"job_name": "periodic-ci-example", "job_execution_type": "1"}
-
-    NIGHTLY.print_dry_run(payload)
+def test_dry_run_is_an_offline_preview_with_a_replayable_command(tmp_path, capsys):
+    NIGHTLY.main(
+        [
+            "--job",
+            JOB,
+            "--tag",
+            "1.10-171",
+            "--catalog-index-image",
+            "registry.access.redhat.com/rhdh/plugin-catalog-index:1.10.4-1788447603",
+            "--dry-run",
+        ]
+    )
 
     output = capsys.readouterr().out
     preview = json.loads(output.split("\n", 1)[1])
-    assert preview == {
-        "adapter": "openshift-ci-gangway/v1",
-        "operation": "gangway.execution.create",
-        "target": NIGHTLY.GANGWAY_URL,
-        "authentication": "native oc kubeconfig (redacted)",
-        "payload": payload,
+    assert preview["operation"] == "gangway.execution.create"
+    assert preview["target"] == NIGHTLY.GANGWAY_URL
+    assert preview["payload"] == {
+        "job_name": JOB,
+        "job_execution_type": "1",
+        "pod_spec_options": {
+            "envs": {
+                "MULTISTAGE_PARAM_OVERRIDE_TAG_NAME": "1.10-171",
+                "MULTISTAGE_PARAM_OVERRIDE_CATALOG_INDEX_IMAGE": "registry.access.redhat.com/rhdh/plugin-catalog-index:1.10.4-1788447603",
+                "MULTISTAGE_PARAM_OVERRIDE_SKIP_SEND_ALERT": "true",
+            }
+        },
     }
+    command = shlex.split(preview["execution_command"])
+    assert command[:3] == ["uv", "run", str(SCRIPT)]
+    replay = NIGHTLY.parse_args(command[3:])
+    assert not replay.dry_run
+    assert NIGHTLY.build_payload(replay) == preview["payload"]
+    assert {"validation", "impact", "abort", "failure_behavior", "verification"} <= preview.keys()
+    assert "--status" in preview["verification"]
     assert "Bearer" not in output
     assert "whoami -t" not in output
+    assert not (tmp_path / "config").exists()
+
+
+def test_preview_command_preserves_quoted_values_and_boolean_flags(capsys):
+    NIGHTLY.main(["-j", JOB, "--branch", "literal $value `text` 'quoted'", "-Sn"])
+    preview = json.loads(capsys.readouterr().out.split("\n", 1)[1])
+    replay = NIGHTLY.parse_args(shlex.split(preview["execution_command"])[3:])
+    assert replay.branch == "literal $value `text` 'quoted'"
+    assert replay.send_alerts
+    assert not replay.dry_run
+    assert NIGHTLY.build_payload(replay) == preview["payload"]
+
+
+@pytest.mark.parametrize(
+    "job",
+    [
+        "",
+        "periodic-ci-openshift-release-main-e2e-nightly",
+        "periodic-ci-redhat-developer-rhdh-main-e2e-ocp-helm",
+        "periodic-ci-redhat-developer-rhdh--nightly",
+        JOB + "\n",
+    ],
+)
+@pytest.mark.parametrize("dry_run", [False, True])
+def test_unsupported_job_names_fail_offline(job, dry_run):
+    with pytest.raises(SystemExit) as error:
+        NIGHTLY.main(["--job", job, *(["--dry-run"] if dry_run else [])])
+    assert error.value.code != 0
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
+        ["--job", JOB],
+        ["--dry-run"],
+        ["--tag", "1.10-171"],
+        ["--send-alerts"],
+        ["--list"],
+        ["--list-tags"],
+    ],
+)
+def test_status_rejects_conflicting_actions_and_overrides(extra):
+    with pytest.raises(SystemExit) as error:
+        NIGHTLY.main(["--status", "execution-123", *extra])
+    assert error.value.code != 0
+
+
+@pytest.mark.parametrize("job_id", ["", "../executions", "id?job_name=other", "https://prow/id"])
+def test_status_rejects_paths_and_urls(job_id):
+    with pytest.raises(SystemExit):
+        NIGHTLY.main(["--status", job_id])
+
+
+@pytest.mark.parametrize("jobs", [[], [JOB + "-other"]])
+def test_unverifiable_or_unknown_job_stops_before_authentication(monkeypatch, jobs):
+    monkeypatch.setattr(NIGHTLY, "fetch_configured_jobs", lambda _repo: jobs)
+    with pytest.raises(SystemExit) as error:
+        NIGHTLY.main(["--job", JOB])
+    assert error.value.code == 1
+
+
+@pytest.mark.parametrize(
+    "job,repo",
+    [
+        (JOB, "redhat-developer/rhdh"),
+        (OVERLAY_JOB, "redhat-developer/rhdh-plugin-export-overlays"),
+    ],
+)
+def test_live_submission_verifies_owning_repo_and_submits_once(monkeypatch, live_cli, job, repo):
+    lookups, submissions = [], []
+
+    def configured_jobs(requested_repo):
+        lookups.append(requested_repo)
+        return [job]
+
+    def trigger(payload):
+        assert lookups == [repo]
+        submissions.append(payload)
+        return {"id": "execution-123"}
+
+    monkeypatch.setattr(NIGHTLY, "fetch_configured_jobs", configured_jobs)
+    monkeypatch.setattr(
+        NIGHTLY,
+        "GangwayAdapter",
+        lambda _path: SimpleNamespace(
+            trigger=trigger,
+            status=lambda _id: {"job_url": "https://prow.example/run"},
+        ),
+    )
+    NIGHTLY.main(["--job", job])
+    assert [payload["job_name"] for payload in submissions] == [job]
+
+
+def test_printed_refresh_command_only_reads_existing_execution(monkeypatch, live_cli, capsys):
+    reads = []
+    fake_adapter = SimpleNamespace(
+        status=lambda job_id: (
+            reads.append(job_id)
+            or {
+                "id": job_id,
+                "job_status": "PENDING",
+                "job_url": "https://prow.example/run",
+            }
+        )
+    )
+    NIGHTLY.poll_job_status(fake_adapter, "execution-123")
+    output = capsys.readouterr().err
+    command = next(line.split(": ", 1)[1] for line in output.splitlines() if "uv run" in line)
+    monkeypatch.setattr(NIGHTLY, "GangwayAdapter", lambda _path: fake_adapter)
+    NIGHTLY.main(shlex.split(command)[3:])
+    assert reads == ["execution-123", "execution-123"]
+    assert json.loads(capsys.readouterr().out)["job_status"] == "PENDING"
+
+
+def test_polling_failure_keeps_submitted_id_and_safe_refresh(monkeypatch, capsys):
+    def status(_job_id):
+        raise ADAPTER.GangwayAdapterError("HTTP 401: /setup-rhdh-skills openshift-ci")
+
+    NIGHTLY.poll_job_status(SimpleNamespace(status=status), "execution-123")
+    output = capsys.readouterr().err
+    assert "execution-123" in output
+    assert "--status execution-123" in output
+    assert "/setup-rhdh-skills openshift-ci" in output
+
+
+def test_adapter_status_uses_get_without_a_request_body(monkeypatch, adapter):
+    def urlopen(request, **_kwargs):
+        assert request.method == "GET"
+        assert request.full_url == f"{ADAPTER.GANGWAY_URL}/execution-123"
+        assert request.data is None
+        assert request.get_header("Authorization") == "Bearer test-token"
+        return io.BytesIO(b'{"id":"execution-123"}')
+
+    monkeypatch.setattr(ADAPTER.urllib.request, "urlopen", urlopen)
+    assert adapter.status("execution-123") == {"id": "execution-123"}
+
+
+@pytest.mark.parametrize(
+    "status,uncertain",
+    [
+        (400, False),
+        (401, False),
+        (403, False),
+        (404, False),
+        (408, True),
+        (429, False),
+        (503, True),
+    ],
+)
+def test_http_errors_are_actionable_and_do_not_expose_response_data(
+    monkeypatch,
+    adapter,
+    status,
+    uncertain,
+):
+    def urlopen(request, **_kwargs):
+        raise urllib.error.HTTPError(
+            request.full_url,
+            status,
+            "test-token",
+            {"X-Secret": "test-token"},
+            io.BytesIO(b"test-token"),
+        )
+
+    monkeypatch.setattr(ADAPTER.urllib.request, "urlopen", urlopen)
+    with pytest.raises(ADAPTER.GangwayAdapterError) as error:
+        adapter.trigger({"job_name": JOB})
+    assert f"HTTP {status}" in str(error.value)
+    assert ("/setup-rhdh-skills openshift-ci" in str(error.value)) is (status == 401)
+    assert error.value.outcome_unknown is uncertain
+    assert "test-token" not in str(error.value)
+
+
+@pytest.mark.parametrize(
+    "failure", [urllib.error.URLError("test-token"), TimeoutError("test-token")]
+)
+def test_network_failures_do_not_retry_or_claim_job_rejection(
+    monkeypatch, adapter, capsys, failure
+):
+    requests = []
+
+    def urlopen(request, **_kwargs):
+        requests.append(request)
+        raise failure
+
+    monkeypatch.setattr(ADAPTER.urllib.request, "urlopen", urlopen)
+    with pytest.raises(SystemExit):
+        NIGHTLY.trigger_job(adapter, {"job_name": JOB})
+    assert len(requests) == 1
+    output = capsys.readouterr().err
+    assert f"?job={JOB}" in output
+    assert "test-token" not in output
+
+
+@pytest.mark.parametrize("body", [b"test-token", b"[]", b"\xff"])
+def test_unreadable_submission_responses_have_unknown_outcome(monkeypatch, adapter, body):
+    monkeypatch.setattr(ADAPTER.urllib.request, "urlopen", lambda *_a, **_kw: io.BytesIO(body))
+    with pytest.raises(ADAPTER.GangwayAdapterError) as error:
+        adapter.trigger({"job_name": JOB})
+    assert error.value.outcome_unknown
+    assert "test-token" not in str(error.value)
+
+
+def test_credential_retrieval_failure_routes_to_setup(monkeypatch):
+    monkeypatch.setattr(
+        ADAPTER.subprocess,
+        "run",
+        lambda *_a, **_kw: SimpleNamespace(
+            returncode=1,
+            stdout="test-token",
+            stderr="test-token",
+        ),
+    )
+    with pytest.raises(ADAPTER.GangwayAdapterError) as error:
+        ADAPTER.GangwayAdapter("ci-kubeconfig").trigger({"job_name": JOB})
+    assert "/setup-rhdh-skills openshift-ci" in str(error.value)
+    assert not error.value.outcome_unknown
+    assert "test-token" not in str(error.value)


### PR DESCRIPTION
The nightly trigger CLI tells users to repeat a submission command to refresh status, which can create duplicate ProwJobs. It also accepts unrelated periodic job names and suggests an invalid job name after every API failure. Its dry-run output lacks the command, impact, and recovery details required by the skill workflow.

This PR makes nightly submissions easier to review and gives users a status command that cannot submit another job.

- Add `--status <EXECUTION_ID>` and print it after submission. Reject combinations with submission flags.
- Restrict job names to the supported nightly patterns. Before live submission, require membership in the owning repository's configured-job list. If job discovery cannot verify membership, stop submission.
- Give separate guidance for authentication, permissions, invalid requests, missing executions, rate limits, service failures, and network failures. Treat uncertain submission outcomes explicitly and avoid automatic POST retries.
- Expand offline previews with the executable command, overrides, validation limits, resource impact, unknown cost, abort guidance, and verification steps. Previewing neither accesses credentials nor creates configuration.

Update the skill workflow with status and recovery instructions, and add regression tests for these behaviors. The release-1.10 dry run with tag `1.10-171` and catalog image `registry.access.redhat.com/rhdh/plugin-catalog-index:1.10.4-1788447603` retains its original payload.

## Validation

- Full suite: 673 passed with `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 UV_CACHE_DIR=/tmp/rhdh-prow-trigger-uv-cache uv run pytest`.
- Focused trigger tests: 44 passed.
- `uv run ruff check .` and `uv run ruff format --check .`: passed.
- Skill catalog validation and `git diff --check`: passed.
- Ran the exact image-verification command with `--dry-run`. The command submitted no ProwJob.

The test environment excludes global Git configuration so temporary fixtures do not inherit GPG signing. Earlier runs exceeded the unchanged prose-linter timing threshold. The final full run passes.

generated-by: codex using gpt-6-astra xhigh
